### PR TITLE
Move developer tools into hero toggle and improve summary responsiveness

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -64,8 +64,39 @@
 .left-panel { overflow-x: visible; }
 .right-panel { overflow-x: visible; }
 #backtest-result { position: relative; overflow: visible; }
+.developer-area-wrapper { width: 100%; }
+.developer-area-wrapper:not(.hidden) .hero-developer-card { animation: fadeIn 0.3s ease-in-out; }
+.developer-toggle-active { border-color: var(--primary) !important; color: var(--primary) !important; background-color: color-mix(in srgb, var(--primary) 12%, var(--input)) !important; box-shadow: 0 8px 20px rgba(8, 145, 178, 0.15); }
+.summary-card { width: 100%; max-width: 100%; }
+.summary-card .card-header { padding-left: 1.5rem; padding-right: 1.5rem; }
+.summary-card .card-content { padding: 1.5rem; }
+.summary-result-container { width: 100%; color: var(--foreground); }
+.summary-result-container > * { width: 100%; }
+.summary-result-container table { width: 100%; }
+.summary-result-container { scrollbar-width: thin; scrollbar-color: var(--border) transparent; }
+.summary-result-container::-webkit-scrollbar { height: 6px; }
+.summary-result-container::-webkit-scrollbar-thumb { background-color: var(--border); border-radius: 9999px; }
+.backtest-result-placeholder {
+    min-height: 200px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    border: 2px dashed var(--card);
+    border-radius: calc(var(--radius) + 2px);
+    color: var(--muted-foreground);
+    background-color: color-mix(in srgb, var(--muted) 6%, transparent);
+    padding: 1.5rem;
+}
 #chart-container { height: 500px; }
 @media (max-width: 768px) { #chart-container { height: 350px; } }
+.summary-card .card-header { padding-top: 1.5rem; padding-bottom: 0; }
+.summary-card .card-content { padding-top: 1.5rem; }
+@media (max-width: 640px) {
+    .summary-card .card-header { padding: 1.25rem 1rem 0 1rem; }
+    .summary-card .card-content { padding: 1.25rem 1rem 1.5rem 1rem; }
+    .backtest-result-placeholder { padding: 1.5rem 1.25rem; }
+}
 .optimization-table th { position: sticky; top: 0; z-index: 1; background-color: #f9fafb; }
 .optimization-table th.sortable-header { cursor: pointer; position: relative; padding-right: 1.5rem; }
 .optimization-table th.sortable-header::after { content: ''; position: absolute; right: 0.5rem; top: 50%; transform: translateY(-50%); border: 4px solid transparent; opacity: 0.3; transition: opacity 0.2s; }

--- a/index.html
+++ b/index.html
@@ -369,36 +369,46 @@
                 <!-- Hero Section -->
                 <div class="bg-background border-b flex-shrink-0" style="background-color: var(--background); border-color: var(--border);">
                     <div class="container mx-auto px-4 py-12">
-                        <div class="text-center">
-                            <h1 class="text-4xl lg:text-5xl font-bold text-foreground mb-6" style="color: var(--foreground);">
-                                股票回測工具
-                            </h1>
-                            <p class="text-lg text-muted mb-8 max-w-3xl mx-auto" style="color: var(--muted-foreground);">
-                                透過歷史數據驗證您的交易策略，做出更明智的投資決策
-                            </p>
-                            
-                            <!-- 一鍵回測按鈕 -->
-                            <button 
-                                id="quickBacktestBtn"
-                                class="btn-primary px-8 py-4 text-lg font-semibold rounded-lg transition duration-150 ease-in-out flex items-center justify-center mx-auto"
-                                style="background-color: var(--primary); color: var(--primary-foreground); border: 1px solid var(--primary);"
+                        <div class="text-center flex flex-col items-center gap-8">
+                            <div class="space-y-6 max-w-3xl">
+                                <h1 class="text-4xl lg:text-5xl font-bold text-foreground" style="color: var(--foreground);">
+                                    股票回測工具
+                                </h1>
+                                <p class="text-lg text-muted mx-auto" style="color: var(--muted-foreground);">
+                                    透過歷史數據驗證您的交易策略，做出更明智的投資決策
+                                </p>
+                            </div>
+
+                            <div class="flex flex-col sm:flex-row items-center justify-center gap-3 w-full sm:w-auto">
+                                <!-- 一鍵回測按鈕 -->
+                                <button
+                                    id="quickBacktestBtn"
+                                    class="btn-primary px-8 py-4 text-lg font-semibold rounded-lg transition duration-150 ease-in-out flex items-center justify-center"
+                                    style="background-color: var(--primary); color: var(--primary-foreground); border: 1px solid var(--primary);"
+                                >
+                                    <i data-lucide="zap" class="lucide mr-3"></i>
+                                    一鍵回測台積電
+                                </button>
+
+                                <button
+                                    id="developerAreaToggle"
+                                    type="button"
+                                    class="btn-outline px-6 py-4 text-sm font-semibold rounded-lg transition duration-150 ease-in-out flex items-center justify-center"
+                                    style="color: var(--foreground); border: 1px solid var(--border); background-color: var(--input);"
+                                    aria-expanded="false"
+                                    aria-controls="developerAreaWrapper"
+                                >
+                                    <i data-lucide="wrench" class="lucide mr-2"></i>
+                                    開發者區域
+                                </button>
+                            </div>
+
+                            <div
+                                id="developerAreaWrapper"
+                                class="hidden w-full max-w-4xl text-left mx-auto developer-area-wrapper"
+                                aria-hidden="true"
                             >
-                                <i data-lucide="zap" class="lucide mr-3"></i>
-                                一鍵回測台積電
-                            </button>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="container mx-auto px-4 py-8 flex-1 overflow-hidden">
-                    <div class="grid lg:grid-cols-[30%_70%] gap-1 h-full overflow-hidden overflow-x-hidden main-grid">
-                        <!-- Left Panel - Settings and Controls -->
-                        <div class="space-y-6 lg:overflow-y-auto lg:h-screen lg:sticky lg:top-0 lg:pb-8 overflow-x-hidden left-panel" style="scrollbar-width: thin; scrollbar-color: var(--muted) var(--background);">
-
-                            <!-- Settings Cards -->
-                            <div class="space-y-6">
-                                <!-- Developer Area Card -->
-                                <div class="card" id="developerAreaCard">
+                                <div class="card hero-developer-card" id="developerAreaCard">
                                     <div class="card-header">
                                         <h3 class="card-title flex items-center gap-2">
                                             <i data-lucide="wrench" class="lucide text-primary" style="color: var(--primary);"></i>
@@ -491,16 +501,23 @@
                                                 <div id="blobUsageUpdatedAt" class="text-[11px]" style="color: var(--muted-foreground);"></div>
                                             </div>
                                             <div class="rounded-md border bg-white/70 shadow-sm" style="border-color: var(--border);">
-                                                <div id="blobUsageContent" class="px-3 py-3 space-y-3 text-[11px]" style="color: var(--foreground);">
-                                                    <div class="rounded-md border border-dashed px-3 py-2" style="border-color: var(--border); color: var(--muted-foreground);">
-                                                        尚未累積 Blob 用量統計，執行回測後將在此顯示本月操作數與熱門查詢。
-                                                    </div>
-                                                </div>
+                                                <div id="blobUsageContent" class="px-3 py-3 space-y-3 text-[11px]" style="color: var(--foreground);"></div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
+                <div class="container mx-auto px-4 py-8 flex-1 overflow-hidden">
+                    <div class="grid lg:grid-cols-[30%_70%] gap-1 h-full overflow-hidden overflow-x-hidden main-grid">
+                        <!-- Left Panel - Settings and Controls -->
+                        <div class="space-y-6 lg:overflow-y-auto lg:h-screen lg:sticky lg:top-0 lg:pb-8 overflow-x-hidden left-panel" style="scrollbar-width: thin; scrollbar-color: var(--muted) var(--background);">
+
+                            <!-- Settings Cards -->
+                            <div class="space-y-6">
                                 <!-- Basic Settings Card -->
                                 <div class="card">
                                 <div class="card">
@@ -1107,7 +1124,7 @@
                             <!-- Summary Tab -->
                             <div class="tab-content active" id="summary-tab">
                                 <!-- Chart Area -->
-                                <div class="card shadow-lg mb-8">
+                                <div class="card shadow-lg summary-card mb-8">
                                     <div class="card-header">
                                         <h3 class="card-title">淨值曲線圖</h3>
                                     </div>
@@ -1123,17 +1140,15 @@
                                 </div>
                                 
                                 <!-- Summary Results -->
-                                <div class="card shadow-lg">
+                                <div class="card shadow-lg summary-card">
                                     <div class="card-header">
                                         <h3 class="card-title">回測摘要</h3>
                                     </div>
                                     <div class="card-content">
-                                        <div
-                                            id="backtest-result"
-                                            class="text-muted min-h-[200px] flex items-center justify-center border-2 border-dashed rounded-lg"
-                                            style="color: var(--muted-foreground); border-color: var(--card);"
-                                        >
-                                            執行回測後將顯示詳細結果
+                                        <div id="backtest-result" class="summary-result-container">
+                                            <div id="backtest-result-placeholder" class="backtest-result-placeholder">
+                                                執行回測後將顯示詳細結果
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,7 @@
 // Patch Tag: LB-US-YAHOO-20250613A
 // Patch Tag: LB-TW-DIRECTORY-20250620A
 // Patch Tag: LB-US-BACKTEST-20250621A
+// Patch Tag: LB-DEVELOPER-HERO-20250711A
 
 // 全局變量
 let stockChart = null;
@@ -1569,6 +1570,38 @@ function initDataSourceTester() {
     window.applyMarketPreset = applyMarketPreset;
 }
 
+function initDeveloperAreaToggle() {
+    const toggleBtn = document.getElementById('developerAreaToggle');
+    const wrapper = document.getElementById('developerAreaWrapper');
+    if (!toggleBtn || !wrapper) return;
+
+    let expanded = false;
+
+    const applyState = (open) => {
+        expanded = Boolean(open);
+        wrapper.classList.toggle('hidden', !expanded);
+        wrapper.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+        toggleBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        toggleBtn.classList.toggle('developer-toggle-active', expanded);
+    };
+
+    applyState(false);
+
+    toggleBtn.addEventListener('click', () => {
+        applyState(!expanded);
+        if (expanded) {
+            wrapper.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && expanded) {
+            applyState(false);
+            toggleBtn.focus();
+        }
+    });
+}
+
 function showLoading(m="⌛ 處理中...") {
     const el = document.getElementById("loading");
     const loadingText = document.getElementById('loadingText');
@@ -2314,6 +2347,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // 初始化資料來源測試面板
         initDataSourceTester();
+
+        // 初始化開發者區域切換
+        initDeveloperAreaToggle();
 
         // 初始化頁籤功能
         initTabs();

--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+# 2025-07-11 — Patch LB-DEVELOPER-HERO-20250711A
+- **Issue recap**: 開發者區域需要納入 Hero 區域並改為按鈕開闔，同時回測摘要卡在手機版仍會被擠壓成窄幅視窗，使用者難以閱讀完整結果。
+- **Fix**: 將原本位於左欄的開發者卡片搬移至 Hero，下方新增切換按鈕與動畫顯示；重構回測摘要卡的 placeholder 與 CSS，讓結果容器在小尺寸螢幕可自適應寬度並保留捲軸。
+- **Diagnostics**: 靜態檢視 DOM 確認左側設定仍維持原先卡片順序，Hero 按鈕 aria 狀態隨切換更新；回測摘要容器移除 flex 限制後，模擬手機寬度檢查不再橫向截斷。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');new vm.Script(fs.readFileSync('js/worker.js','utf8'));console.log('worker.js compiles');NODE`、`node - <<'NODE' const fs=require('fs');const vm=require('vm');new vm.Script(fs.readFileSync('js/backtest.js','utf8'));console.log('backtest.js compiles');NODE`、`node - <<'NODE' const fs=require('fs');const vm=require('vm');new vm.Script(fs.readFileSync('js/main.js','utf8'));console.log('main.js compiles');NODE`
+
 # 2025-07-24 — Patch LB-UI-DEDUP-20250724A
 - **Issue recap**: 首頁下方（Footer 前）殘留舊版配置，重複出現策略管理、快速結果、執行回測卡片及摘要/績效分析等分頁導覽，造成內容冗長並讓使用者誤以為需要再次設定。
 - **Fix**: 移除左側面板重複的交易設定、風險管理、策略卡片，以及右側結果分頁的重複區塊，僅保留新版含分段優化導覽的版本以維持資訊結構一致。


### PR DESCRIPTION
## Summary
- relocate the developer diagnostics card into the hero area behind a dedicated toggle button while keeping the original left/right panel structure intact
- add responsive styling for the developer toggle and summary results card so the backtest summary fits on small screens and exposes scrollbars when needed
- extend main initialization with a developer-area toggle controller and document the change in `log.md`

## Testing
- `node - <<'NODE' const fs=require('fs');const vm=require('vm');new vm.Script(fs.readFileSync('js/worker.js','utf8'));console.log('worker.js compiles');NODE`
- `node - <<'NODE' const fs=require('fs');const vm=require('vm');new vm.Script(fs.readFileSync('js/backtest.js','utf8'));console.log('backtest.js compiles');NODE`
- `node - <<'NODE' const fs=require('fs');const vm=require('vm');new vm.Script(fs.readFileSync('js/main.js','utf8'));console.log('main.js compiles');NODE`

------
https://chatgpt.com/codex/tasks/task_e_68d346556f8883248deb63a47d355dfa