### PR TITLE
Adjust dashboard toggles and diagnostics for LB-UI-REFRESH-20251030A

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -496,6 +496,106 @@ html, body { overflow-x: hidden; }
     gap: 1.25rem;
 }
 
+.toggle-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+    font-weight: 700;
+    font-size: 0.75rem;
+    line-height: 1;
+    transition: transform 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.trend-toggle-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+    font-weight: 700;
+    font-size: 0.85rem;
+    line-height: 1;
+    color: color-mix(in srgb, var(--foreground) 88%, var(--muted-foreground));
+    transition: transform 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+[data-trend-toggle-label] {
+    color: var(--muted-foreground);
+    transition: color 0.2s ease;
+}
+
+[data-trend-toggle-label].open {
+    color: var(--primary);
+}
+
+.trend-toggle-indicator.open {
+    transform: rotate(45deg);
+    border-color: color-mix(in srgb, var(--primary) 35%, transparent);
+    color: var(--primary);
+}
+
+#trendAnalysisToggle {
+    background: transparent;
+    border: none;
+    padding: 0;
+    color: inherit;
+    cursor: pointer;
+}
+
+#trendAnalysisToggle:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--primary) 35%, transparent);
+    border-radius: calc(var(--radius) + 4px);
+}
+
+.today-suggestion-controls {
+    display: flex;
+    justify-content: flex-start;
+}
+
+.today-suggestion-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+    padding: 0.35rem 0.75rem;
+    background: color-mix(in srgb, var(--background) 92%, transparent);
+    color: color-mix(in srgb, var(--foreground) 88%, var(--muted-foreground));
+    transition: all 0.2s ease;
+}
+
+.today-suggestion-toggle:hover,
+.today-suggestion-toggle:focus {
+    outline: none;
+    border-color: color-mix(in srgb, var(--primary) 30%, transparent);
+    color: var(--primary);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 18%, transparent);
+}
+
+.today-suggestion-stats-wrapper {
+    transition: max-height 0.3s ease, opacity 0.2s ease;
+}
+
+.sensitivity-collapse-toggle {
+    transition: all 0.2s ease;
+}
+
+.sensitivity-collapse-toggle:hover,
+.sensitivity-collapse-toggle:focus-visible {
+    outline: none;
+    border-color: color-mix(in srgb, var(--primary) 30%, transparent);
+    color: var(--primary) !important;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 18%, transparent);
+}
+
 .today-suggestion-highlight {
     border-radius: 0.9rem;
     border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
@@ -505,6 +605,7 @@ html, body { overflow-x: hidden; }
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    color: color-mix(in srgb, var(--foreground) 88%, var(--muted-foreground));
 }
 
 .today-suggestion-topline {
@@ -533,9 +634,11 @@ html, body { overflow-x: hidden; }
     color: var(--muted-foreground);
 }
 
-.today-suggestion-price {
-    font-size: 0.85rem;
-    color: color-mix(in srgb, var(--foreground) 85%, var(--muted-foreground));
+.today-suggestion-message {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: inherit;
+    white-space: pre-wrap;
 }
 
 .today-suggestion-highlight.is-bullish {
@@ -577,6 +680,36 @@ html, body { overflow-x: hidden; }
 .today-suggestion-highlight.is-neutral {
     background: linear-gradient(135deg, color-mix(in srgb, var(--muted) 12%, var(--background)) 0%, color-mix(in srgb, var(--muted) 6%, var(--background)) 100%);
     border-color: color-mix(in srgb, var(--border) 75%, transparent);
+}
+
+#trend-legend {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    padding: 0.125rem 0;
+}
+
+#trend-legend::-webkit-scrollbar {
+    height: 4px;
+}
+
+#trend-legend::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--muted) 45%, transparent);
+    border-radius: 999px;
+}
+
+#trend-legend > div {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+    #trend-legend {
+        justify-content: flex-start;
+    }
 }
 
 .today-suggestion-stats {

--- a/index.html
+++ b/index.html
@@ -493,22 +493,52 @@
                                                 </div>
                                             </div>
                                         </div>
+                                        <div class="space-y-2" id="dataSourceSummaryContainer">
+                                            <div class="flex items-center justify-between">
+                                                <div class="text-sm font-medium flex items-center gap-2" style="color: var(--foreground);">
+                                                    <i data-lucide="layers" class="lucide w-4 h-4"></i>
+                                                    數據來源摘要
+                                                </div>
+                                                <span id="dataSourceSummaryTag" class="text-[11px] text-muted-foreground" style="color: var(--muted-foreground);"></span>
+                                            </div>
+                                            <div class="rounded-md border bg-white/70 shadow-sm" style="border-color: var(--border);">
+                                                <div id="dataSourceDisplay" class="px-3 py-3 space-y-2 text-[11px]" style="color: var(--foreground);"></div>
+                                            </div>
+                                        </div>
                                         <div class="space-y-2" id="todaySuggestionLogContainer">
                                             <div class="flex items-center justify-between">
                                                 <div class="text-sm font-medium flex items-center gap-2" style="color: var(--foreground);">
                                                     <i data-lucide="message-square-warning" class="lucide w-4 h-4"></i>
                                                     今日建議記錄
                                                 </div>
-                                                <button
-                                                    id="todaySuggestionLogClear"
-                                                    type="button"
-                                                    class="px-2 py-1 text-[11px] rounded-md border transition-colors"
-                                                    style="color: var(--muted-foreground); border-color: var(--border); background-color: var(--background);"
-                                                >
-                                                    清除紀錄
-                                                </button>
+                                                <div class="flex items-center gap-2">
+                                                    <button
+                                                        id="todaySuggestionLogToggle"
+                                                        type="button"
+                                                        class="px-2 py-1 text-[11px] rounded-md border transition-colors flex items-center gap-1"
+                                                        style="color: var(--foreground); border-color: var(--border); background-color: var(--background);"
+                                                        aria-expanded="false"
+                                                        aria-controls="todaySuggestionLogPanel"
+                                                    >
+                                                        <span class="toggle-indicator">＋</span>
+                                                        <span class="toggle-label">展開</span>
+                                                    </button>
+                                                    <button
+                                                        id="todaySuggestionLogClear"
+                                                        type="button"
+                                                        class="px-2 py-1 text-[11px] rounded-md border transition-colors"
+                                                        style="color: var(--muted-foreground); border-color: var(--border); background-color: var(--background);"
+                                                    >
+                                                        清除紀錄
+                                                    </button>
+                                                </div>
                                             </div>
-                                            <div class="rounded-md border bg-white/70 shadow-sm" style="border-color: var(--border);">
+                                            <div
+                                                id="todaySuggestionLogPanel"
+                                                class="rounded-md border bg-white/70 shadow-sm hidden"
+                                                style="border-color: var(--border);"
+                                                aria-hidden="true"
+                                            >
                                                 <div
                                                     id="today-suggestion-log-body"
                                                     class="px-3 py-3 space-y-3 text-[11px]"
@@ -573,9 +603,9 @@
                                                         class="px-2 py-1 border border-border rounded-md text-xs bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                                                         style="border-color: var(--border); background-color: var(--input); color: var(--foreground);"
                                                     >
-                                                        <option value="TWSE">上市 (TWSE)</option>
-                                                        <option value="TPEX">上櫃 (TPEX)</option>
-                                                        <option value="US">美股 (US)</option>
+                                                        <option value="TWSE">上市</option>
+                                                        <option value="TPEX">上櫃</option>
+                                                        <option value="US">美股</option>
                                                     </select>
                                                 </div>
                                             </div>
@@ -584,22 +614,6 @@
                                             </div>
                                             <div id="stockNameDisplay" class="mt-1 text-xs" style="display: none;">
                                                 <!-- 股票名稱和市場切換提示將顯示在這裡 -->
-                                            </div>
-                                            <p id="dataSourceDisplay" class="text-xs text-gray-500 mt-1 hidden"></p>
-                                            <div id="priceInspectorControls" class="mt-2 hidden flex items-center gap-2">
-                                                <button
-                                                    type="button"
-                                                    id="openPriceInspector"
-                                                    class="px-3 py-1.5 text-[11px] font-medium rounded-md border transition-colors"
-                                                    style="border-color: var(--border); color: var(--foreground); background-color: var(--background);"
-                                                >
-                                                    查看區間價格
-                                                </button>
-                                                <span
-                                                    id="priceInspectorSummary"
-                                                    class="text-[11px] text-muted-foreground"
-                                                    style="color: var(--muted-foreground);"
-                                                ></span>
                                             </div>
                                             <div
                                                 id="pricePipelineSteps"
@@ -1043,26 +1057,40 @@
                                                 <span id="today-suggestion-label" class="today-suggestion-chip">計算中</span>
                                                 <span id="today-suggestion-date" class="today-suggestion-date">—</span>
                                             </div>
-                                            <div id="today-suggestion-price" class="today-suggestion-price">—</div>
+                                            <div id="today-suggestion-message" class="today-suggestion-message">—</div>
                                         </div>
-                                        <dl class="today-suggestion-stats">
-                                            <div class="today-suggestion-stat">
-                                                <dt class="today-suggestion-stat-label">多單概況</dt>
-                                                <dd id="today-suggestion-long" class="today-suggestion-stat-value">—</dd>
-                                            </div>
-                                            <div class="today-suggestion-stat">
-                                                <dt class="today-suggestion-stat-label">空單概況</dt>
-                                                <dd id="today-suggestion-short" class="today-suggestion-stat-value">—</dd>
-                                            </div>
-                                            <div class="today-suggestion-stat">
-                                                <dt class="today-suggestion-stat-label">整體部位</dt>
-                                                <dd id="today-suggestion-position" class="today-suggestion-stat-value">—</dd>
-                                            </div>
-                                            <div class="today-suggestion-stat">
-                                                <dt class="today-suggestion-stat-label">資產估值</dt>
-                                                <dd id="today-suggestion-portfolio" class="today-suggestion-stat-value">—</dd>
-                                            </div>
-                                        </dl>
+                                        <div id="today-suggestion-controls" class="today-suggestion-controls">
+                                            <button
+                                                id="today-suggestion-stats-toggle"
+                                                type="button"
+                                                class="today-suggestion-toggle"
+                                                aria-expanded="false"
+                                                aria-controls="today-suggestion-stats-wrapper"
+                                            >
+                                                <span class="toggle-indicator">＋</span>
+                                                <span class="toggle-label">展開部位概況</span>
+                                            </button>
+                                        </div>
+                                        <div id="today-suggestion-stats-wrapper" class="today-suggestion-stats-wrapper hidden" aria-hidden="true">
+                                            <dl class="today-suggestion-stats">
+                                                <div class="today-suggestion-stat">
+                                                    <dt class="today-suggestion-stat-label">多單概況</dt>
+                                                    <dd id="today-suggestion-long" class="today-suggestion-stat-value">—</dd>
+                                                </div>
+                                                <div class="today-suggestion-stat">
+                                                    <dt class="today-suggestion-stat-label">空單概況</dt>
+                                                    <dd id="today-suggestion-short" class="today-suggestion-stat-value">—</dd>
+                                                </div>
+                                                <div class="today-suggestion-stat">
+                                                    <dt class="today-suggestion-stat-label">整體部位</dt>
+                                                    <dd id="today-suggestion-position" class="today-suggestion-stat-value">—</dd>
+                                                </div>
+                                                <div class="today-suggestion-stat">
+                                                    <dt class="today-suggestion-stat-label">資產估值</dt>
+                                                    <dd id="today-suggestion-portfolio" class="today-suggestion-stat-value">—</dd>
+                                                </div>
+                                            </dl>
+                                        </div>
                                         <div id="today-suggestion-notes-container" class="today-suggestion-notes hidden">
                                             <div class="today-suggestion-notes-title">備註</div>
                                             <ul id="today-suggestion-notes" class="today-suggestion-notes-list"></ul>
@@ -1179,6 +1207,28 @@
                             
                             <!-- Summary Tab -->
                             <div class="tab-content active space-y-6" id="summary-tab">
+                                <!-- Strategy Status Card -->
+                                <div class="card shadow-lg summary-card" id="strategy-status-card">
+                                    <div class="card-header pb-4">
+                                        <div class="space-y-2">
+                                            <div class="flex items-center gap-2">
+                                                <span id="strategy-status-badge" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-semibold tracking-wider uppercase" style="background-color: color-mix(in srgb, var(--muted) 28%, transparent); color: var(--muted-foreground);">等待開賽</span>
+                                                <span id="strategy-status-diff" class="text-xs font-semibold hidden" style="color: var(--muted-foreground);"></span>
+                                            </div>
+                                            <h3 id="strategy-status-title" class="text-lg font-semibold" style="color: var(--foreground);">策略戰況尚未更新</h3>
+                                            <p id="strategy-status-subtitle" class="text-xs leading-relaxed" style="color: var(--muted-foreground);">
+                                                完成回測後，這張戰報會綜合策略與買入持有的差距、指標體檢與建議行動，請優先回到此卡片檢視結果。
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <div class="card-content space-y-3">
+                                        <div id="strategy-status-detail" class="text-sm leading-relaxed space-y-2" style="color: var(--muted-foreground);">
+                                            <p>• 等待您啟動回測，我們會追蹤策略與買入持有的差距並提出指標體檢。</p>
+                                            <p>• 回測完成後，這裡會用條列式寫給散戶看的戰況懶人包。</p>
+                                        </div>
+                                    </div>
+                                </div>
+
                                 <!-- Chart Area -->
                                 <div class="card shadow-lg summary-card">
                                     <div class="card-header">
@@ -1192,7 +1242,22 @@
                                                 <p>執行回測後將顯示淨值曲線</p>
                                             </div>
                                         </div>
-                                        <div id="trend-legend" class="mt-4 grid gap-3 text-xs text-muted-foreground sm:grid-cols-3">
+                                        <div id="priceInspectorControls" class="mt-4 hidden flex flex-wrap items-center gap-2 justify-between sm:justify-start">
+                                            <button
+                                                type="button"
+                                                id="openPriceInspector"
+                                                class="px-3 py-1.5 text-[11px] font-medium rounded-md border transition-colors"
+                                                style="border-color: var(--border); color: var(--foreground); background-color: var(--background);"
+                                            >
+                                                查看區間價格
+                                            </button>
+                                            <span
+                                                id="priceInspectorSummary"
+                                                class="text-[11px] text-muted-foreground"
+                                                style="color: var(--muted-foreground);"
+                                            ></span>
+                                        </div>
+                                        <div id="trend-legend" class="mt-3 hidden flex flex-wrap items-center gap-3 text-xs text-muted-foreground" aria-hidden="true">
                                             <div class="flex items-center gap-2">
                                                 <span class="w-3 h-3 rounded-sm border" style="background-color: rgba(239, 68, 68, 0.2); border-color: rgba(239, 68, 68, 0.38);"></span>
                                                 <span>牛市・高波動</span>
@@ -1209,19 +1274,41 @@
                                     </div>
                                 </div>
 
-                                <div class="card shadow-lg summary-card" id="trend-analysis-card">
+                                <div class="card shadow-lg summary-card" id="trend-analysis-card" data-collapsed="true">
                                     <div class="card-header">
-                                        <div class="flex items-center justify-between gap-2">
-                                            <h3 class="card-title flex items-center gap-2">
+                                        <button
+                                            id="trendAnalysisToggle"
+                                            type="button"
+                                            class="w-full flex items-center justify-between gap-3 text-left"
+                                            aria-expanded="false"
+                                            aria-controls="trend-analysis-content"
+                                        >
+                                            <span class="card-title flex items-center gap-3">
+                                                <span class="trend-toggle-indicator" aria-hidden="true">＋</span>
                                                 <i data-lucide="line-chart" class="lucide-sm" aria-hidden="true"></i>
                                                 <span>趨勢區間評估</span>
-                                            </h3>
-                                        </div>
-                                        <p class="text-xs mt-2 leading-relaxed" style="color: var(--muted-foreground);">
+                                            </span>
+                                            <span class="text-xs text-muted-foreground" data-trend-toggle-label>展開分析</span>
+                                        </button>
+                                    </div>
+                                    <div id="trend-analysis-content" class="card-content space-y-4 hidden" aria-hidden="true">
+                                        <p class="text-xs leading-relaxed" style="color: var(--muted-foreground);">
                                             將價格序列拆成牛市・高波動、熊市・高波動與盤整三態，結合 ADX、布林帶寬與 ATR 比率作為趨勢／盤整門檻，並以二維 HMM 訓練趨勢狀態；滑桿 0→10 經 1000 組覆蓋率測試校準，可快速切換預設最佳值 5 附近的信心門檻，數值越高門檻越寬鬆、趨勢覆蓋越接近 80% 以上。
                                         </p>
-                                    </div>
-                                    <div class="card-content space-y-4">
+                                        <div id="trend-card-legend" class="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                                            <div class="flex items-center gap-2">
+                                                <span class="w-3 h-3 rounded-sm border" style="background-color: rgba(239, 68, 68, 0.2); border-color: rgba(239, 68, 68, 0.38);"></span>
+                                                <span>牛市・高波動</span>
+                                            </div>
+                                            <div class="flex items-center gap-2">
+                                                <span class="w-3 h-3 rounded-sm border" style="background-color: rgba(148, 163, 184, 0.18); border-color: rgba(148, 163, 184, 0.38);"></span>
+                                                <span>盤整區域</span>
+                                            </div>
+                                            <div class="flex items-center gap-2">
+                                                <span class="w-3 h-3 rounded-sm border" style="background-color: rgba(34, 197, 94, 0.2); border-color: rgba(34, 197, 94, 0.35);"></span>
+                                                <span>熊市・高波動</span>
+                                            </div>
+                                        </div>
                                         <div class="space-y-2">
                                             <div class="flex items-center justify-between">
                                                 <label for="trendSensitivitySlider" class="text-xs font-medium" style="color: var(--foreground);">狀態精細度</label>
@@ -1241,27 +1328,6 @@
                                         </div>
                                         <div id="trend-summary-meta" class="hidden text-[11px]" style="color: var(--muted-foreground);"></div>
                                         <div id="trend-summary-container" class="trend-summary-grid"></div>
-                                    </div>
-                                </div>
-
-                                <div class="card shadow-lg summary-card" id="strategy-status-card">
-                                    <div class="card-header pb-4">
-                                        <div class="space-y-2">
-                                            <div class="flex items-center gap-2">
-                                                <span id="strategy-status-badge" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-semibold tracking-wider uppercase" style="background-color: color-mix(in srgb, var(--muted) 28%, transparent); color: var(--muted-foreground);">等待開賽</span>
-                                                <span id="strategy-status-diff" class="text-xs font-semibold hidden" style="color: var(--muted-foreground);"></span>
-                                            </div>
-                                            <h3 id="strategy-status-title" class="text-lg font-semibold" style="color: var(--foreground);">策略戰況尚未更新</h3>
-                                            <p id="strategy-status-subtitle" class="text-xs leading-relaxed" style="color: var(--muted-foreground);">
-                                                回測完成後會立刻比對策略與買入持有，給您一份幽默但實用的戰況簡報。
-                                            </p>
-                                        </div>
-                                    </div>
-                                    <div class="card-content space-y-3">
-                                        <div id="strategy-status-detail" class="text-sm leading-relaxed space-y-2" style="color: var(--muted-foreground);">
-                                            <p>• 等待您啟動回測，我們會追蹤策略與買入持有的差距並提出指標體檢。</p>
-                                            <p>• 完成回測後，這裡會用條列式寫給散戶看的戰況懶人包。</p>
-                                        </div>
                                     </div>
                                 </div>
 

--- a/log.md
+++ b/log.md
@@ -1,3 +1,27 @@
+## 2025-11-06 — Patch LB-UI-TODAY-TREND-20251106A
+- **Scope**: 今日建議資訊層與趨勢圖例互動調整，優化行動訊息展示與小螢幕可讀性。
+- **Today Suggestion**:
+  - 改為以重點訊息填入原本價格欄位，保留第一則備註作為主體文案並同步寫入開發者紀錄。
+  - 調整 UI 控制，部位概況與錯誤時的提示仍預設折疊，載入狀態改顯示文字提醒；開發者紀錄摘要改以 highlight 訊息為主。
+- **Charts & Trend**:
+  - 趨勢區間評估按鈕將圓形「＋」指示器搬到標題前並新增狀態文字，僅在展開時顯示趨勢圖例且支援橫向捲動並排顯示於窄螢幕。
+- **Developer Tools**:
+  - 今日建議開發者 log 更新摘要欄位，優先顯示主體訊息並沿用 highlight 值於詳情段落。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
+## 2025-10-30 — Patch LB-UI-REFRESH-20251030A
+- **Scope**: 主頁版面與診斷工具整體調整，強化敏感度與今日建議的可讀性與互動設計。
+- **UI**:
+  - 策略戰報卡移至淨值曲線圖上方，並更新導引文案提醒使用者回測完成後優先查看戰報。
+  - 今日建議改為以備註摘要取代價格文字，新增部位概況摺疊按鈕並預設收合，同時讓今日建議記錄面板改為預設摺疊。
+  - 將區間價格檢視按鈕搬移至淨值卡片下方；市場下拉選單移除英文代碼；資料來源資訊改至開發者區塊顯示。
+- **Charts & Analytics**:
+  - 趨勢區間評估卡改為「＋」圓形按鈕控制的摺疊模式，開啟時同步顯示淨值底色圖例；淨值圖例支援小螢幕並僅在趨勢卡展開時顯示。
+  - 敏感度分析在「如何解讀」段落後新增摺疊控制，預設收合所有表格內容。
+- **Diagnostics**:
+  - Blob 監控新增寫入摘要卡，揭露本月寫入次數與最近寫入事件；資料來源卡支援顯示主來源與命中資訊。
+- **Testing**: `node - <<'NODE' ...` 檢查主要腳本語法無誤（同既有回歸命令）。
+
 ## 2025-09-12 — Patch LB-TODAY-SUGGESTION-FINALEVAL-RETURN-20250912A
 - **Issue recap**: 今日建議持續回傳 `no_data`，追查後發現 `runStrategy` 在建構回傳物件時直接 `return { ... }`，導致 `captureFinalState` 模式下的 `finalEvaluation` 永遠未附加，Worker 因而判定今日缺乏最終評估。
 - **Fix**: 將 `runStrategy` 的回傳流程改為建立 `result` 物件後再附加 `finalEvaluation` 與傳回，確保主執行緒能取得最終評估快照並推導當日建議。


### PR DESCRIPTION
## Summary
- move the strategy war report card above the equity chart and refresh the onboarding copy
- collapse developer and today suggestion panels by default, migrate data source details, and add blob write monitoring
- gate the trend legend behind the trend card, relocate price inspector controls, and add a collapsible sensitivity analysis section

## Testing
- `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`


------
https://chatgpt.com/codex/tasks/task_e_68d5e63ea7a88324a0c05e3dc96d8597