### PR TITLE
Guard sensitivity data lookup in backtest summary

### DIFF
--- a/js/backtest.js
+++ b/js/backtest.js
@@ -2806,7 +2806,61 @@ function displayBacktestResult(result) {
         el.innerHTML = `<p class="text-gray-500">無效結果</p>`; 
         return; 
     } 
-    const entryKey = result.entryStrategy; const exitKeyRaw = result.exitStrategy; const exitInternalKey = (['ma_cross','macd_cross','k_d_cross','ema_cross'].includes(exitKeyRaw)) ? `${exitKeyRaw}_exit` : exitKeyRaw; const entryDesc = strategyDescriptions[entryKey] || { name: result.entryStrategy || 'N/A', desc: 'N/A' }; const exitDesc = strategyDescriptions[exitInternalKey] || { name: result.exitStrategy || 'N/A', desc: 'N/A' }; let shortEntryDesc = null, shortExitDesc = null; if (result.enableShorting && result.shortEntryStrategy && result.shortExitStrategy) { shortEntryDesc = strategyDescriptions[result.shortEntryStrategy] || { name: result.shortEntryStrategy, desc: 'N/A' }; shortExitDesc = strategyDescriptions[result.shortExitStrategy] || { name: result.shortExitStrategy, desc: 'N/A' }; } const avgP = result.completedTrades?.length > 0 ? result.completedTrades.reduce((s, t) => s + (t.profit||0), 0) / result.completedTrades.length : 0; const maxCL = result.maxConsecutiveLosses || 0; const bhR = parseFloat(result.buyHoldReturns?.[result.buyHoldReturns.length - 1] ?? 0); const bhAnnR = result.buyHoldAnnualizedReturn ?? 0; const sharpe = result.sharpeRatio?.toFixed(2) ?? 'N/A'; const sortino = result.sortinoRatio ? (isFinite(result.sortinoRatio) ? result.sortinoRatio.toFixed(2) : '∞') : 'N/A'; const maxDD = result.maxDrawdown?.toFixed(2) ?? 0; const totalTrades = result.tradesCount ?? 0; const winTrades = result.winTrades ?? 0; const winR = totalTrades > 0 ? (winTrades / totalTrades * 100).toFixed(1) : 0; const totalProfit = result.totalProfit ?? 0; const returnRate = result.returnRate ?? 0; const annualizedReturn = result.annualizedReturn ?? 0; const finalValue = result.finalValue ?? result.initialCapital; let annReturnRatioStr = 'N/A'; let sharpeRatioStr = 'N/A'; if (result.annReturnHalf1 !== null && result.annReturnHalf2 !== null && result.annReturnHalf1 !== 0) { annReturnRatioStr = (result.annReturnHalf2 / result.annReturnHalf1).toFixed(2); } if (result.sharpeHalf1 !== null && result.sharpeHalf2 !== null && result.sharpeHalf1 !== 0) { sharpeRatioStr = (result.sharpeHalf2 / result.sharpeHalf1).toFixed(2); } const overfittingTooltip = "將回測期間前後對半分，計算兩段各自的總報酬率與夏普值，再計算其比值 (後段/前段)。比值接近 1 較佳，代表策略績效在不同時期較穩定。一般認為 > 0.5 可接受。"; let performanceHtml = `
+    const entryKey = result.entryStrategy; const exitKeyRaw = result.exitStrategy; const exitInternalKey = (['ma_cross','macd_cross','k_d_cross','ema_cross'].includes(exitKeyRaw)) ? `${exitKeyRaw}_exit` : exitKeyRaw; const entryDesc = strategyDescriptions[entryKey] || { name: result.entryStrategy || 'N/A', desc: 'N/A' }; const exitDesc = strategyDescriptions[exitInternalKey] || { name: result.exitStrategy || 'N/A', desc: 'N/A' }; let shortEntryDesc = null, shortExitDesc = null; if (result.enableShorting && result.shortEntryStrategy && result.shortExitStrategy) { shortEntryDesc = strategyDescriptions[result.shortEntryStrategy] || { name: result.shortEntryStrategy, desc: 'N/A' }; shortExitDesc = strategyDescriptions[result.shortExitStrategy] || { name: result.shortExitStrategy, desc: 'N/A' }; } const avgP = result.completedTrades?.length > 0 ? result.completedTrades.reduce((s, t) => s + (t.profit||0), 0) / result.completedTrades.length : 0; const maxCL = result.maxConsecutiveLosses || 0; const bhR = parseFloat(result.buyHoldReturns?.[result.buyHoldReturns.length - 1] ?? 0); const bhAnnR = result.buyHoldAnnualizedReturn ?? 0; const sharpe = result.sharpeRatio?.toFixed(2) ?? 'N/A'; const sortino = result.sortinoRatio ? (isFinite(result.sortinoRatio) ? result.sortinoRatio.toFixed(2) : '∞') : 'N/A'; const maxDD = result.maxDrawdown?.toFixed(2) ?? 0; const totalTrades = result.tradesCount ?? 0; const winTrades = result.winTrades ?? 0; const winR = totalTrades > 0 ? (winTrades / totalTrades * 100).toFixed(1) : 0; const totalProfit = result.totalProfit ?? 0; const returnRate = result.returnRate ?? 0; const annualizedReturn = result.annualizedReturn ?? 0; const finalValue = result.finalValue ?? result.initialCapital; let annReturnRatioStr = 'N/A'; let sharpeRatioStr = 'N/A'; if (result.annReturnHalf1 !== null && result.annReturnHalf2 !== null && result.annReturnHalf1 !== 0) { annReturnRatioStr = (result.annReturnHalf2 / result.annReturnHalf1).toFixed(2); } if (result.sharpeHalf1 !== null && result.sharpeHalf2 !== null && result.sharpeHalf1 !== 0) { sharpeRatioStr = (result.sharpeHalf2 / result.sharpeHalf1).toFixed(2); } const overfittingTooltip = "將回測期間前後對半分，計算兩段各自的總報酬率與夏普值，再計算其比值 (後段/前段)。比值接近 1 較佳，代表策略績效在不同時期較穩定。一般認為 > 0.5 可接受。"; const findSensitivityData = (payload, visited = new Set()) => {
+        if (!payload || typeof payload !== 'object') {
+            return null;
+        }
+        if (visited.has(payload)) {
+            return null;
+        }
+        visited.add(payload);
+        if (!Array.isArray(payload) && Array.isArray(payload.groups) && payload.groups.length > 0) {
+            return payload;
+        }
+        if (Array.isArray(payload)) {
+            for (const item of payload) {
+                const resolvedFromArray = findSensitivityData(item, visited);
+                if (resolvedFromArray) {
+                    return resolvedFromArray;
+                }
+            }
+            return null;
+        }
+        const candidateKeys = [
+            'sensitivityData',
+            'sensitivity',
+            'sensitivityAnalysis',
+            'parameterSensitivity',
+            'parameterSensitivitySummary',
+            'sensitivitySummary',
+            'diagnostics',
+            'summary',
+        ];
+        for (const key of candidateKeys) {
+            if (Object.prototype.hasOwnProperty.call(payload, key)) {
+                const resolvedFromKey = findSensitivityData(payload[key], visited);
+                if (resolvedFromKey) {
+                    return resolvedFromKey;
+                }
+            }
+        }
+        return null;
+    };
+    const sensitivityData = (() => {
+        const sources = [result];
+        if (typeof window !== 'undefined') {
+            if (window.sensitivityData) sources.push(window.sensitivityData);
+            if (window.__latestSensitivityData) sources.push(window.__latestSensitivityData);
+        }
+        for (const source of sources) {
+            const resolved = findSensitivityData(source);
+            if (resolved) {
+                return resolved;
+            }
+        }
+        return null;
+    })();
+    let performanceHtml = `
         <div class="mb-8">
             <h4 class="text-lg font-semibold mb-6" style="color: var(--foreground);">績效指標</h4>
             <div class="summary-metrics-grid summary-metrics-grid--performance">

--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+## 2025-07-30 — Patch LB-SENSITIVITY-GUARD-20250730A
+- **Issue recap**: 回測完成後 `displayBacktestResult` 直接引用未定義的 `sensitivityData`，導致前端在渲染摘要前即拋出 `ReferenceError`，使用者無法看到任何回測結果。
+- **Fix**: 新增遞迴尋找流程自動從回傳結果及瀏覽器快取來源擷取參數敏感度資料，若未取得有效 `groups` 則回退為空狀態提示，避免主流程因缺資料而中斷。
+- **Diagnostics**: 逐步檢視 `displayBacktestResult` 內的敏感度卡片渲染邏輯，確認在缺少敏感度資料時改為渲染「暫無結果可顯示」說明，並保持既有 tooltip 與佈局結構。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach(p=>new vm.Script(fs.readFileSync(p,'utf8'),{filename:p}));console.log('scripts compile');NODE`
+
 ## 2025-07-25 — Patch LB-SUMMARY-COMPACT-20250725A
 - **Issue recap**: 摘要卡在手機僅能單欄呈現，績效與風險指標無法成對對照；敏感度分析的進出場表格在窄螢幕需左右捲動才能看完欄位。
 - **Fix**: 重新定義 `summary-metrics-grid` 讓績效、風險、交易統計與策略設定卡在手機預設雙欄排列並調整間距；敏感度卡片新增桌機表格與手機卡片雙視圖，移除橫向捲軸並壓縮字級與 padding 以完整顯示指標。


### PR DESCRIPTION
## Summary
- guard the backtest result renderer with a resolver that locates valid sensitivity data before attempting to render the card, falling back to an empty state when unavailable
- document patch LB-SENSITIVITY-GUARD-20250730A in `log.md`

## Testing
- node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach(p=>new vm.Script(fs.readFileSync(p,'utf8'),{filename:p}));console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68d3733b420c8324a717624d030ce3f3