### PR TITLE
feat: enhance range fallback detection

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+# 2025-05-30 — Patch LB-RANGE-FALLBACK-20250530A
+- **Issue recap**: 月線快取僅落地前半段資料時，尾端缺口達一週仍無法觸發備援切換，前端缺乏涵蓋率提示，難以判讀是否改用備援來源。
+- **Fix**: Worker 新增區間涵蓋度檢測，尾端缺口達 5 個交易日即切換 `/api/stock-range` 備援，並透過 `fallbackRangeMeta` 回傳覆蓋率與缺口；前端價格檢視器同步顯示區間備援摘要。
+- **Diagnostics**: Price Inspector Summary 顯示覆蓋率變化、尾端缺口與觸發原因，協助營運端判斷備援狀態與成效。
+- **Testing**: `node scripts/check-range-fallback.mjs`（手動驗證觸發條件，確認 console 無錯誤）。
+
 # Lazybacktest Debug Log
 
 # 2025-05-18 — Patch LB-ADJ-COMPOSER-20250518A / LB-PRICE-INSPECTOR-20250518A

--- a/scripts/check-range-fallback.mjs
+++ b/scripts/check-range-fallback.mjs
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import vm from 'vm';
+
+const workerSource = fs.readFileSync(new URL('../js/worker.js', import.meta.url), 'utf-8');
+const sandbox = {
+  self: {
+    addEventListener() {},
+    removeEventListener() {},
+    postMessage() {},
+  },
+  console,
+  fetch: async () => { throw new Error('fetch not stubbed'); },
+  URLSearchParams,
+  Map,
+  Set,
+};
+vm.createContext(sandbox);
+vm.runInContext(workerSource, sandbox);
+
+const { computeRangeCoverageMeta, shouldTriggerFallbackRangeSwitch } = sandbox;
+
+if (typeof computeRangeCoverageMeta !== 'function' || typeof shouldTriggerFallbackRangeSwitch !== 'function') {
+  throw new Error('Required helpers were not initialised from worker.js');
+}
+
+const buildRows = (startISO, count) => {
+  const rows = [];
+  let current = new Date(startISO);
+  while (rows.length < count) {
+    const day = current.getUTCDay();
+    if (day !== 0 && day !== 6) {
+      rows.push({ date: current.toISOString().split('T')[0] });
+    }
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+  return rows;
+};
+
+const startISO = '2024-01-01';
+const endISO = '2024-01-31';
+const partialRows = buildRows(startISO, 10); // roughly前半段
+
+const coverage = computeRangeCoverageMeta(partialRows, startISO, endISO);
+const decision = shouldTriggerFallbackRangeSwitch(coverage, {
+  trailingGapThreshold: sandbox.RANGE_FALLBACK_CONFIG?.TRAILING_GAP_WEEKDAYS_THRESHOLD ?? 5,
+  densityThreshold: sandbox.RANGE_FALLBACK_CONFIG?.DENSITY_THRESHOLD ?? 0.7,
+  minWeekdays: sandbox.RANGE_FALLBACK_CONFIG?.MIN_REQUESTED_WEEKDAYS ?? 5,
+});
+
+console.log('[Fallback Check] Coverage:', coverage);
+console.log('[Fallback Check] Decision:', decision);
+
+const denseRows = buildRows(startISO, 15);
+const denseCoverage = computeRangeCoverageMeta(denseRows, startISO, endISO);
+const denseDecision = shouldTriggerFallbackRangeSwitch(denseCoverage, {
+  trailingGapThreshold: sandbox.RANGE_FALLBACK_CONFIG?.TRAILING_GAP_WEEKDAYS_THRESHOLD ?? 5,
+  densityThreshold: sandbox.RANGE_FALLBACK_CONFIG?.DENSITY_THRESHOLD ?? 0.7,
+  minWeekdays: sandbox.RANGE_FALLBACK_CONFIG?.MIN_REQUESTED_WEEKDAYS ?? 5,
+});
+
+console.log('[Fallback Check] Dense coverage:', denseCoverage);
+console.log('[Fallback Check] Dense decision:', denseDecision);


### PR DESCRIPTION
## Summary
- strengthen the worker range fallback detection by introducing coverage metrics, trailing gap thresholds, and emitting `fallbackRangeMeta` metadata for cache consumers【F:js/worker.js†L21-L220】【F:js/worker.js†L1558-L1708】
- extend the backtest UI pipeline so cached entries keep the new metadata and the Price Inspector surfaces range fallback diagnostics to the user【F:js/backtest.js†L8-L213】【F:js/backtest.js†L433-L485】
- document the patch and add a Node verification script to manually exercise the new fallback trigger logic【F:log.md†L1-L5】【F:scripts/check-range-fallback.mjs†L1-L62】

## Testing
- node scripts/check-range-fallback.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d0c53e6e6883248b78b0bc70e42236