### PR TITLE
feat: align fallback suggestion payload with main worker

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -474,60 +474,214 @@ html, body { overflow-x: hidden; }
     display: none;
 }
 
-.today-suggestion-highlight {
-    border-radius: 0.75rem;
+.today-suggestion-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.today-suggestion-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.today-suggestion-banner {
+    border-radius: 0.85rem;
     border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-    padding: 0.875rem 1rem;
+    padding: 1rem 1.125rem;
     background: color-mix(in srgb, var(--muted) 6%, var(--background));
     transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
+.today-suggestion-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.today-suggestion-title {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.today-suggestion-label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--foreground);
+}
+
+.today-suggestion-date {
+    font-size: 0.75rem;
+    color: var(--muted-foreground);
+}
+
+.today-suggestion-tag {
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    background: color-mix(in srgb, var(--accent) 15%, transparent);
+    color: var(--accent);
+    border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+    white-space: nowrap;
+}
+
+.today-suggestion-price {
+    margin-top: 0.75rem;
+    font-size: 0.85rem;
+    color: var(--muted-foreground);
+}
+
+.today-suggestion-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.today-suggestion-stat {
+    border-radius: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+    background: color-mix(in srgb, var(--muted) 4%, var(--background));
+    padding: 0.75rem 0.85rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.today-suggestion-stat dt {
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
+}
+
+.today-suggestion-stat dd {
+    font-size: 0.92rem;
+    font-weight: 600;
+    color: var(--foreground);
+}
+
+.today-suggestion-notes {
+    border-radius: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+    background: color-mix(in srgb, var(--muted) 3%, var(--background));
+    padding: 0.9rem 1rem;
+}
+
+.today-suggestion-notes-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: var(--muted-foreground);
+}
+
+.today-suggestion-notes-list {
+    list-style: disc;
+    padding-left: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-size: 0.78rem;
+    color: color-mix(in srgb, var(--muted-foreground) 88%, var(--foreground) 12%);
+}
+
+.today-suggestion-notes-list li {
+    line-height: 1.45;
+}
+
 .today-suggestion-highlight.is-bullish {
-    background: linear-gradient(135deg, color-mix(in srgb, #16a34a 10%, var(--background)) 0%, color-mix(in srgb, #16a34a 4%, var(--background)) 100%);
+    background: linear-gradient(135deg, color-mix(in srgb, #16a34a 12%, var(--background)) 0%, color-mix(in srgb, #16a34a 5%, var(--background)) 100%);
     border-color: color-mix(in srgb, #16a34a 35%, transparent);
     color: #065f46;
 }
 
 .today-suggestion-highlight.is-bearish {
-    background: linear-gradient(135deg, color-mix(in srgb, #dc2626 10%, var(--background)) 0%, color-mix(in srgb, #dc2626 4%, var(--background)) 100%);
+    background: linear-gradient(135deg, color-mix(in srgb, #dc2626 12%, var(--background)) 0%, color-mix(in srgb, #dc2626 5%, var(--background)) 100%);
     border-color: color-mix(in srgb, #dc2626 35%, transparent);
     color: #7f1d1d;
 }
 
 .today-suggestion-highlight.is-exit {
-    background: linear-gradient(135deg, color-mix(in srgb, #f97316 10%, var(--background)) 0%, color-mix(in srgb, #f97316 4%, var(--background)) 100%);
+    background: linear-gradient(135deg, color-mix(in srgb, #f97316 12%, var(--background)) 0%, color-mix(in srgb, #f97316 5%, var(--background)) 100%);
     border-color: color-mix(in srgb, #f97316 35%, transparent);
     color: #9a3412;
 }
 
 .today-suggestion-highlight.is-info {
-    background: linear-gradient(135deg, color-mix(in srgb, #0284c7 10%, var(--background)) 0%, color-mix(in srgb, #0284c7 4%, var(--background)) 100%);
+    background: linear-gradient(135deg, color-mix(in srgb, #0284c7 12%, var(--background)) 0%, color-mix(in srgb, #0284c7 5%, var(--background)) 100%);
     border-color: color-mix(in srgb, #0ea5e9 35%, transparent);
     color: #0b4f75;
 }
 
 .today-suggestion-highlight.is-warning {
-    background: linear-gradient(135deg, color-mix(in srgb, #eab308 10%, var(--background)) 0%, color-mix(in srgb, #eab308 4%, var(--background)) 100%);
+    background: linear-gradient(135deg, color-mix(in srgb, #eab308 12%, var(--background)) 0%, color-mix(in srgb, #eab308 5%, var(--background)) 100%);
     border-color: color-mix(in srgb, #facc15 35%, transparent);
     color: #854d0e;
 }
 
 .today-suggestion-highlight.is-error {
-    background: linear-gradient(135deg, color-mix(in srgb, #ef4444 10%, var(--background)) 0%, color-mix(in srgb, #ef4444 4%, var(--background)) 100%);
+    background: linear-gradient(135deg, color-mix(in srgb, #ef4444 12%, var(--background)) 0%, color-mix(in srgb, #ef4444 5%, var(--background)) 100%);
     border-color: color-mix(in srgb, #f87171 35%, transparent);
     color: #7f1d1d;
 }
 
 .today-suggestion-highlight.is-neutral {
-    background: linear-gradient(135deg, color-mix(in srgb, var(--muted) 12%, var(--background)) 0%, color-mix(in srgb, var(--muted) 6%, var(--background)) 100%);
-    border-color: color-mix(in srgb, var(--border) 75%, transparent);
+    background: linear-gradient(135deg, color-mix(in srgb, var(--muted) 8%, var(--background)) 0%, color-mix(in srgb, var(--muted) 3%, var(--background)) 100%);
+    border-color: color-mix(in srgb, var(--border) 65%, transparent);
+    color: var(--foreground);
 }
 
-.today-suggestion-stats div {
-    background: color-mix(in srgb, var(--muted) 6%, transparent);
-    border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
-    border-radius: 0.75rem;
-    padding: 0.75rem;
+.today-suggestion-tag.is-bullish {
+    background: color-mix(in srgb, #16a34a 18%, transparent);
+    border-color: color-mix(in srgb, #16a34a 45%, transparent);
+    color: #065f46;
+}
+
+.today-suggestion-tag.is-bearish {
+    background: color-mix(in srgb, #dc2626 18%, transparent);
+    border-color: color-mix(in srgb, #dc2626 45%, transparent);
+    color: #7f1d1d;
+}
+
+.today-suggestion-tag.is-exit {
+    background: color-mix(in srgb, #f97316 18%, transparent);
+    border-color: color-mix(in srgb, #f97316 45%, transparent);
+    color: #9a3412;
+}
+
+.today-suggestion-tag.is-warning {
+    background: color-mix(in srgb, #eab308 18%, transparent);
+    border-color: color-mix(in srgb, #eab308 45%, transparent);
+    color: #713f12;
+}
+
+.today-suggestion-tag.is-info {
+    background: color-mix(in srgb, #0284c7 18%, transparent);
+    border-color: color-mix(in srgb, #0284c7 45%, transparent);
+    color: #0c4a6e;
+}
+
+.today-suggestion-tag.is-neutral {
+    background: color-mix(in srgb, var(--muted-foreground) 18%, transparent);
+    border-color: color-mix(in srgb, var(--muted-foreground) 45%, transparent);
+    color: var(--muted-foreground);
+}
+
+@media (max-width: 640px) {
+    .today-suggestion-stats {
+        grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+    .today-suggestion-heading {
+        align-items: flex-start;
+    }
+    .today-suggestion-tag {
+        margin-left: auto;
+    }
 }
 
 /* 批量策略優化樣式 */

--- a/index.html
+++ b/index.html
@@ -1011,36 +1011,44 @@
                                     </h3>
                                 </div>
                                 <div class="card-content">
-                                    <div id="today-suggestion-empty" class="text-xs text-center" style="color: var(--muted-foreground);">
-                                        執行回測後將顯示策略的最新操作建議
-                                    </div>
-                                    <div id="today-suggestion-body" class="space-y-4 hidden">
-                                        <div id="today-suggestion-banner" class="today-suggestion-highlight">
-                                            <div class="flex items-center justify-between gap-3">
-                                                <span id="today-suggestion-label" class="text-sm font-semibold" style="color: var(--foreground);">計算中</span>
-                                                <span id="today-suggestion-date" class="text-xs" style="color: var(--muted-foreground);">—</span>
-                                            </div>
-                                            <div id="today-suggestion-price" class="text-xs" style="color: var(--muted-foreground);">—</div>
+                                    <div class="today-suggestion-card">
+                                        <div id="today-suggestion-empty" class="today-suggestion-empty text-xs text-center" style="color: var(--muted-foreground);">
+                                            執行回測後將顯示策略的最新操作建議
                                         </div>
-                                        <dl class="today-suggestion-stats grid grid-cols-2 gap-3 text-xs">
-                                            <div>
-                                                <dt class="text-[10px] uppercase tracking-wide" style="color: var(--muted-foreground);">多單狀態</dt>
-                                                <dd id="today-suggestion-long" class="text-sm font-medium" style="color: var(--foreground);">—</dd>
+                                        <div id="today-suggestion-body" class="today-suggestion-body hidden space-y-4">
+                                            <div id="today-suggestion-banner" class="today-suggestion-banner today-suggestion-highlight">
+                                                <div class="today-suggestion-heading">
+                                                    <div class="today-suggestion-title">
+                                                        <span id="today-suggestion-label" class="today-suggestion-label">計算中</span>
+                                                        <span id="today-suggestion-date" class="today-suggestion-date">—</span>
+                                                    </div>
+                                                    <span id="today-suggestion-action" class="today-suggestion-tag">—</span>
+                                                </div>
+                                                <div id="today-suggestion-price" class="today-suggestion-price">—</div>
                                             </div>
-                                            <div>
-                                                <dt class="text-[10px] uppercase tracking-wide" style="color: var(--muted-foreground);">空單狀態</dt>
-                                                <dd id="today-suggestion-short" class="text-sm font-medium" style="color: var(--foreground);">—</dd>
+                                            <dl class="today-suggestion-stats">
+                                                <div class="today-suggestion-stat">
+                                                    <dt>多單狀態</dt>
+                                                    <dd id="today-suggestion-long">—</dd>
+                                                </div>
+                                                <div class="today-suggestion-stat">
+                                                    <dt>空單狀態</dt>
+                                                    <dd id="today-suggestion-short">—</dd>
+                                                </div>
+                                                <div class="today-suggestion-stat">
+                                                    <dt>今日部位</dt>
+                                                    <dd id="today-suggestion-position">—</dd>
+                                                </div>
+                                                <div class="today-suggestion-stat">
+                                                    <dt>資金概況</dt>
+                                                    <dd id="today-suggestion-portfolio">—</dd>
+                                                </div>
+                                            </dl>
+                                            <div class="today-suggestion-notes">
+                                                <p class="today-suggestion-notes-title">備註</p>
+                                                <ul id="today-suggestion-notes" class="today-suggestion-notes-list"></ul>
                                             </div>
-                                            <div>
-                                                <dt class="text-[10px] uppercase tracking-wide" style="color: var(--muted-foreground);">部位概況</dt>
-                                                <dd id="today-suggestion-position" class="text-sm font-medium" style="color: var(--foreground);">—</dd>
-                                            </div>
-                                            <div>
-                                                <dt class="text-[10px] uppercase tracking-wide" style="color: var(--muted-foreground);">模擬資金</dt>
-                                                <dd id="today-suggestion-portfolio" class="text-sm font-medium" style="color: var(--foreground);">—</dd>
-                                            </div>
-                                        </dl>
-                                        <ul id="today-suggestion-notes" class="text-[11px] space-y-1 list-disc pl-5" style="color: var(--muted-foreground);"></ul>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/js/backtest.js
+++ b/js/backtest.js
@@ -162,8 +162,9 @@ const todaySuggestionUI = (() => {
             || formatPriceValue(payload.price?.value, payload.price?.type)
             || payload.message
             || '—';
+        const displayDate = payload.latestTradingDate || payload.latestDate;
         setText(labelEl, payload.label || '—');
-        setText(dateEl, payload.latestDate || '—');
+        setText(dateEl, displayDate || '—');
         setText(priceEl, priceText);
         setText(longEl, describePosition(payload.longPosition));
         setText(shortEl, describePosition(payload.shortPosition));

--- a/js/backtest.js
+++ b/js/backtest.js
@@ -5,6 +5,7 @@
 // Patch Tag: LB-TREND-SENSITIVITY-20250726A
 // Patch Tag: LB-TREND-SENSITIVITY-20250817A
 // Patch Tag: LB-TREND-REGRESSION-20250903A
+// Patch Tag: LB-TODAY-UI-20250913A
 
 // 確保 zoom 插件正確註冊
 document.addEventListener('DOMContentLoaded', function() {
@@ -50,18 +51,14 @@ const todaySuggestionUI = (() => {
     const labelEl = document.getElementById('today-suggestion-label');
     const dateEl = document.getElementById('today-suggestion-date');
     const priceEl = document.getElementById('today-suggestion-price');
+    const actionEl = document.getElementById('today-suggestion-action');
     const longEl = document.getElementById('today-suggestion-long');
     const shortEl = document.getElementById('today-suggestion-short');
     const positionEl = document.getElementById('today-suggestion-position');
     const portfolioEl = document.getElementById('today-suggestion-portfolio');
+    const notesContainer = area ? area.querySelector('.today-suggestion-notes') : null;
     const notesEl = document.getElementById('today-suggestion-notes');
     const toneClasses = ['is-bullish', 'is-bearish', 'is-exit', 'is-neutral', 'is-info', 'is-warning', 'is-error'];
-    const numberFormatter = typeof Intl !== 'undefined'
-        ? new Intl.NumberFormat('zh-TW', { maximumFractionDigits: 2 })
-        : { format: (value) => (Number.isFinite(value) ? value.toString() : '—') };
-    const integerFormatter = typeof Intl !== 'undefined'
-        ? new Intl.NumberFormat('zh-TW', { maximumFractionDigits: 0 })
-        : { format: (value) => (Number.isFinite(value) ? value.toString() : '—') };
     const toneMap = {
         bullish: 'is-bullish',
         bear: 'is-bearish',
@@ -72,6 +69,21 @@ const todaySuggestionUI = (() => {
         warning: 'is-warning',
         error: 'is-error',
     };
+    const actionLabelMap = {
+        enter_long: '做多買入',
+        enter_short: '做空賣出',
+        exit_long: '做多賣出',
+        cover_short: '做空回補',
+        hold_long: '繼續持有多單',
+        hold_short: '繼續持有空單',
+        stay_flat: '維持空手',
+    };
+    const numberFormatter = typeof Intl !== 'undefined'
+        ? new Intl.NumberFormat('zh-TW', { maximumFractionDigits: 2 })
+        : { format: (value) => (Number.isFinite(value) ? value.toString() : '—') };
+    const integerFormatter = typeof Intl !== 'undefined'
+        ? new Intl.NumberFormat('zh-TW', { maximumFractionDigits: 0 })
+        : { format: (value) => (Number.isFinite(value) ? value.toString() : '—') };
     const priceTypeLabel = {
         close: '收盤',
         open: '開盤',
@@ -98,6 +110,25 @@ const todaySuggestionUI = (() => {
         toneClasses.forEach((cls) => banner.classList.remove(cls));
         const resolved = toneMap[tone] || toneMap.neutral;
         banner.classList.add(resolved);
+    }
+
+    function setActionTag(payload) {
+        if (!actionEl) return;
+        const text = payload?.actionTag?.text
+            || payload?.actionLabel
+            || payload?.label
+            || '';
+        if (!text) {
+            actionEl.textContent = '';
+            toneClasses.forEach((cls) => actionEl.classList.remove(cls));
+            actionEl.style.display = 'none';
+            return;
+        }
+        actionEl.style.display = 'inline-flex';
+        actionEl.textContent = text;
+        toneClasses.forEach((cls) => actionEl.classList.remove(cls));
+        const tone = payload?.actionTag?.tone || payload?.tone || 'neutral';
+        actionEl.classList.add(toneMap[tone] || toneMap.neutral);
     }
 
     function setText(el, text) {
@@ -141,16 +172,93 @@ const todaySuggestionUI = (() => {
         return parts.join('，');
     }
 
-    function setNotes(notes) {
-        if (!notesEl) return;
+    function formatDetail(detail, payload) {
+        if (!detail || typeof detail !== 'object') return null;
+        switch (detail.type) {
+        case 'action': {
+            const label = detail.label || actionLabelMap[detail.action] || payload?.label;
+            return label ? `今日策略：${label}` : null;
+        }
+        case 'execution': {
+            const sideLabel = detail.side === 'short' ? '空單' : '多單';
+            let actionLabel = '操作';
+            if (detail.event === 'enter') actionLabel = '進場';
+            else if (detail.event === 'exit') actionLabel = '平倉';
+            else if (detail.event === 'cover') actionLabel = '回補';
+            const parts = [`${sideLabel}${actionLabel}`];
+            const priceText = formatPriceValue(detail.price, detail.priceType);
+            if (priceText) parts.push(priceText);
+            const shareText = formatShares(detail.shares);
+            if (shareText) parts.push(shareText);
+            return parts.join('，');
+        }
+        case 'holding': {
+            const sideLabel = detail.side === 'short' ? '空單' : '多單';
+            const parts = [];
+            if (detail.state && detail.state !== '空手') {
+                parts.push(`${sideLabel}${detail.state}`);
+            }
+            const shareText = formatShares(detail.shares);
+            if (shareText) parts.push(shareText);
+            if (Number.isFinite(detail.averagePrice)) {
+                parts.push(`均價 ${numberFormatter.format(detail.averagePrice)}`);
+            }
+            if (Number.isFinite(detail.marketValue)) {
+                parts.push(`市值 ${numberFormatter.format(detail.marketValue)} 元`);
+            }
+            return parts.length ? parts.join('，') : null;
+        }
+        case 'portfolio':
+            return Number.isFinite(detail.value)
+                ? `策略資金估算約 ${numberFormatter.format(detail.value)} 元。`
+                : null;
+        case 'dataLag':
+            return detail.latestDate && Number.isFinite(detail.days)
+                ? `最新資料為 ${detail.latestDate}，距今日 ${detail.days} 日。`
+                : null;
+        case 'rangeExtension':
+            return detail.requestedEndDate && detail.appliedEndDate
+                ? `原設定結束日 ${detail.requestedEndDate}，已延伸至 ${detail.appliedEndDate} 以評估今日部位。`
+                : null;
+        case 'rangeShorter':
+            return detail.requestedEndDate && detail.appliedEndDate
+                ? `策略結束日為 ${detail.requestedEndDate}，最新資料僅至 ${detail.appliedEndDate}。`
+                : null;
+        case 'info':
+            return typeof detail.message === 'string' ? detail.message : null;
+        default:
+            return typeof detail.message === 'string' ? detail.message : null;
+        }
+    }
+
+    function buildNoteLines(payload) {
+        const lines = [];
+        const details = Array.isArray(payload?.details) ? payload.details : [];
+        details.forEach((detail) => {
+            const text = formatDetail(detail, payload);
+            if (text && !lines.includes(text)) {
+                lines.push(text);
+            }
+        });
+        const notes = Array.isArray(payload?.notes) ? payload.notes : [];
+        notes.forEach((note) => {
+            if (typeof note === 'string' && note.trim() && !lines.includes(note)) {
+                lines.push(note);
+            }
+        });
+        return lines;
+    }
+
+    function renderNotes(payload) {
+        if (!notesEl || !notesContainer) return;
+        const notes = buildNoteLines(payload);
         notesEl.innerHTML = '';
-        if (!Array.isArray(notes) || notes.length === 0) {
-            notesEl.style.display = 'none';
+        if (!notes.length) {
+            notesContainer.style.display = 'none';
             return;
         }
-        notesEl.style.display = 'block';
+        notesContainer.style.display = 'block';
         notes.forEach((note) => {
-            if (!note) return;
             const li = document.createElement('li');
             li.textContent = note;
             notesEl.appendChild(li);
@@ -173,7 +281,7 @@ const todaySuggestionUI = (() => {
             const portfolioText = formatCurrency(payload.evaluation?.portfolioValue);
             setText(portfolioEl, portfolioText || '—');
         }
-        setNotes(payload.notes);
+        renderNotes(payload);
     }
 
     return {
@@ -182,6 +290,7 @@ const todaySuggestionUI = (() => {
             ensureAreaVisible();
             showPlaceholderContent();
             setTone('neutral');
+            setActionTag({ label: '—', tone: 'neutral' });
             setText(labelEl, '尚未取得建議');
             setText(dateEl, '—');
             setText(priceEl, '—');
@@ -189,13 +298,14 @@ const todaySuggestionUI = (() => {
             setText(shortEl, '—');
             setText(positionEl, '—');
             if (portfolioEl) setText(portfolioEl, '—');
-            setNotes([]);
+            renderNotes({ notes: [] });
         },
         showLoading() {
             if (!area) return;
             ensureAreaVisible();
             showBodyContent();
             setTone('info');
+            setActionTag({ actionTag: { text: '計算中', tone: 'info' } });
             setText(labelEl, '計算今日建議中...');
             setText(dateEl, '—');
             setText(priceEl, '資料計算中，請稍候');
@@ -203,7 +313,7 @@ const todaySuggestionUI = (() => {
             setText(shortEl, '—');
             setText(positionEl, '—');
             if (portfolioEl) setText(portfolioEl, '—');
-            setNotes([]);
+            renderNotes({ notes: [] });
         },
         showResult(payload = {}) {
             if (!area) return;
@@ -214,7 +324,14 @@ const todaySuggestionUI = (() => {
                 const fallbackNotes = [];
                 if (payload.message) fallbackNotes.push(payload.message);
                 if (Array.isArray(payload.notes)) fallbackNotes.push(...payload.notes);
-                setTone(status === 'no_data' ? 'warning' : status === 'future_start' ? 'info' : 'neutral');
+                const tone = status === 'no_data' ? 'warning' : status === 'future_start' ? 'info' : 'neutral';
+                setTone(tone);
+                setActionTag({
+                    actionTag: {
+                        text: status === 'no_data' ? '資料不足' : status === 'future_start' ? '尚未開始' : '提醒',
+                        tone,
+                    },
+                });
                 applyResultPayload({
                     label: payload.label || (status === 'future_start' ? '策略尚未開始' : '無法取得建議'),
                     latestDate: payload.latestDate || '—',
@@ -228,6 +345,7 @@ const todaySuggestionUI = (() => {
                 return;
             }
             setTone(payload.tone || 'neutral');
+            setActionTag(payload);
             applyResultPayload(payload);
         },
         showError(message) {
@@ -235,6 +353,7 @@ const todaySuggestionUI = (() => {
             ensureAreaVisible();
             showBodyContent();
             setTone('error');
+            setActionTag({ actionTag: { text: '計算失敗', tone: 'error' } });
             applyResultPayload({
                 label: '計算失敗',
                 latestDate: '—',

--- a/js/backtest_corrupted.js
+++ b/js/backtest_corrupted.js
@@ -126,7 +126,8 @@ const fallbackTodaySuggestionUI = (() => {
             || payload.message
             || '—';
         setText(labelEl, payload.label || '—');
-        setText(dateEl, payload.latestDate || '—');
+        const displayDate = payload.latestTradingDate || payload.latestDate;
+        setText(dateEl, displayDate || '—');
         setText(priceEl, priceText);
         setText(longEl, describePosition(payload.longPosition));
         setText(shortEl, describePosition(payload.shortPosition));
@@ -180,7 +181,7 @@ const fallbackTodaySuggestionUI = (() => {
                 setTone(tone);
                 applyResultPayload({
                     label: payload.label || (status === 'future_start' ? '策略尚未開始' : '無法取得建議'),
-                    latestDate: payload.latestDate || '—',
+                    latestDate: payload.latestTradingDate || payload.latestDate || '—',
                     price: { text: payload.price?.text || payload.message || '—' },
                     longPosition: { state: '空手' },
                     shortPosition: { state: '空手' },

--- a/log.md
+++ b/log.md
@@ -452,3 +452,13 @@
   後續檢視資料覆蓋情形。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js','js/worker_backup.js'].forEach(p=>new vm.Script(fs.readFileSync(p,'utf8'),{filename:p}));console.log('primary scripts compile');NODE`
 
+
+# 2025-09-13 — Patch LB-TODAY-UI-20250913A / LB-TODAY-ACTION-20250913A
+- **Issue recap**: 首頁「今日建議」仍以單段文字呈現，容易出現「等待」字樣且缺乏行動標籤與倉位細節；Worker 僅回傳純文字訊息，無法辨識策略延伸
+  結束日或資料落後等狀態，使用者難以判讀今日操作重點。
+- **Fix**: 重構 `todaySuggestionUI`，加入行動標籤、長短倉統計與備註列表，並以格式化工具統一顯示價格、市值與分享數；主／備援 Worker
+  改以 `composeSuggestionDetails` 產生結構化 `details` 與 `actionTag`，延伸策略至最新交易日並揭露進出場事件、持有部位與資料落後天數。
+- **Diagnostics**: UI 會依 `details` 動態生成備註，若策略延伸或資料不足會標示來源與日期，錯誤情境則透過標籤顯示「資料不足」或「計算失敗」。
+- **Testing**:
+  - `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js','js/worker_backup.js'].forEach(p=>new vm.Script(fs.readFileSync(p,'utf8'),{filename:p}));console.log('core scripts compile');NODE`
+  - `node - <<'NODE' const fs=require('fs');const vm=require('vm');const code=fs.readFileSync('js/backtest_corrupted.js','utf8');const match=code.match(/const fallbackTodaySuggestionUI = \(\(\) => \{[\s\S]*?\}\)\(\);/);if(!match)throw new Error('fallback UI block not found');new vm.Script(match[0],{filename:'fallback_today_suggestion.js'});console.log('fallback UI block compiles');NODE`

--- a/log.md
+++ b/log.md
@@ -1,4 +1,12 @@
 
+## 2025-09-10 — Patch LB-TODAY-CURRENT-20250910A
+- **Issue recap**: 今日建議卡片仍沿用使用者設定的結束日，未主動延伸到最新交易日，導致原策略已結束時無法告知今日應進出或持倉的動作。
+- **Fix**: Worker 會先抓取本月行情推導最後交易日，再以 `forceFinalLiquidation: false` 重跑策略到該日並產出多空進出指示；前端同步顯示解析後的交易日期與動作文案。
+- **Diagnostics**: 建議負載新增 `latestTradingDate`、`monthReference` 與結束日差異提醒，並保留資料落後天數提示，協助辨識延伸區間與資料時效。
+- **Testing**:
+  - `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/worker.js','js/backtest.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('primary scripts compile');NODE`
+  - `node - <<'NODE' const fs=require('fs');const vm=require('vm');const code=fs.readFileSync('js/backtest_corrupted.js','utf8');const match=code.match(/const FALLBACK_DAY_MS[\s\S]*?function getSuggestion\([\s\S]*?\n}\n/);if(!match)throw new Error('Unable to extract fallback suggestion module');new vm.Script(match[0],{filename:'fallback_today_suggestion.js'});console.log('fallback suggestion module compiles');NODE`
+
 ## 2025-09-05 — Patch LB-TODAY-ACTION-20250828A
 - **Issue recap**: 備援腳本 `backtest_corrupted.js` 仍僅渲染舊版文字訊息，遇到新結構的 `action/label/tone` 會落入空白，亦缺乏快取覆蓋資訊與延遲提示。
 - **Fix**: 導入與主版一致的 `todaySuggestionUI` 呈現邏輯、調整 Worker 訊息處理與錯誤復原，並補上快取覆蓋計算、lookback 解析與結構化請求，確保備援流程同樣拉齊到今日資料。

--- a/log.md
+++ b/log.md
@@ -1,4 +1,16 @@
 
+## 2025-09-05 — Patch LB-TODAY-ACTION-20250828A
+- **Issue recap**: 備援腳本 `backtest_corrupted.js` 仍僅渲染舊版文字訊息，遇到新結構的 `action/label/tone` 會落入空白，亦缺乏快取覆蓋資訊與延遲提示。
+- **Fix**: 導入與主版一致的 `todaySuggestionUI` 呈現邏輯、調整 Worker 訊息處理與錯誤復原，並補上快取覆蓋計算、lookback 解析與結構化請求，確保備援流程同樣拉齊到今日資料。
+- **Diagnostics**: 備援模式下 `getSuggestion` 會將快取指紋與 coverage fingerprint 一併送往 Worker，UI 顯示多空倉位、市值、筆記與落後天數；錯誤時改以卡片顯示明確訊息。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');const code=fs.readFileSync('js/backtest_corrupted.js','utf8');const match=code.match(/const FALLBACK_DAY_MS[\s\S]*?function getSuggestion\([\s\S]*?\n}\n/);if(!match)throw new Error('Unable to extract fallback suggestion module');new vm.Script(match[0],{filename:'fallback_today_suggestion.js'});console.log('fallback suggestion module compiles');NODE`
+
+## 2025-09-04 — Patch LB-TODAY-ACTION-20250727B
+- **Issue recap**: 備援 worker 仍回傳單純的文字建議與「等待」訊息，前端解析新結構時會顯示空白內容，也缺乏資料不足與延遲提示。
+- **Fix**: 在 `worker_backup.js` 新增今日日期與日差計算工具，將建議輸出包裝為含行動、色彩、價格與備註的物件，遇到資料不足或指標失敗時改以結構化狀態回傳。
+- **Diagnostics**: 呼叫備援建議時，應看到 `action/label/tone/notes` 等欄位且 console 會標示對應行動；若資料落後將附註最新日期與落後天數。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/worker_backup.js'].forEach(f=>new vm.Script(fs.readFileSync(f,'utf8'),{filename:f}));console.log('backup worker compiles');NODE`
+
 ## 2025-09-03 — Patch LB-TREND-REGRESSION-20250903A
 - **Issue recap**: 先前趨勢偵測僅透過斜率與波動度比值判定，對盤整或不穩定區段常出現誤判，滑桿雖能調整倍率但無法穩定反映趨勢強度。
 - **Fix**: 導入 20 日對數淨值線性回歸，加入 R²、斜率÷殘差與斜率÷波動度等訊噪指標，並依滑桿重新插值嚴格與寬鬆門檻，提升起漲／跌落判定準確度。


### PR DESCRIPTION
## Summary
- add helper utilities in `worker_backup.js` to build structured suggestion payloads with action, notes, and data lag info
- update fallback worker to return status objects instead of raw strings and ensure message handler forwards the new structure
- document the change in `log.md` with patch ID LB-TODAY-ACTION-20250727B

## Testing
- node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/worker_backup.js','js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68d4953222fc83249f92d52e71b90043