### PR TITLE
Add summary strategy status card with humorous health checks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -321,9 +321,119 @@ html, body { overflow-x: hidden; }
      line-height: 1.75rem;
      font-weight: 700; /* font-bold */
  }
- #today-suggestion-area.hidden {
-     display: none;
- }
+#today-suggestion-area.hidden {
+    display: none;
+}
+
+/* Strategy Status Card */
+.strategy-status-version {
+    color: var(--muted-foreground);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.strategy-status-badge {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    background-color: color-mix(in srgb, var(--muted) 18%, transparent);
+    color: var(--muted-foreground);
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.strategy-status-badge--idle {
+    background-color: color-mix(in srgb, var(--muted) 22%, transparent);
+    color: var(--muted-foreground);
+}
+
+.strategy-status-badge--loading {
+    background-color: color-mix(in srgb, var(--primary) 24%, transparent);
+    color: var(--primary);
+}
+
+.strategy-status-badge--lead {
+    background-color: color-mix(in srgb, #22c55e 24%, var(--background));
+    color: #166534;
+}
+
+.strategy-status-badge--tie {
+    background-color: color-mix(in srgb, var(--secondary) 22%, var(--background));
+    color: var(--secondary-foreground, var(--foreground));
+}
+
+.strategy-status-badge--lag {
+    background-color: color-mix(in srgb, #f97316 24%, var(--background));
+    color: #9a3412;
+}
+
+.strategy-status-badge--sleep {
+    background-color: color-mix(in srgb, #60a5fa 24%, var(--background));
+    color: #1d4ed8;
+}
+
+.strategy-status-badge--error {
+    background-color: color-mix(in srgb, #f87171 26%, var(--background));
+    color: #b91c1c;
+}
+
+.strategy-status-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--foreground);
+}
+
+.strategy-status-detail {
+    color: var(--muted-foreground);
+    line-height: 1.7;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.strategy-status-highlight {
+    font-size: 1.125rem;
+    font-weight: 700;
+    line-height: 1.5;
+}
+
+.strategy-status-card--lag .strategy-status-highlight {
+    color: #b91c1c;
+}
+
+.strategy-status-card--lead .strategy-status-highlight {
+    color: #047857;
+}
+
+.strategy-status-card--loading .strategy-status-highlight,
+.strategy-status-card--idle .strategy-status-highlight {
+    color: var(--foreground);
+}
+
+.strategy-status-list {
+    list-style: disc;
+    padding-left: 1.25rem;
+    margin: 0;
+    display: grid;
+    gap: 0.35rem;
+}
+
+.strategy-status-list li {
+    color: var(--foreground);
+    font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+    .strategy-status-highlight {
+        font-size: 1.05rem;
+    }
+
+    .strategy-status-list li {
+        font-size: 0.9rem;
+    }
+}
 
 /* 批量策略優化樣式 */
 .batch-optimization-tab {

--- a/index.html
+++ b/index.html
@@ -1121,7 +1121,7 @@
                                 </div>
                             </div>
                             
-                            <!-- Summary Tab -->
+                                <!-- Summary Tab -->
                             <div class="tab-content active" id="summary-tab">
                                 <!-- Chart Area -->
                                 <div class="card shadow-lg summary-card mb-8">
@@ -1138,7 +1138,31 @@
                                         </div>
                                     </div>
                                 </div>
-                                
+
+                                <!-- Strategy Status Card -->
+                                <div class="card shadow-lg summary-card" id="strategy-status-card">
+                                    <div class="card-header flex items-center justify-between gap-3">
+                                        <h3 class="card-title flex items-center gap-2">
+                                            <i data-lucide="activity" class="lucide text-accent" style="color: var(--accent);"></i>
+                                            策略狀態速報
+                                        </h3>
+                                        <span class="strategy-status-version text-xs font-medium" data-strategy-status-version>
+                                            LB-STRATEGY-STATUS-20250726A
+                                        </span>
+                                    </div>
+                                    <div class="card-content space-y-3">
+                                        <span class="strategy-status-badge strategy-status-badge--idle" data-strategy-status-badge>尚未開賽</span>
+                                        <p class="strategy-status-title" data-strategy-status-title>
+                                            等待最新戰況，回測完成後會立刻通報策略與買入持有的差距。
+                                        </p>
+                                        <div class="strategy-status-detail text-sm" data-strategy-status-detail>
+                                            <p class="text-muted" style="color: var(--muted-foreground);">
+                                                版本碼 <strong>LB-STRATEGY-STATUS-20250726A</strong>，回測完成後將同步提供勝負戰報與指標體檢結論。
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+
                                 <!-- Summary Results -->
                                 <div class="card shadow-lg summary-card">
                                     <div class="card-header">

--- a/log.md
+++ b/log.md
@@ -1,3 +1,8 @@
+# 2025-07-26 — Patch LB-STRATEGY-STATUS-20250726A
+- **Feature**: 摘要分頁新增「策略狀態速報」卡片，搬移戰況提示至淨值曲線下方，預設揭示版本碼與即將提供的對戰資訊。
+- **Logic**: 建立 `resetStrategyStatusCard`、`updateStrategyStatusCard` 與 `buildStrategyHealthSummary`，以報酬差距與年化/夏普/索提諾/最大回撤/前後段穩定度評分，輸出領先、拉鋸、落後與資料補眠狀態；落後時以強調句開場並改為條列句型。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach(p=>new vm.Script(fs.readFileSync(p,'utf8'),{filename:p}));console.log('strategy status patch scripts compile');NODE`
+
 ## 2025-07-25 — Patch LB-SUMMARY-COMPACT-20250725A
 - **Issue recap**: 摘要卡在手機僅能單欄呈現，績效與風險指標無法成對對照；敏感度分析的進出場表格在窄螢幕需左右捲動才能看完欄位。
 - **Fix**: 重新定義 `summary-metrics-grid` 讓績效、風險、交易統計與策略設定卡在手機預設雙欄排列並調整間距；敏感度卡片新增桌機表格與手機卡片雙視圖，移除橫向捲軸並壓縮字級與 padding 以完整顯示指標。


### PR DESCRIPTION
## Summary
- add the strategy status bulletin card to the summary tab and preload it with version LB-STRATEGY-STATUS-20250726A
- implement reset/update helpers that evaluate win/loss states and produce humorous bulletins with health diagnostics
- style the new card with badges, highlight text, and bullet formatting for different scenarios

## Testing
- node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach(p=>new vm.Script(fs.readFileSync(p,'utf8'),{filename:p}));console.log('strategy status patch scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68d3773c2aec83248686320031689c4a