### PR TITLE
Reuse shared worker for batch optimization sweeps

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,3 +1,8 @@
+## 2025-11-10 — Patch LB-BATCH-OPT-SHAREDWORKER-20251110A
+- **Issue recap**: 批量參數優化與交叉優化流程為每組參數重新建立 Web Worker，導致快取資料被捨棄、重複抓取歷史股價並拉長執行時間。
+- **Fix**: 新增共享 Worker 佇列控制器重用同一個 Worker 實例，並改寫批量回測、單參數／風險參數優化與交叉優化回測流程，統一透過佇列派工與回收快取資料。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/batch-optimization.js','js/worker.js','js/main.js','js/backtest.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
 ## 2025-11-10 — Patch LB-TREND-STATE-20251110A
 - **Issue recap**: Patch `LB-UI-SUMMARY-FOCUS-20251109A` 將趨勢評估狀態重設為僅保留日期與策略報酬，使 `recomputeTrendAnalysis` 重新整理時喪失 `rawData` 而覆寫基礎資料，導致初次回測後趨勢區間卡片顯示空白。
 - **Fix**: 新增 `captureTrendAnalysisSource` 將回測結果所需欄位（日期、策略報酬與原始價格）完整封裝，並在趨勢分析重算時保留既有基礎資料，避免再度覆寫為空值。


### PR DESCRIPTION
## Summary
- introduce a shared optimization worker controller so parameter searches reuse a single worker instance and cached datasets
- update batch, risk, and cross-optimization routines to route through the shared worker queue and dispose it when stopping
- document patch LB-BATCH-OPT-SHAREDWORKER-20251110A in log.md

## Testing
- node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/batch-optimization.js','js/worker.js','js/main.js','js/backtest.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68d637db4d1c8324876d04eb4190281a