### PR TITLE
Add Goodinfo adjusted fallback and comparison UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -782,6 +782,20 @@
                                 </div>
                             </div>
 
+                            <!-- Adjusted vs Raw Comparison -->
+                            <div class="card hidden" id="adjustedComparisonCard">
+                                <div class="card-header">
+                                    <h3 class="card-title flex items-center gap-2">
+                                        <i data-lucide="scale" class="lucide text-primary" style="color: var(--primary);"></i>
+                                        還原股價對比
+                                    </h3>
+                                    <p class="card-description">對比原始收盤與還原收盤，確認除權息調整成果</p>
+                                </div>
+                                <div class="card-content" id="adjustedComparisonContent">
+                                    <p class="text-xs text-muted-foreground">啟用「除權息還原股價」後將顯示原始與還原股價的對比摘要。</p>
+                                </div>
+                            </div>
+
                             <!-- Today Suggestion -->
                             <div class="card hidden" id="today-suggestion-area">
                                 <div class="card-header">

--- a/js/backtest.js
+++ b/js/backtest.js
@@ -221,6 +221,13 @@ function clearPreviousResults() {
         suggestionArea.className = 'my-4 p-4 bg-yellow-50 border-l-4 border-yellow-500 text-yellow-800 rounded-md text-center hidden';
         suggestionText.textContent = "-";
     }
+    if (typeof window.hideAdjustedComparisonCard === 'function') {
+        try {
+            window.hideAdjustedComparisonCard();
+        } catch (error) {
+            console.warn('[Main] 重置還原對比卡片時發生例外:', error);
+        }
+    }
 }
 
 function updateDataSourceDisplay(dataSource, stockName) {
@@ -261,6 +268,17 @@ function handleBacktestResult(result, stockName, dataSource) {
         displayBacktestResult(result);
         displayTradeResults(result);
         renderChart(result);
+        if (typeof window.updateAdjustedComparisonCard === 'function') {
+            try {
+                window.updateAdjustedComparisonCard(result, {
+                    settings: lastFetchSettings,
+                    stockName,
+                    dataSource,
+                });
+            } catch (error) {
+                console.warn('[Main] 更新還原對比卡片失敗:', error);
+            }
+        }
         activateTab('summary');
 
         setTimeout(() => {

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,11 @@ let workerUrl = null; // Loader 會賦值
 let cachedStockData = null;
 const cachedDataStore = new Map(); // Map<market|stockNo|priceMode, CacheEntry>
 const progressAnimator = createProgressAnimator();
+const adjustedComparisonState = {
+    version: 'LB-ADJ-CARD-20241015A',
+    lastContextKey: null,
+    busy: false,
+};
 
 window.cachedDataStore = cachedDataStore;
 let lastFetchSettings = null;
@@ -61,6 +66,7 @@ function getTesterSourceConfigs(market, adjusted) {
     if (adjusted) {
         return [
             { id: 'yahoo', label: 'Yahoo 還原價', description: '主來源 (還原股價)' },
+            { id: 'goodinfo', label: 'Goodinfo 還原備援', description: 'Yahoo 失效時啟用' },
         ];
     }
     if (market === 'TPEX') {
@@ -154,8 +160,8 @@ async function runDataSourceTester(sourceId, sourceLabel) {
     }
     const market = getCurrentMarketFromUI();
     const adjusted = isAdjustedMode();
-    if (adjusted && sourceId === 'finmind') {
-        showTesterResult('error', '還原股價目前僅提供 Yahoo Finance 測試來源。');
+    if (adjusted && !['yahoo', 'goodinfo'].includes(sourceId)) {
+        showTesterResult('error', '還原股價目前僅支援 Yahoo 或 Goodinfo 測試來源。');
         return;
     }
     const endpoint = market === 'TPEX' ? '/api/tpex/' : '/api/twse/';
@@ -663,6 +669,117 @@ function summariseSourceLabels(labels) {
 
 }
 
+function buildUiCacheKey(stockNo, startDate, endDate, adjusted) {
+    const mode = adjusted ? 'ADJ' : 'RAW';
+    return `${stockNo}__${startDate}__${endDate}__${mode}`;
+}
+
+function parsePriceValue(value) {
+    if (value === null || value === undefined) return null;
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+}
+
+function parseVolumeValue(value) {
+    if (value === null || value === undefined) return 0;
+    const num = Number(String(value).replace(/,/g, ''));
+    return Number.isFinite(num) ? num : 0;
+}
+
+function normalizePriceSeries(rows) {
+    if (!Array.isArray(rows)) return [];
+    return rows
+        .map((row) => {
+            if (!row) return null;
+            const date = row.date;
+            if (!date) return null;
+            const close = parsePriceValue(row.close);
+            const open = parsePriceValue(row.open ?? close);
+            const base = close ?? open ?? 0;
+            const highCandidate = parsePriceValue(row.high);
+            const lowCandidate = parsePriceValue(row.low);
+            const high = highCandidate !== null ? highCandidate : Math.max(open ?? base, close ?? base);
+            const low = lowCandidate !== null ? lowCandidate : Math.min(open ?? base, close ?? base);
+            const change = parsePriceValue(row.change);
+            const volume = parseVolumeValue(row.volume);
+            return {
+                date,
+                open,
+                high,
+                low,
+                close,
+                change: Number.isFinite(change) ? change : null,
+                volume,
+            };
+        })
+        .filter((entry) => entry && entry.close !== null)
+        .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+function getCachedSeriesForComparison(stockNo, startDate, endDate, adjusted) {
+    if (!stockNo || !startDate || !endDate) return null;
+    const key = buildUiCacheKey(stockNo, startDate, endDate, adjusted);
+    const entry = cachedDataStore.get(key);
+    if (!entry || !Array.isArray(entry.data)) return null;
+    const rows = normalizePriceSeries(extractRangeData(entry.data, startDate, endDate));
+    return {
+        rows,
+        dataSource: entry.dataSource || summariseSourceLabels(entry.dataSources || []),
+        stockName: entry.stockName || stockNo,
+    };
+}
+
+async function fetchPricePreviewSeries(stockNo, market, startISO, endISO, adjusted) {
+    const endpoint = market === 'TPEX' ? '/api/tpex/' : '/api/twse/';
+    const params = new URLSearchParams({ stockNo });
+    if (startISO) params.set('start', startISO);
+    if (endISO) params.set('end', endISO);
+    if (adjusted) params.set('adjusted', '1');
+    params.set('preview', '1');
+    const response = await fetch(`${endpoint}?${params.toString()}`, { headers: { Accept: 'application/json' } });
+    const rawText = await response.text();
+    let payload = {};
+    try {
+        payload = rawText ? JSON.parse(rawText) : {};
+    } catch (error) {
+        console.warn('[AdjustedComparison] 無法解析預覽回應 JSON:', error);
+        payload = {};
+    }
+    if (!response.ok || payload?.error) {
+        const message = payload?.error || `HTTP ${response.status}`;
+        throw new Error(message);
+    }
+    const aaData = Array.isArray(payload.aaData) ? payload.aaData : [];
+    const converted = aaData
+        .map((row) => {
+            if (!Array.isArray(row) || row.length < 7) return null;
+            const isoDate = rocToIsoDate(row[0]);
+            if (!isoDate) return null;
+            return {
+                date: isoDate,
+                open: parsePriceValue(row[3]),
+                high: parsePriceValue(row[4]),
+                low: parsePriceValue(row[5]),
+                close: parsePriceValue(row[6]),
+                change: parsePriceValue(row[7]),
+                volume: parseVolumeValue(row[8]),
+                stockName: row[2] || payload.stockName || stockNo,
+            };
+        })
+        .filter(Boolean);
+    const rows = normalizePriceSeries(converted);
+    return {
+        rows,
+        dataSource: payload.dataSource || '',
+        stockName: payload.stockName || (converted[0]?.stockName) || stockNo,
+    };
+}
+
+function formatNumber(value, digits = 2) {
+    if (!Number.isFinite(value)) return '—';
+    return Number(value).toFixed(digits);
+}
+
 function needsDataFetch(cur) {
     if (!cur || !cur.stockNo || !cur.startDate || !cur.endDate) return true;
     const key = buildCacheKey(cur);
@@ -737,6 +854,214 @@ function getSuggestion() {
         if(backtestWorker) backtestWorker.terminate(); backtestWorker = null;
     }
 }
+
+window.hideAdjustedComparisonCard = function hideAdjustedComparisonCard() {
+    const card = document.getElementById('adjustedComparisonCard');
+    const contentEl = document.getElementById('adjustedComparisonContent');
+    adjustedComparisonState.lastContextKey = null;
+    adjustedComparisonState.busy = false;
+    if (card) card.classList.add('hidden');
+    if (contentEl) {
+        contentEl.innerHTML = '<p class="text-xs text-muted-foreground">啟用「除權息還原股價」後將顯示原始與還原股價的對比摘要。</p>';
+    }
+};
+
+window.updateAdjustedComparisonCard = async function updateAdjustedComparisonCard(result, context = {}) {
+    const card = document.getElementById('adjustedComparisonCard');
+    const contentEl = document.getElementById('adjustedComparisonContent');
+    if (!card || !contentEl) return;
+
+    const settings = context.settings || lastFetchSettings;
+    if (!settings || !settings.adjustedPrice) {
+        window.hideAdjustedComparisonCard();
+        return;
+    }
+
+    const stockNo = settings.stockNo;
+    const startISO = settings.startDate;
+    const endISO = settings.endDate;
+    if (!stockNo || !startISO || !endISO) {
+        window.hideAdjustedComparisonCard();
+        return;
+    }
+
+    const marketValue = settings.market || settings.marketType || getCurrentMarketFromUI() || 'TWSE';
+    const market = typeof marketValue === 'string' ? marketValue.toUpperCase() : 'TWSE';
+    const contextKey = JSON.stringify([stockNo, startISO, endISO, market, settings.adjustedPrice]);
+    adjustedComparisonState.lastContextKey = contextKey;
+    adjustedComparisonState.busy = true;
+
+    card.classList.remove('hidden');
+    contentEl.innerHTML = '<p class="text-xs text-muted-foreground">正在準備還原股價對比...</p>';
+
+    try {
+        let stockName = context.stockName || stockNo;
+        let adjustedSource = context.dataSource || '';
+        let adjustedSeries = [];
+
+        if (Array.isArray(result?.rawData) && result.rawData.length > 0) {
+            adjustedSeries = normalizePriceSeries(result.rawData);
+        } else if (Array.isArray(cachedStockData) && cachedStockData.length > 0) {
+            adjustedSeries = normalizePriceSeries(extractRangeData(cachedStockData, startISO, endISO));
+        } else {
+            const cachedAdjusted = getCachedSeriesForComparison(stockNo, startISO, endISO, true);
+            if (cachedAdjusted) {
+                adjustedSeries = cachedAdjusted.rows;
+                adjustedSource = cachedAdjusted.dataSource || adjustedSource;
+                stockName = cachedAdjusted.stockName || stockName;
+            } else {
+                const fetchedAdjusted = await fetchPricePreviewSeries(stockNo, market, startISO, endISO, true);
+                adjustedSeries = fetchedAdjusted.rows;
+                adjustedSource = fetchedAdjusted.dataSource || adjustedSource;
+                stockName = fetchedAdjusted.stockName || stockName;
+            }
+        }
+
+        if (adjustedComparisonState.lastContextKey !== contextKey) {
+            return;
+        }
+
+        if (!Array.isArray(adjustedSeries) || adjustedSeries.length === 0) {
+            contentEl.innerHTML = '<p class="text-xs text-rose-600">未能取得還原股價資料供對比。</p>';
+            return;
+        }
+
+        let rawSeries = [];
+        let rawSource = '';
+        let rawError = null;
+        const cachedRaw = getCachedSeriesForComparison(stockNo, startISO, endISO, false);
+        if (cachedRaw) {
+            rawSeries = cachedRaw.rows;
+            rawSource = cachedRaw.dataSource || rawSource;
+        } else {
+            try {
+                const fetchedRaw = await fetchPricePreviewSeries(stockNo, market, startISO, endISO, false);
+                rawSeries = fetchedRaw.rows;
+                rawSource = fetchedRaw.dataSource || rawSource;
+            } catch (error) {
+                rawError = error;
+                console.warn('[AdjustedComparison] 原始價格預覽取得失敗:', error);
+            }
+        }
+
+        if (adjustedComparisonState.lastContextKey !== contextKey) {
+            return;
+        }
+
+        if (!Array.isArray(rawSeries) || rawSeries.length === 0) {
+            const reason = rawError ? ` (${rawError.message})` : '。請先關閉「除權息還原股價」執行一次回測建立原始資料快取。';
+            contentEl.innerHTML = `<p class="text-xs text-amber-600">尚未取得原始股價對照${reason}</p>`;
+            return;
+        }
+
+        const adjustedMap = new Map(adjustedSeries.map((item) => [item.date, item]));
+        const rawMap = new Map(rawSeries.map((item) => [item.date, item]));
+        const commonDates = Array.from(adjustedMap.keys())
+            .filter((date) => rawMap.has(date))
+            .sort((a, b) => a.localeCompare(b));
+
+        if (commonDates.length === 0) {
+            contentEl.innerHTML = '<p class="text-xs text-amber-600">還原資料與原始資料無共同交易日，請確認查詢日期區間。</p>';
+            return;
+        }
+
+        const latestDate = commonDates[commonDates.length - 1];
+        const latestAdjusted = adjustedMap.get(latestDate);
+        const latestRaw = rawMap.get(latestDate);
+        const diff = latestAdjusted && latestRaw && latestAdjusted.close !== null && latestRaw.close !== null
+            ? latestAdjusted.close - latestRaw.close
+            : null;
+        const diffRatio = diff !== null && latestRaw && latestRaw.close
+            ? ((latestAdjusted.close / latestRaw.close) - 1) * 100
+            : null;
+
+        const recentRows = commonDates.slice(-3).map((date) => {
+            const adj = adjustedMap.get(date);
+            const raw = rawMap.get(date);
+            return {
+                date,
+                rawClose: raw?.close ?? null,
+                adjClose: adj?.close ?? null,
+                diff: raw && adj && raw.close !== null && adj.close !== null ? adj.close - raw.close : null,
+            };
+        }).reverse();
+
+        const diffLabel = diff !== null ? `${diff >= 0 ? '+' : ''}${formatNumber(diff)}` : '—';
+        const ratioLabel = diffRatio !== null ? `${diffRatio >= 0 ? '+' : ''}${formatNumber(diffRatio, 2)}%` : '—';
+        const statusClass = diff !== null && Math.abs(diff) < 0.0001 ? 'bg-emerald-600' : 'bg-sky-600';
+        const statusText = diff !== null && Math.abs(diff) < 0.0001 ? '已對齊' : '已還原';
+
+        const rowsHtml = recentRows
+            .map((row) => {
+                const diffText = row.diff !== null ? `${row.diff >= 0 ? '+' : ''}${formatNumber(row.diff)}` : '—';
+                const diffClass = row.diff === null ? 'text-muted-foreground' : row.diff >= 0 ? 'text-emerald-600' : 'text-rose-600';
+                return `<tr>
+                        <td class="py-1 pr-2 text-left text-muted-foreground">${row.date}</td>
+                        <td class="py-1 pr-2 text-right">${formatNumber(row.rawClose)}</td>
+                        <td class="py-1 pr-2 text-right">${formatNumber(row.adjClose)}</td>
+                        <td class="py-1 text-right ${diffClass}">${diffText}</td>
+                    </tr>`;
+            })
+            .join('');
+
+        contentEl.innerHTML = `
+            <div class="flex items-center justify-between text-xs text-muted-foreground mb-1">
+                <span>最近交易日</span>
+                <span>${latestDate}</span>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div class="p-3 border rounded-md bg-white/70">
+                    <p class="text-[11px] text-muted-foreground">原始收盤</p>
+                    <p class="text-lg font-semibold" style="color: var(--foreground);">${formatNumber(latestRaw?.close)}</p>
+                    <p class="text-[11px] text-muted-foreground truncate">來源: ${rawSource || '未知'}</p>
+                </div>
+                <div class="p-3 border rounded-md ${diff !== null ? (diff >= 0 ? 'bg-emerald-50 border-emerald-200' : 'bg-rose-50 border-rose-200') : 'bg-white/70'}">
+                    <div class="flex items-center justify-between mb-1">
+                        <p class="text-[11px] text-muted-foreground">還原收盤</p>
+                        <span class="px-2 py-0.5 text-[10px] text-white rounded-full ${statusClass}">${statusText}</span>
+                    </div>
+                    <p class="text-lg font-semibold" style="color: var(--foreground);">${formatNumber(latestAdjusted?.close)}</p>
+                    <p class="text-[11px] text-muted-foreground truncate">來源: ${adjustedSource || '未知'}</p>
+                </div>
+            </div>
+            <div class="grid grid-cols-2 gap-3 mt-2">
+                <div class="p-3 rounded-md border bg-muted/20">
+                    <p class="text-[11px] text-muted-foreground">價差</p>
+                    <p class="text-sm font-semibold">${diffLabel}</p>
+                </div>
+                <div class="p-3 rounded-md border bg-muted/20">
+                    <p class="text-[11px] text-muted-foreground">還原倍率</p>
+                    <p class="text-sm font-semibold">${ratioLabel}</p>
+                </div>
+            </div>
+            <div class="mt-3">
+                <p class="text-[11px] text-muted-foreground mb-1">最近三筆對比</p>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full text-xs">
+                        <thead>
+                            <tr class="text-muted-foreground">
+                                <th class="text-left py-1 pr-2">日期</th>
+                                <th class="text-right py-1 pr-2">原始收盤</th>
+                                <th class="text-right py-1 pr-2">還原收盤</th>
+                                <th class="text-right py-1">差值</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            ${rowsHtml}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        `;
+    } catch (error) {
+        console.error('[AdjustedComparison] 更新還原對比卡片失敗:', error);
+        contentEl.innerHTML = `<p class="text-xs text-rose-600">還原股價對比更新失敗：${error.message}</p>`;
+    } finally {
+        if (adjustedComparisonState.lastContextKey === contextKey) {
+            adjustedComparisonState.busy = false;
+        }
+    }
+};
 
 // --- 新增：頁籤切換功能 ---
 function initTabs() {

--- a/netlify/functions/lib/goodinfo.js
+++ b/netlify/functions/lib/goodinfo.js
@@ -1,0 +1,254 @@
+// netlify/functions/lib/goodinfo.js
+// Patch Tag: LB-GOODINFO-ADJ-20241015A
+
+const GOODINFO_VERSION = 'LB-GOODINFO-ADJ-20241015A';
+
+const GOODINFO_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36',
+    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+    'Accept-Language': 'zh-TW,zh;q=0.9,en-US;q=0.6,en;q=0.3',
+    'Cache-Control': 'no-cache',
+    Pragma: 'no-cache',
+    Referer: 'https://goodinfo.tw/tw/index.asp',
+    'Sec-Fetch-Site': 'same-origin',
+    'Sec-Fetch-Mode': 'navigate',
+    'Sec-Fetch-Dest': 'document',
+    'Upgrade-Insecure-Requests': '1',
+};
+
+function stripTags(html) {
+    if (!html) return '';
+    return html.replace(/<[^>]*>/g, '');
+}
+
+function decodeEntities(text) {
+    if (!text) return '';
+    return text
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/&amp;/gi, '&')
+        .replace(/&lt;/gi, '<')
+        .replace(/&gt;/gi, '>')
+        .replace(/&#x2f;/gi, '/')
+        .replace(/&#47;/gi, '/')
+        .replace(/&quot;/gi, '"')
+        .replace(/&#39;/gi, "'")
+        .replace(/&minus;/gi, '-')
+        .replace(/&#8722;/gi, '-')
+        .replace(/&ensp;/gi, ' ')
+        .replace(/&emsp;/gi, ' ')
+        .replace(/&hellip;/gi, '...');
+}
+
+function normaliseText(text) {
+    return decodeEntities(stripTags(text)).replace(/\s+/g, ' ').trim();
+}
+
+function parseNumber(text) {
+    if (text === undefined || text === null) return null;
+    const trimmed = String(text).replace(/,/g, '').replace(/\s+/g, '').replace(/％/g, '');
+    if (!trimmed || trimmed === '-' || trimmed === '－' || trimmed === '--' || trimmed === '---') {
+        return null;
+    }
+    const num = Number(trimmed);
+    return Number.isFinite(num) ? num : null;
+}
+
+function toISODate(text) {
+    if (!text) return null;
+    const trimmed = text.replace(/\s+/g, '');
+    const parts = trimmed.split('/');
+    if (parts.length !== 3) return null;
+    let [yearStr, monthStr, dayStr] = parts;
+    if (!yearStr || !monthStr || !dayStr) return null;
+    let year = Number(yearStr);
+    if (!Number.isFinite(year)) return null;
+    if (yearStr.length <= 3) {
+        year += 1911;
+    }
+    const month = String(Number(monthStr)).padStart(2, '0');
+    const day = String(Number(dayStr)).padStart(2, '0');
+    if (!Number.isFinite(Number(month)) || !Number.isFinite(Number(day))) return null;
+    const iso = `${year}-${month}-${day}`;
+    const check = new Date(iso);
+    return Number.isNaN(check.getTime()) ? null : iso;
+}
+
+function extractStockName(html, fallback) {
+    if (!html) return fallback;
+    const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    if (titleMatch) {
+        const cleanTitle = normaliseText(titleMatch[1]);
+        const nameMatch = cleanTitle.match(/\s([\u4e00-\u9fa5A-Za-z0-9\-]+)(?:\s|-|\||$)/);
+        if (nameMatch && nameMatch[1]) {
+            return nameMatch[1];
+        }
+    }
+    const headerMatch = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+    if (headerMatch) {
+        const cleanHeader = normaliseText(headerMatch[1]);
+        const parts = cleanHeader.split(/\s+/);
+        if (parts.length >= 2) {
+            return parts[1];
+        }
+    }
+    return fallback;
+}
+
+function locateAdjustedTable(html) {
+    if (!html) return null;
+    const marker = html.indexOf('還原權值股價');
+    if (marker === -1) return null;
+    const sliced = html.slice(marker);
+    const match = sliced.match(/<table[^>]*>([\s\S]*?)<\/table>/i);
+    return match ? match[0] : null;
+}
+
+function parseAdjustedRows(tableHtml) {
+    const rows = [];
+    const rowMatches = tableHtml ? tableHtml.match(/<tr[^>]*>[\s\S]*?<\/tr>/gi) : null;
+    if (!rowMatches || rowMatches.length === 0) return rows;
+    let headers = null;
+    for (const rowHtml of rowMatches) {
+        const cellMatches = rowHtml.match(/<t[hd][^>]*>[\s\S]*?<\/t[hd]>/gi);
+        if (!cellMatches || cellMatches.length === 0) continue;
+        const cells = cellMatches.map(normaliseText);
+        if (!headers) {
+            if (cells.some((cell) => cell.includes('日期'))) {
+                headers = cells.map((cell) => cell.replace(/\s+/g, ''));
+            }
+            continue;
+        }
+        if (cells.some((cell) => /合計|平均|備註/.test(cell))) {
+            continue;
+        }
+        if (cells.length < headers.length) {
+            continue;
+        }
+        rows.push(cells);
+    }
+    if (!headers) return [];
+    const indexOfHeader = (predicate) => {
+        return headers.findIndex((header) => predicate(header));
+    };
+    const idxDate = indexOfHeader((header) => header.includes('日期'));
+    const idxAdjClose = indexOfHeader((header) => header.includes('還原收盤'));
+    const idxAdjOpen = indexOfHeader((header) => header.includes('還原開盤'));
+    const idxAdjHigh = indexOfHeader((header) => header.includes('還原最高'));
+    const idxAdjLow = indexOfHeader((header) => header.includes('還原最低'));
+    const idxVolume = indexOfHeader((header) => /量/.test(header));
+    const idxRawClose = indexOfHeader((header) => header.includes('收盤') && !header.includes('還原'));
+    const idxRawOpen = indexOfHeader((header) => header.includes('開盤') && !header.includes('還原'));
+    const idxRawHigh = indexOfHeader((header) => header.includes('最高') && !header.includes('還原'));
+    const idxRawLow = indexOfHeader((header) => header.includes('最低') && !header.includes('還原'));
+    const parsed = [];
+    for (const cells of rows) {
+        const dateText = idxDate >= 0 ? cells[idxDate] : null;
+        const isoDate = toISODate(dateText);
+        if (!isoDate) continue;
+        const adjClose = idxAdjClose >= 0 ? parseNumber(cells[idxAdjClose]) : null;
+        const adjOpen = idxAdjOpen >= 0 ? parseNumber(cells[idxAdjOpen]) : null;
+        const adjHigh = idxAdjHigh >= 0 ? parseNumber(cells[idxAdjHigh]) : null;
+        const adjLow = idxAdjLow >= 0 ? parseNumber(cells[idxAdjLow]) : null;
+        const rawClose = idxRawClose >= 0 ? parseNumber(cells[idxRawClose]) : null;
+        const rawOpen = idxRawOpen >= 0 ? parseNumber(cells[idxRawOpen]) : null;
+        const rawHigh = idxRawHigh >= 0 ? parseNumber(cells[idxRawHigh]) : null;
+        const rawLow = idxRawLow >= 0 ? parseNumber(cells[idxRawLow]) : null;
+        const volume = idxVolume >= 0 ? parseNumber(cells[idxVolume]) : null;
+        if (!adjClose && !adjOpen && !adjHigh && !adjLow) {
+            continue;
+        }
+        parsed.push({
+            date: isoDate,
+            adjOpen,
+            adjHigh,
+            adjLow,
+            adjClose,
+            rawOpen,
+            rawHigh,
+            rawLow,
+            rawClose,
+            volume,
+        });
+    }
+    parsed.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    let prevAdjClose = null;
+    for (const item of parsed) {
+        if (item.adjClose !== null && item.adjClose !== undefined) {
+            if (prevAdjClose !== null && prevAdjClose !== undefined) {
+                item.change = Number.isFinite(item.adjClose - prevAdjClose)
+                    ? item.adjClose - prevAdjClose
+                    : 0;
+            } else {
+                item.change = 0;
+            }
+            prevAdjClose = item.adjClose;
+        } else {
+            item.change = 0;
+        }
+    }
+    return parsed;
+}
+
+async function fetchHtml(fetchImpl, url) {
+    const response = await fetchImpl(url, { headers: GOODINFO_HEADERS });
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+    }
+    const buffer = await response.arrayBuffer();
+    return Buffer.from(buffer).toString('utf8');
+}
+
+async function tryFetchAdjusted(fetchImpl, stockNo, endpointBuilder) {
+    const url = endpointBuilder(stockNo);
+    const html = await fetchHtml(fetchImpl, url);
+    const tableHtml = locateAdjustedTable(html);
+    if (!tableHtml) {
+        throw new Error('找不到還原權值股價表格');
+    }
+    const rows = parseAdjustedRows(tableHtml);
+    if (!rows || rows.length === 0) {
+        throw new Error('解析還原權值股價表格失敗');
+    }
+    const stockName = extractStockName(html, stockNo);
+    return { stockName, rows };
+}
+
+export async function fetchGoodinfoAdjustedSeries(fetchImpl, stockNo, options = {}) {
+    if (!fetchImpl) {
+        throw new Error('缺少 fetch 實例');
+    }
+    if (!stockNo) {
+        throw new Error('缺少股票代號');
+    }
+    const builders = [
+        (id) => `https://goodinfo.tw/tw/StockDividendSchedule.asp?STOCK_ID=${encodeURIComponent(id)}`,
+        (id) => `https://goodinfo.tw/StockInfo/StockDividendSchedule.asp?STOCK_ID=${encodeURIComponent(id)}`,
+        (id) => `https://goodinfo.tw/tw/StockPriceHistory.asp?STOCK_ID=${encodeURIComponent(id)}`,
+    ];
+    const errors = [];
+    for (const builder of builders) {
+        try {
+            const result = await tryFetchAdjusted(fetchImpl, stockNo, builder);
+            const { startISO, endISO } = options;
+            if (startISO || endISO) {
+                const start = startISO ? new Date(startISO) : null;
+                const end = endISO ? new Date(endISO) : null;
+                result.rows = result.rows.filter((row) => {
+                    const date = new Date(row.date);
+                    if (Number.isNaN(date.getTime())) return false;
+                    if (start && date < start) return false;
+                    if (end && date > end) return false;
+                    return true;
+                });
+            }
+            return { ...result, version: GOODINFO_VERSION };
+        } catch (error) {
+            errors.push(`${builder(stockNo)} => ${error.message}`);
+        }
+    }
+    const err = new Error(`無法自 Goodinfo 取得還原股價 (${errors.join('; ')})`);
+    err.version = GOODINFO_VERSION;
+    throw err;
+}
+
+export { GOODINFO_VERSION };

--- a/netlify/functions/tpex-proxy.js
+++ b/netlify/functions/tpex-proxy.js
@@ -4,6 +4,7 @@
 // Patch Tag: LB-BLOBS-LOCAL-20241007B
 import { getStore } from '@netlify/blobs';
 import fetch from 'node-fetch';
+import { fetchGoodinfoAdjustedSeries, GOODINFO_VERSION } from './lib/goodinfo.js';
 
 const TPEX_CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12 小時
 const inMemoryCache = new Map(); // Map<cacheKey, { timestamp, data }>
@@ -429,6 +430,85 @@ async function persistYahooEntries(store, stockNo, yahooData, adjusted) {
     return label;
 }
 
+async function hydrateGoodinfoAdjusted(store, stockNo, startDateISO, endDateISO) {
+    console.log(`[TPEX Proxy ${GOODINFO_VERSION}] 嘗試 Goodinfo 還原資料: ${stockNo} (${startDateISO} ~ ${endDateISO})`);
+    const result = await fetchGoodinfoAdjustedSeries(fetch, stockNo, {
+        startISO: startDateISO,
+        endISO: endDateISO,
+    });
+    if (!result || !Array.isArray(result.rows) || result.rows.length === 0) {
+        throw new Error('Goodinfo 未回傳還原股價資料');
+    }
+    const buckets = new Map();
+    const stockName = result.stockName || stockNo;
+    for (const row of result.rows) {
+        const isoDate = row.date;
+        if (!isoDate) continue;
+        const rocDate = isoToRoc(isoDate);
+        if (!rocDate) continue;
+        const monthKey = isoDate.slice(0, 7).replace('-', '');
+        if (!buckets.has(monthKey)) buckets.set(monthKey, []);
+
+        const adjClose = Number.isFinite(row.adjClose) ? row.adjClose : null;
+        const adjOpen = Number.isFinite(row.adjOpen) ? row.adjOpen : null;
+        const adjHigh = Number.isFinite(row.adjHigh) ? row.adjHigh : null;
+        const adjLow = Number.isFinite(row.adjLow) ? row.adjLow : null;
+        const rawClose = Number.isFinite(row.rawClose) ? row.rawClose : null;
+        const rawOpen = Number.isFinite(row.rawOpen) ? row.rawOpen : null;
+        const rawHigh = Number.isFinite(row.rawHigh) ? row.rawHigh : null;
+        const rawLow = Number.isFinite(row.rawLow) ? row.rawLow : null;
+
+        const baseClose = adjClose ?? rawClose;
+        if (!Number.isFinite(baseClose)) {
+            continue;
+        }
+
+        const open = safeRound(adjOpen ?? rawOpen ?? baseClose);
+        const close = safeRound(adjClose ?? baseClose);
+        const high = safeRound(
+            adjHigh ?? rawHigh ?? Math.max(open ?? baseClose, close ?? baseClose),
+        );
+        const low = safeRound(
+            adjLow ?? rawLow ?? Math.min(open ?? baseClose, close ?? baseClose),
+        );
+        const change = safeRound(row.change ?? 0) ?? 0;
+        const volume = Number.isFinite(row.volume) ? Math.round(row.volume) : 0;
+
+        if (close === null || close === undefined) continue;
+        const finalOpen = open ?? close;
+        const finalHigh = high ?? Math.max(finalOpen, close);
+        const finalLow = low ?? Math.min(finalOpen, close);
+
+        buckets.get(monthKey).push([
+            rocDate,
+            stockNo,
+            stockName,
+            finalOpen,
+            finalHigh,
+            finalLow,
+            close,
+            change,
+            volume,
+        ]);
+    }
+
+    if (buckets.size === 0) {
+        throw new Error('Goodinfo 資料解析後無有效筆數');
+    }
+
+    for (const [monthKey, rows] of buckets.entries()) {
+        rows.sort((a, b) => new Date(rocToISO(a[0])) - new Date(rocToISO(b[0])));
+        await writeCache(store, buildMonthCacheKey(stockNo, monthKey, true), {
+            stockName,
+            aaData: rows,
+            dataSource: 'Goodinfo (還原備援)',
+            meta: { goodinfoVersion: GOODINFO_VERSION },
+        });
+    }
+
+    return 'Goodinfo (還原備援)';
+}
+
 function summariseSources(flags, adjusted) {
     if (flags.size === 0) return adjusted ? 'Yahoo Finance' : 'FinMind';
     if (flags.size === 1) return Array.from(flags)[0];
@@ -436,7 +516,8 @@ function summariseSources(flags, adjusted) {
     const hasCache = labels.some(label => /快取|cache|記憶體/i.test(label));
     const primaryYahoo = labels.find(label => /Yahoo Finance/i.test(label));
     const primaryFinMind = labels.find(label => /FinMind/i.test(label));
-    const primary = primaryYahoo || primaryFinMind || (adjusted ? 'Yahoo Finance' : 'FinMind');
+    const primaryGoodinfo = labels.find(label => /Goodinfo/i.test(label));
+    const primary = primaryYahoo || primaryFinMind || primaryGoodinfo || (adjusted ? 'Yahoo Finance' : 'FinMind');
     if (hasCache) return `${primary} (快取)`;
     return primary;
 }
@@ -445,8 +526,8 @@ function validateForceSource(adjusted, forceSource) {
     if (!forceSource) return null;
     const normalized = forceSource.toLowerCase();
     if (adjusted) {
-        if (normalized === 'yahoo') return normalized;
-        throw new Error('還原模式目前僅支援 Yahoo Finance 測試來源');
+        if (normalized === 'yahoo' || normalized === 'goodinfo') return normalized;
+        throw new Error('還原模式僅支援 Yahoo 或 Goodinfo 測試來源');
     }
     if (normalized === 'finmind' || normalized === 'yahoo') return normalized;
     throw new Error('原始模式僅支援 FinMind 或 Yahoo 測試來源');
@@ -506,6 +587,8 @@ export default async (req) => {
         let yahooLabel = '';
         let finmindHydrated = false;
         let finmindLabel = '';
+        let goodinfoHydrated = false;
+        let goodinfoLabel = '';
 
         for (const month of months) {
             const cacheKey = buildMonthCacheKey(stockNo, month, adjusted);
@@ -547,11 +630,27 @@ export default async (req) => {
                         console.error('[TPEX Proxy v10.2] 強制 Yahoo 失敗:', error);
                         return new Response(JSON.stringify({ error: `Yahoo 來源取得失敗: ${error.message}` }), { status: 502 });
                     }
+                } else if (forcedSource === 'goodinfo') {
+                    try {
+                        goodinfoLabel = await hydrateGoodinfoAdjusted(
+                            store,
+                            stockNo,
+                            startDate.toISOString().split('T')[0],
+                            endDate.toISOString().split('T')[0],
+                        );
+                        payload = await readCache(store, cacheKey);
+                        if (payload) sourceFlags.add(goodinfoLabel);
+                        goodinfoHydrated = true;
+                    } catch (error) {
+                        console.error('[TPEX Proxy v10.2] 強制 Goodinfo 失敗:', error);
+                        return new Response(JSON.stringify({ error: `Goodinfo 來源取得失敗: ${error.message}` }), { status: 502 });
+                    }
                 }
             } else {
                 payload = await readCache(store, cacheKey);
                 if (!payload) {
                     if (adjusted) {
+                        let yahooError = null;
                         if (!yahooHydrated) {
                             try {
                                 yahooLabel = await persistYahooEntries(
@@ -562,15 +661,53 @@ export default async (req) => {
                                 );
                                 yahooHydrated = true;
                             } catch (error) {
+                                yahooError = error;
                                 console.error('[TPEX Proxy v10.2] Yahoo 還原來源失敗:', error);
-                                return new Response(
-                                    JSON.stringify({ error: `Yahoo 還原來源取得失敗: ${error.message}` }),
-                                    { status: 502 },
-                                );
                             }
                         }
                         payload = await readCache(store, cacheKey);
-                        if (payload) {
+                        if (!payload) {
+                            if (!goodinfoHydrated) {
+                                try {
+                                    goodinfoLabel = await hydrateGoodinfoAdjusted(
+                                        store,
+                                        stockNo,
+                                        startDate.toISOString().split('T')[0],
+                                        endDate.toISOString().split('T')[0],
+                                    );
+                                    goodinfoHydrated = true;
+                                } catch (error) {
+                                    console.error('[TPEX Proxy v10.2] Goodinfo 還原來源失敗:', error);
+                                    if (yahooError) {
+                                        return new Response(
+                                            JSON.stringify({
+                                                error: `Yahoo 還原來源取得失敗: ${yahooError.message}; Goodinfo 備援亦失敗: ${error.message}`,
+                                            }),
+                                            { status: 502 },
+                                        );
+                                    }
+                                    return new Response(
+                                        JSON.stringify({ error: `Goodinfo 還原來源取得失敗: ${error.message}` }),
+                                        { status: 502 },
+                                    );
+                                }
+                            }
+                            payload = await readCache(store, cacheKey);
+                            if (payload) {
+                                if (payload.dataSource) sourceFlags.add(payload.dataSource);
+                                else if (goodinfoLabel) sourceFlags.add(goodinfoLabel);
+                            } else if (yahooError) {
+                                return new Response(
+                                    JSON.stringify({ error: `Yahoo 還原來源取得失敗: ${yahooError.message}` }),
+                                    { status: 502 },
+                                );
+                            } else {
+                                return new Response(
+                                    JSON.stringify({ error: 'Goodinfo 還原來源取得失敗: 未取得任何資料' }),
+                                    { status: 502 },
+                                );
+                            }
+                        } else {
                             if (payload.dataSource) sourceFlags.add(payload.dataSource);
                             else if (yahooLabel) sourceFlags.add(yahooLabel);
                         }

--- a/netlify/functions/twse-proxy.js
+++ b/netlify/functions/twse-proxy.js
@@ -4,6 +4,7 @@
 // Patch Tag: LB-BLOBS-LOCAL-20241007B
 import { getStore } from '@netlify/blobs';
 import fetch from 'node-fetch';
+import { fetchGoodinfoAdjustedSeries, GOODINFO_VERSION } from './lib/goodinfo.js';
 
 const TWSE_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 小時
 const inMemoryCache = new Map(); // Map<cacheKey, { timestamp, data }>
@@ -475,6 +476,85 @@ async function persistYahooEntries(store, stockNo, yahooData, adjusted) {
     return label;
 }
 
+async function hydrateGoodinfoAdjusted(store, stockNo, startDateISO, endDateISO) {
+    console.log(`[TWSE Proxy ${GOODINFO_VERSION}] 嘗試 Goodinfo 還原資料: ${stockNo} (${startDateISO} ~ ${endDateISO})`);
+    const result = await fetchGoodinfoAdjustedSeries(fetch, stockNo, {
+        startISO: startDateISO,
+        endISO: endDateISO,
+    });
+    if (!result || !Array.isArray(result.rows) || result.rows.length === 0) {
+        throw new Error('Goodinfo 未回傳還原股價資料');
+    }
+    const buckets = new Map();
+    const stockName = result.stockName || stockNo;
+    for (const row of result.rows) {
+        const isoDate = row.date;
+        if (!isoDate) continue;
+        const rocDate = isoToRoc(isoDate);
+        if (!rocDate) continue;
+        const monthKey = isoDate.slice(0, 7).replace('-', '');
+        if (!buckets.has(monthKey)) buckets.set(monthKey, []);
+
+        const adjClose = Number.isFinite(row.adjClose) ? row.adjClose : null;
+        const adjOpen = Number.isFinite(row.adjOpen) ? row.adjOpen : null;
+        const adjHigh = Number.isFinite(row.adjHigh) ? row.adjHigh : null;
+        const adjLow = Number.isFinite(row.adjLow) ? row.adjLow : null;
+        const rawClose = Number.isFinite(row.rawClose) ? row.rawClose : null;
+        const rawOpen = Number.isFinite(row.rawOpen) ? row.rawOpen : null;
+        const rawHigh = Number.isFinite(row.rawHigh) ? row.rawHigh : null;
+        const rawLow = Number.isFinite(row.rawLow) ? row.rawLow : null;
+
+        const baseClose = adjClose ?? rawClose;
+        if (!Number.isFinite(baseClose)) {
+            continue;
+        }
+
+        const open = safeRound(adjOpen ?? rawOpen ?? baseClose);
+        const close = safeRound(adjClose ?? baseClose);
+        const high = safeRound(
+            adjHigh ?? rawHigh ?? Math.max(open ?? baseClose, close ?? baseClose),
+        );
+        const low = safeRound(
+            adjLow ?? rawLow ?? Math.min(open ?? baseClose, close ?? baseClose),
+        );
+        const change = safeRound(row.change ?? 0) ?? 0;
+        const volume = Number.isFinite(row.volume) ? Math.round(row.volume) : 0;
+
+        if (close === null || close === undefined) continue;
+        const finalOpen = open ?? close;
+        const finalHigh = high ?? Math.max(finalOpen, close);
+        const finalLow = low ?? Math.min(finalOpen, close);
+
+        buckets.get(monthKey).push([
+            rocDate,
+            stockNo,
+            stockName,
+            finalOpen,
+            finalHigh,
+            finalLow,
+            close,
+            change,
+            volume,
+        ]);
+    }
+
+    if (buckets.size === 0) {
+        throw new Error('Goodinfo 資料解析後無有效筆數');
+    }
+
+    for (const [monthKey, rows] of buckets.entries()) {
+        rows.sort((a, b) => new Date(rocToISO(a[0])) - new Date(rocToISO(b[0])));
+        await writeCache(store, buildMonthCacheKey(stockNo, monthKey, true), {
+            stockName,
+            aaData: rows,
+            dataSource: 'Goodinfo (還原備援)',
+            meta: { goodinfoVersion: GOODINFO_VERSION },
+        });
+    }
+
+    return 'Goodinfo (還原備援)';
+}
+
 function summariseSources(flags) {
     if (flags.size === 0) return 'TWSE';
     if (flags.size === 1) return Array.from(flags)[0];
@@ -494,8 +574,8 @@ function validateForceSource(adjusted, forceSource) {
     if (!forceSource) return null;
     const normalized = forceSource.toLowerCase();
     if (adjusted) {
-        if (normalized === 'yahoo') return normalized;
-        throw new Error('還原模式目前僅支援 Yahoo Finance 測試來源');
+        if (normalized === 'yahoo' || normalized === 'goodinfo') return normalized;
+        throw new Error('還原模式僅支援 Yahoo 或 Goodinfo 測試來源');
     }
     if (normalized === 'twse' || normalized === 'finmind') return normalized;
     throw new Error('原始模式僅支援 TWSE 或 FinMind 測試來源');
@@ -556,6 +636,8 @@ export default async (req) => {
         let yahooLabel = '';
         let finmindHydrated = false;
         let finmindLabel = '';
+        let goodinfoHydrated = false;
+        let goodinfoLabel = '';
 
         for (const month of months) {
             const cacheKey = buildMonthCacheKey(stockNo, month, adjusted);
@@ -607,11 +689,27 @@ export default async (req) => {
                         console.error('[TWSE Proxy v10.2] 強制 Yahoo 失敗:', error);
                         return new Response(JSON.stringify({ error: `Yahoo 來源取得失敗: ${error.message}` }), { status: 502 });
                     }
+                } else if (forcedSource === 'goodinfo') {
+                    try {
+                        goodinfoLabel = await hydrateGoodinfoAdjusted(
+                            store,
+                            stockNo,
+                            startDate.toISOString().split('T')[0],
+                            endDate.toISOString().split('T')[0],
+                        );
+                        payload = await readCache(store, cacheKey);
+                        if (payload) sourceFlags.add(goodinfoLabel);
+                        goodinfoHydrated = true;
+                    } catch (error) {
+                        console.error('[TWSE Proxy v10.2] 強制 Goodinfo 失敗:', error);
+                        return new Response(JSON.stringify({ error: `Goodinfo 來源取得失敗: ${error.message}` }), { status: 502 });
+                    }
                 }
             } else {
                 payload = await readCache(store, cacheKey);
                 if (!payload) {
                     if (adjusted) {
+                        let yahooError = null;
                         if (!yahooHydrated) {
                             try {
                                 yahooLabel = await persistYahooEntries(
@@ -622,15 +720,53 @@ export default async (req) => {
                                 );
                                 yahooHydrated = true;
                             } catch (error) {
+                                yahooError = error;
                                 console.error('[TWSE Proxy v10.2] Yahoo 還原來源失敗:', error);
-                                return new Response(
-                                    JSON.stringify({ error: `Yahoo 還原來源取得失敗: ${error.message}` }),
-                                    { status: 502 },
-                                );
                             }
                         }
                         payload = await readCache(store, cacheKey);
-                        if (payload) {
+                        if (!payload) {
+                            if (!goodinfoHydrated) {
+                                try {
+                                    goodinfoLabel = await hydrateGoodinfoAdjusted(
+                                        store,
+                                        stockNo,
+                                        startDate.toISOString().split('T')[0],
+                                        endDate.toISOString().split('T')[0],
+                                    );
+                                    goodinfoHydrated = true;
+                                } catch (error) {
+                                    console.error('[TWSE Proxy v10.2] Goodinfo 還原來源失敗:', error);
+                                    if (yahooError) {
+                                        return new Response(
+                                            JSON.stringify({
+                                                error: `Yahoo 還原來源取得失敗: ${yahooError.message}; Goodinfo 備援亦失敗: ${error.message}`,
+                                            }),
+                                            { status: 502 },
+                                        );
+                                    }
+                                    return new Response(
+                                        JSON.stringify({ error: `Goodinfo 還原來源取得失敗: ${error.message}` }),
+                                        { status: 502 },
+                                    );
+                                }
+                            }
+                            payload = await readCache(store, cacheKey);
+                            if (payload) {
+                                if (payload.dataSource) sourceFlags.add(payload.dataSource);
+                                else if (goodinfoLabel) sourceFlags.add(goodinfoLabel);
+                            } else if (yahooError) {
+                                return new Response(
+                                    JSON.stringify({ error: `Yahoo 還原來源取得失敗: ${yahooError.message}` }),
+                                    { status: 502 },
+                                );
+                            } else {
+                                return new Response(
+                                    JSON.stringify({ error: 'Goodinfo 還原來源取得失敗: 未取得任何資料' }),
+                                    { status: 502 },
+                                );
+                            }
+                        } else {
                             if (payload.dataSource) sourceFlags.add(payload.dataSource);
                             else if (yahooLabel) sourceFlags.add(yahooLabel);
                         }


### PR DESCRIPTION
## Summary
- integrate a Goodinfo-based adjusted price scraper and wire it into both TWSE/TPEX Netlify proxies with cache writes, forced-source support, and enhanced logging
- expose Goodinfo as an adjusted-mode tester option and add a resettable comparison card that visualises adjusted versus raw close prices after backtests
- share reusable price-series normalisers so the UI can reuse cached data or preview fetches when building the comparison view

## Testing
- `node -e "require('./netlify/functions/lib/goodinfo.js')"`

------
https://chatgpt.com/codex/tasks/task_e_68cf999691b48324b129cf7040823ccd