### PR TITLE
Add Netlify adjusted-price fallback using FinMind dividends

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,9 @@
   to = "/.netlify/functions/twse-proxy"
   status = 200
   force = true
+
+[[redirects]]
+  from = "/api/adjusted-price/*"
+  to = "/.netlify/functions/calculateAdjustedPrice"
+  status = 200
+  force = true


### PR DESCRIPTION
## Summary
- expose a dedicated adjusted-price endpoint on Netlify with TWSE→FinMind fallback and richer summary metadata
- wire the worker adjusted-price pipeline to consume the new endpoint and cache adjustment details
- update the UI tester to support the Netlify adjusted fallback source alongside Yahoo

## Testing
- Not run (FinMind API token unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ce7578f84c8324ae173b5b015fe306