### PR TITLE
feat: smooth backtest progress animation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-// --- 主 JavaScript 邏輯 (Part 1 of X) - v3.4.1 ---
+// --- 主 JavaScript 邏輯 (Part 1 of X) - v3.5.0 ---
 
 // 全局變量
 let stockChart = null;
@@ -7,6 +7,7 @@ let optimizationWorker = null;
 let workerUrl = null; // Loader 會賦值
 let cachedStockData = null;
 const cachedDataStore = new Map(); // Map<market|stockNo, CacheEntry>
+const progressAnimator = createProgressAnimator();
 
 window.cachedDataStore = cachedDataStore;
 let lastFetchSettings = null;
@@ -24,23 +25,231 @@ function formatDate(d) { if(!(d instanceof Date)||isNaN(d))return ''; const y=d.
 function showError(m) { const el=document.getElementById("result"); el.innerHTML=`<i class="fas fa-times-circle mr-2"></i> ${m}`; el.className = 'my-6 p-4 bg-red-100 border-l-4 border-red-500 text-red-700 rounded-md'; }
 function showSuccess(m) { const el=document.getElementById("result"); el.innerHTML=`<i class="fas fa-check-circle mr-2"></i> ${m}`; el.className = 'my-6 p-4 bg-green-100 border-l-4 border-green-500 text-green-700 rounded-md'; }
 function showInfo(m) { const el=document.getElementById("result"); el.innerHTML=`<i class="fas fa-info-circle mr-2"></i> ${m}`; el.className = 'my-6 p-4 bg-blue-100 border-l-4 border-blue-500 text-blue-700 rounded-md'; }
-function showLoading(m="⌛ 處理中...") { 
-    const el = document.getElementById("loading"); 
+function showLoading(m="⌛ 處理中...") {
+    const el = document.getElementById("loading");
     const loadingText = document.getElementById('loadingText');
-    const progressBar = document.getElementById("progressBar");
-    
-    if (loadingText) loadingText.textContent = m; 
-    if (el) el.classList.remove("hidden"); 
-    if (progressBar) progressBar.style.width = `0%`; 
-    
-    const spinner = el?.querySelector('.fa-spinner'); 
-    if (spinner) spinner.classList.add('fa-spin'); 
+
+    if (loadingText) loadingText.textContent = m;
+    if (el) el.classList.remove("hidden");
+    progressAnimator.reset();
+    progressAnimator.start();
+
+    const spinner = el?.querySelector('.fa-spinner');
+    if (spinner) spinner.classList.add('fa-spin');
 }
-function hideLoading() { 
-    const el = document.getElementById("loading"); 
-    if (el) el.classList.add("hidden"); 
+function hideLoading() {
+    const el = document.getElementById("loading");
+    progressAnimator.stop();
+    if (el) el.classList.add("hidden");
 }
-function updateProgress(p) { const bar=document.getElementById("progressBar"); bar.style.width=`${Math.min(100,Math.max(0,p))}%`; }
+function updateProgress(p) {
+    progressAnimator.update(p);
+}
+
+function createProgressAnimator() {
+    const AUTO_INTERVAL = 200;
+    const AUTO_STEP = 1.8;
+    const MAX_AUTO_PROGRESS = 99;
+    const MIN_DURATION = 320;
+    const MAX_DURATION = 2400;
+    const MS_PER_PERCENT = 45;
+
+    const raf =
+        (typeof window !== 'undefined' && window.requestAnimationFrame)
+            ? window.requestAnimationFrame.bind(window)
+            : (cb) => setTimeout(() => cb(Date.now()), 16);
+    const caf =
+        (typeof window !== 'undefined' && window.cancelAnimationFrame)
+            ? window.cancelAnimationFrame.bind(window)
+            : clearTimeout;
+
+    let currentValue = 0;
+    let targetValue = 0;
+    let animationFrom = 0;
+    let animationStart = 0;
+    let animationEnd = 0;
+    let rafId = null;
+    let autoTimer = null;
+    let reportedValue = 0;
+    let autoCeiling = 0;
+
+    function now() {
+        if (typeof performance !== 'undefined' && performance.now) {
+            return performance.now();
+        }
+        return Date.now();
+    }
+
+    function clamp(value) {
+        const num = Number(value);
+        if (!Number.isFinite(num)) return 0;
+        return Math.max(0, Math.min(100, num));
+    }
+
+    function apply(value) {
+        const bar = document.getElementById('progressBar');
+        if (bar) {
+            bar.style.width = `${value}%`;
+        }
+    }
+
+    function stopAnimation() {
+        if (rafId) {
+            caf(rafId);
+            rafId = null;
+        }
+    }
+
+    function stopAutoTimer() {
+        if (autoTimer) {
+            clearInterval(autoTimer);
+            autoTimer = null;
+        }
+    }
+
+    function syncCurrent() {
+        if (!rafId) return;
+        const currentTime = now();
+        if (animationEnd <= animationStart || currentTime >= animationEnd) {
+            currentValue = targetValue;
+            stopAnimation();
+            return;
+        }
+        const ratio = (currentTime - animationStart) / (animationEnd - animationStart);
+        const easedRatio = Math.min(1, Math.max(0, ratio));
+        currentValue = animationFrom + (targetValue - animationFrom) * easedRatio;
+    }
+
+    function scheduleAnimation() {
+        stopAnimation();
+        if (targetValue <= currentValue + 0.01) {
+            currentValue = targetValue;
+            apply(currentValue);
+            return;
+        }
+        animationFrom = currentValue;
+        animationStart = now();
+        const distance = targetValue - animationFrom;
+        if (distance <= 0) {
+            currentValue = targetValue;
+            apply(currentValue);
+            return;
+        }
+        let duration = distance * MS_PER_PERCENT;
+        duration = Math.max(MIN_DURATION, Math.min(MAX_DURATION, duration));
+        if (targetValue >= 100) {
+            duration = Math.min(duration, 900);
+        }
+        animationEnd = animationStart + duration;
+        apply(currentValue);
+        rafId = raf(step);
+    }
+
+    function step(timestamp) {
+        if (!rafId) return;
+        const currentTime = typeof timestamp === 'number' ? timestamp : now();
+        if (animationEnd <= animationStart || currentTime >= animationEnd) {
+            currentValue = targetValue;
+            apply(currentValue);
+            stopAnimation();
+            return;
+        }
+        const ratio = (currentTime - animationStart) / (animationEnd - animationStart);
+        const easedRatio = Math.min(1, Math.max(0, ratio));
+        currentValue = animationFrom + (targetValue - animationFrom) * easedRatio;
+        apply(currentValue);
+        rafId = raf(step);
+    }
+
+    function ensureAutoTimer() {
+        if (autoTimer) return;
+        autoTimer = setInterval(() => {
+            if (reportedValue >= 100) {
+                autoCeiling = 100;
+                setTarget(100);
+                stopAutoTimer();
+                return;
+            }
+            autoCeiling = Math.min(
+                MAX_AUTO_PROGRESS,
+                Math.max(reportedValue, autoCeiling + AUTO_STEP)
+            );
+            if (autoCeiling > targetValue + 0.05) {
+                setTarget(autoCeiling);
+            }
+        }, AUTO_INTERVAL);
+    }
+
+    function setTarget(value) {
+        const clamped = clamp(value);
+        if (clamped <= currentValue + 0.01 && clamped <= targetValue + 0.01) {
+            targetValue = clamped;
+            if (!rafId) {
+                currentValue = clamped;
+                apply(currentValue);
+            }
+            return;
+        }
+        syncCurrent();
+        if (clamped <= currentValue) {
+            targetValue = clamped;
+            currentValue = clamped;
+            apply(currentValue);
+            if (clamped >= 100) {
+                stopAnimation();
+                stopAutoTimer();
+            }
+            return;
+        }
+        if (Math.abs(clamped - targetValue) < 0.05) {
+            targetValue = clamped;
+            return;
+        }
+        targetValue = clamped;
+        scheduleAnimation();
+        if (clamped >= 100) {
+            stopAutoTimer();
+        }
+    }
+
+    return {
+        start() {
+            ensureAutoTimer();
+        },
+        stop() {
+            stopAutoTimer();
+            stopAnimation();
+        },
+        reset() {
+            stopAutoTimer();
+            stopAnimation();
+            currentValue = 0;
+            targetValue = 0;
+            animationFrom = 0;
+            animationStart = 0;
+            animationEnd = 0;
+            reportedValue = 0;
+            autoCeiling = 0;
+            apply(0);
+        },
+        update(nextProgress) {
+            const clamped = clamp(nextProgress);
+            if (clamped >= 100) {
+                reportedValue = 100;
+                setTarget(100);
+                return;
+            }
+            if (clamped > reportedValue) {
+                reportedValue = clamped;
+            }
+            if (clamped > autoCeiling) {
+                autoCeiling = clamped;
+            }
+            setTarget(Math.max(targetValue, clamped));
+            ensureAutoTimer();
+        },
+    };
+}
 function getStrategyParams(type) { const strategySelectId = `${type}Strategy`; const strategySelect = document.getElementById(strategySelectId); if (!strategySelect) { console.error(`[Main] Cannot find select element with ID: ${strategySelectId}`); return {}; } const key = strategySelect.value; let internalKey = key; if (type === 'exit') { if(['ma_cross','macd_cross','k_d_cross','ema_cross'].includes(key)) { internalKey = `${key}_exit`; } } else if (type === 'shortEntry') { internalKey = key; if (!strategyDescriptions[internalKey] && ['ma_cross', 'ma_below', 'ema_cross', 'rsi_overbought', 'macd_cross', 'bollinger_reversal', 'k_d_cross', 'price_breakdown', 'williams_overbought', 'turtle_stop_loss'].includes(key)) { internalKey = `short_${key}`; } } else if (type === 'shortExit') { internalKey = key; if (!strategyDescriptions[internalKey] && ['ma_cross', 'ma_above', 'ema_cross', 'rsi_oversold', 'macd_cross', 'bollinger_breakout', 'k_d_cross', 'price_breakout', 'williams_oversold', 'turtle_breakout', 'trailing_stop'].includes(key)) { internalKey = `cover_${key}`; } } const cfg = strategyDescriptions[internalKey]; const prm = {}; if (!cfg?.defaultParams) { return {}; } for (const pName in cfg.defaultParams) { let idSfx = pName.charAt(0).toUpperCase() + pName.slice(1); if (internalKey === 'k_d_cross' && pName === 'thresholdX') idSfx = 'KdThresholdX'; else if (internalKey === 'k_d_cross_exit' && pName === 'thresholdY') idSfx = 'KdThresholdY'; else if (internalKey === 'turtle_stop_loss' && pName === 'stopLossPeriod') idSfx = 'StopLossPeriod'; else if ((internalKey === 'macd_cross' || internalKey === 'macd_cross_exit') && pName === 'signalPeriod') idSfx = 'SignalPeriod'; else if (internalKey === 'short_k_d_cross' && pName === 'thresholdY') idSfx = 'ShortKdThresholdY'; else if (internalKey === 'cover_k_d_cross' && pName === 'thresholdX') idSfx = 'CoverKdThresholdX'; else if (internalKey === 'short_macd_cross' && pName === 'signalPeriod') idSfx = 'ShortSignalPeriod'; else if (internalKey === 'cover_macd_cross' && pName === 'signalPeriod') idSfx = 'CoverSignalPeriod'; else if (internalKey === 'short_turtle_stop_loss' && pName === 'stopLossPeriod') idSfx = 'ShortStopLossPeriod'; else if (internalKey === 'cover_turtle_breakout' && pName === 'breakoutPeriod') idSfx = 'CoverBreakoutPeriod'; else if (internalKey === 'cover_trailing_stop' && pName === 'percentage') idSfx = 'CoverTrailingStopPercentage'; const id = `${type}${idSfx}`; const inp = document.getElementById(id); if (inp) { prm[pName] = (inp.type === 'number') ? (parseFloat(inp.value) || cfg.defaultParams[pName]) : inp.value; } else { prm[pName] = cfg.defaultParams[pName]; } } return prm; }
 function getBacktestParams() { const sN=document.getElementById("stockNo").value.trim().toUpperCase()||"2330"; const sD=document.getElementById("startDate").value; const eD=document.getElementById("endDate").value; const iC=parseFloat(document.getElementById("initialCapital").value)||100000; const pS=parseFloat(document.getElementById("positionSize").value)||100; const sL=parseFloat(document.getElementById("stopLoss").value)||0; const tP=parseFloat(document.getElementById("takeProfit").value)||0; const tT=document.querySelector('input[name="tradeTiming"]:checked')?.value||'close'; const adjP=document.getElementById("adjustedPriceCheckbox").checked; const eS=document.getElementById("entryStrategy").value; const xS=document.getElementById("exitStrategy").value; const eP=getStrategyParams('entry'); const xP=getStrategyParams('exit'); const enableShorting = document.getElementById("enableShortSelling").checked; let shortES = null, shortXS = null, shortEP = {}, shortXP = {}; if (enableShorting) { shortES = document.getElementById("shortEntryStrategy").value; shortXS = document.getElementById("shortExitStrategy").value; shortEP = getStrategyParams('shortEntry'); shortXP = getStrategyParams('shortExit'); } const buyFee = parseFloat(document.getElementById("buyFee").value) || 0; const sellFee = parseFloat(document.getElementById("sellFee").value) || 0;     const positionBasis = document.querySelector('input[name="positionBasis"]:checked')?.value || 'initialCapital'; const marketSwitch = document.getElementById("marketSwitch"); const market = (marketSwitch && marketSwitch.checked) ? 'TPEX' : 'TWSE'; return { stockNo: sN, startDate: sD, endDate: eD, initialCapital: iC, positionSize: pS, stopLoss: sL, takeProfit: tP, tradeTiming: tT, adjustedPrice: adjP, entryStrategy: eS, exitStrategy: xS, entryParams: eP, exitParams: xP, enableShorting: enableShorting, shortEntryStrategy: shortES, shortExitStrategy: shortXS, shortEntryParams: shortEP, shortExitParams: shortXP, buyFee: buyFee, sellFee: sellFee, positionBasis: positionBasis, market: market, marketType: currentMarket }; }
 function validateBacktestParams(p) { if(!/^[0-9A-Z]{3,7}$/.test(p.stockNo)){showError("請輸入有效代碼");return false;} if(!p.startDate||!p.endDate){showError("請選擇日期");return false;} if(new Date(p.startDate)>=new Date(p.endDate)){showError("結束日期需晚於開始日期");return false;} if(p.initialCapital<=0){showError("本金需>0");return false;} if(p.positionSize<=0||p.positionSize>100){showError("部位大小1-100%");return false;} if(p.stopLoss<0||p.stopLoss>100){showError("停損0-100%");return false;} if(p.takeProfit<0){showError("停利>=0%");return false;} if (p.buyFee < 0) { showError("買入手續費不能小於 0%"); return false; } if (p.sellFee < 0) { showError("賣出手續費+稅不能小於 0%"); return false; } const chkP=(ps,t)=>{ if (!ps) return true; for(const k in ps){ if(typeof ps[k]!=='number'||isNaN(ps[k])){ if(Object.keys(ps).length > 0) { showError(`${t}策略的參數 ${k} 錯誤 (值: ${ps[k]})`); return false; } } } return true; }; if(!chkP(p.entryParams,'做多進場'))return false; if(!chkP(p.exitParams,'做多出場'))return false; if (p.enableShorting) { if(!chkP(p.shortEntryParams,'做空進場'))return false; if(!chkP(p.shortExitParams,'回補出場'))return false; } return true; }


### PR DESCRIPTION
## Summary
- introduce a reusable progress animator to smooth and auto-drive the backtest progress bar
- reset, start, and stop the animator alongside existing loading lifecycle for consistent UX
- bump the main script version tag to v3.5.0 to track this UI refinement

## Testing
- not run (frontend change)

------
https://chatgpt.com/codex/tasks/task_e_68cd639accb083249bf10123ef335003