### PR TITLE
feat: allow editing the quick backtest target

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,67 @@
 /* --- 自訂 CSS --- */
+.quick-backtest-editable {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    min-width: 4.5ch;
+    padding: 0 0.1rem;
+    margin: 0 0.15rem;
+    border-bottom: 2px solid currentColor;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    outline: none;
+    cursor: text;
+    transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.quick-backtest-editable:focus {
+    color: var(--primary-foreground);
+    background-color: color-mix(in srgb, var(--primary) 18%, transparent);
+    border-color: currentColor;
+}
+
+.quick-backtest-editable:empty::before {
+    content: attr(data-placeholder);
+    font-weight: 500;
+    color: color-mix(in srgb, var(--primary-foreground) 65%, transparent);
+    letter-spacing: normal;
+}
+
+.quick-backtest-editable[aria-invalid="true"] {
+    color: var(--destructive);
+    border-color: var(--destructive);
+}
+
+.quick-backtest-caret {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0.2rem;
+    font-weight: 800;
+    font-size: 0.95em;
+    color: currentColor;
+    animation: quickCaretBlink 1.15s steps(2, jump-none) infinite;
+}
+
+.quick-backtest-caret.is-hidden {
+    opacity: 0;
+    animation: none;
+}
+
+@keyframes quickCaretBlink {
+    0%, 48% {
+        opacity: 1;
+    }
+    52%, 100% {
+        opacity: 0;
+    }
+}
+
+.quick-backtest-hint {
+    font-size: 0.75rem;
+    color: var(--muted-foreground);
+}
+
 .tooltip { position: relative; display: inline-block; vertical-align: middle; }
 .tooltip .tooltiptext { visibility: hidden; width: 250px; background-color: #333; color: #fff; text-align: left; border-radius: 6px; padding: 10px; position: absolute; z-index: 50; bottom: 135%; left: 50%; transform: translateX(-50%); opacity: 0; transition: opacity 0.3s; font-size: 13px; line-height: 1.5; pointer-events: none; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
 .tooltip:hover .tooltiptext { visibility: visible; opacity: 1; }

--- a/css/style.css
+++ b/css/style.css
@@ -14,6 +14,8 @@
     letter-spacing: 0.02em;
     line-height: 1.2;
     white-space: nowrap;
+    text-align: center;
+    text-align-last: center;
     outline: none;
     cursor: text;
     transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
@@ -31,6 +33,9 @@
     font-weight: 500;
     color: color-mix(in srgb, var(--primary-foreground) 65%, transparent);
     letter-spacing: normal;
+    display: block;
+    text-align: center;
+    width: 100%;
 }
 
 .quick-backtest-editable[aria-invalid="true"] {

--- a/css/style.css
+++ b/css/style.css
@@ -3,21 +3,27 @@
     position: relative;
     display: inline-flex;
     align-items: center;
-    min-width: 4.5ch;
-    padding: 0 0.1rem;
-    margin: 0 0.15rem;
+    justify-content: center;
+    flex-shrink: 0;
+    min-width: clamp(8ch, 10vw, 16ch);
+    min-height: 2.1rem;
+    padding: 0.25rem 0.55rem 0.35rem;
+    margin: 0 0.4rem;
     border-bottom: 2px solid currentColor;
     font-weight: 700;
     letter-spacing: 0.02em;
+    line-height: 1.2;
+    white-space: nowrap;
     outline: none;
     cursor: text;
-    transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+    transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .quick-backtest-editable:focus {
     color: var(--primary-foreground);
-    background-color: color-mix(in srgb, var(--primary) 18%, transparent);
+    background-color: color-mix(in srgb, var(--primary) 22%, transparent);
     border-color: currentColor;
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--primary) 45%, transparent);
 }
 
 .quick-backtest-editable:empty::before {

--- a/css/style.css
+++ b/css/style.css
@@ -38,18 +38,19 @@
     border-color: var(--destructive);
 }
 
-.quick-backtest-caret {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    margin-left: 0.2rem;
+.quick-backtest-editable::after {
+    content: '▏';
+    display: inline-block;
     font-weight: 800;
     font-size: 0.95em;
     color: currentColor;
+    margin-left: -0.02em;
+    pointer-events: none;
+    user-select: none;
     animation: quickCaretBlink 1.15s steps(2, jump-none) infinite;
 }
 
-.quick-backtest-caret.is-hidden {
+.quick-backtest-editable[data-caret-hidden="true"]::after {
     opacity: 0;
     animation: none;
 }

--- a/index.html
+++ b/index.html
@@ -390,7 +390,7 @@
                                     data-state="idle"
                                 >
                                     <i data-lucide="zap" class="lucide mr-3"></i>
-                                    <span id="quickBacktestDefaultLabel" class="flex items-center">
+                                    <span id="quickBacktestDefaultLabel" class="flex items-center gap-2">
                                         一鍵回測
                                         <span
                                             id="quickBacktestKeyword"

--- a/index.html
+++ b/index.html
@@ -403,7 +403,6 @@
                                             tabindex="0"
                                             data-placeholder="輸入股票或代碼"
                                         >台積電</span>
-                                        <span id="quickBacktestCaret" class="quick-backtest-caret" aria-hidden="true">▏</span>
                                     </span>
                                     <span id="quickBacktestStatusText" class="hidden items-center gap-2 text-base font-semibold"></span>
                                 </button>
@@ -2108,10 +2107,9 @@
             }
             
             // 一鍵回測台積電功能
-            const QUICK_BACKTEST_VERSION = 'LB-QUICK-KEYIN-20251112A';
+            const QUICK_BACKTEST_VERSION = 'LB-QUICK-KEYIN-20251114A';
             const quickBacktestBtn = document.getElementById('quickBacktestBtn');
             const quickBacktestKeywordEl = document.getElementById('quickBacktestKeyword');
-            const quickBacktestCaretEl = document.getElementById('quickBacktestCaret');
             const quickBacktestDefaultLabelEl = document.getElementById('quickBacktestDefaultLabel');
             const quickBacktestStatusTextEl = document.getElementById('quickBacktestStatusText');
             const quickBacktestHintEl = document.getElementById('quickBacktestHint');
@@ -2139,11 +2137,11 @@
                 };
 
                 const setCaretVisibility = (isHidden) => {
-                    if (!quickBacktestCaretEl) return;
+                    if (!quickBacktestKeywordEl) return;
                     if (isHidden) {
-                        quickBacktestCaretEl.classList.add('is-hidden');
+                        quickBacktestKeywordEl.setAttribute('data-caret-hidden', 'true');
                     } else {
-                        quickBacktestCaretEl.classList.remove('is-hidden');
+                        quickBacktestKeywordEl.removeAttribute('data-caret-hidden');
                     }
                 };
 

--- a/index.html
+++ b/index.html
@@ -386,9 +386,26 @@
                                     id="quickBacktestBtn"
                                     class="btn-primary px-8 py-4 text-lg font-semibold rounded-lg transition duration-150 ease-in-out flex items-center justify-center"
                                     style="background-color: var(--primary); color: var(--primary-foreground); border: 1px solid var(--primary);"
+                                    aria-label="一鍵回測台積電（可編輯）"
+                                    data-state="idle"
                                 >
                                     <i data-lucide="zap" class="lucide mr-3"></i>
-                                    一鍵回測台積電
+                                    <span id="quickBacktestDefaultLabel" class="flex items-center">
+                                        一鍵回測
+                                        <span
+                                            id="quickBacktestKeyword"
+                                            class="quick-backtest-editable"
+                                            contenteditable="true"
+                                            spellcheck="false"
+                                            role="textbox"
+                                            aria-live="polite"
+                                            aria-label="輸入想回測的股票名稱或代碼"
+                                            tabindex="0"
+                                            data-placeholder="輸入股票或代碼"
+                                        >台積電</span>
+                                        <span id="quickBacktestCaret" class="quick-backtest-caret" aria-hidden="true">▏</span>
+                                    </span>
+                                    <span id="quickBacktestStatusText" class="hidden items-center gap-2 text-base font-semibold"></span>
                                 </button>
 
                                 <button
@@ -403,6 +420,10 @@
                                     開發者區域
                                 </button>
                             </div>
+
+                            <p id="quickBacktestHint" class="quick-backtest-hint text-center sm:text-left">
+                                將使用 2330（台積電）進行一鍵回測。
+                            </p>
 
                             <div
                                 id="developerAreaWrapper"
@@ -2087,49 +2108,395 @@
             }
             
             // 一鍵回測台積電功能
+            const QUICK_BACKTEST_VERSION = 'LB-QUICK-KEYIN-20251112A';
             const quickBacktestBtn = document.getElementById('quickBacktestBtn');
-            if (quickBacktestBtn) {
-                let originalButtonContent = quickBacktestBtn.innerHTML;
-                let progressInterval;
+            const quickBacktestKeywordEl = document.getElementById('quickBacktestKeyword');
+            const quickBacktestCaretEl = document.getElementById('quickBacktestCaret');
+            const quickBacktestDefaultLabelEl = document.getElementById('quickBacktestDefaultLabel');
+            const quickBacktestStatusTextEl = document.getElementById('quickBacktestStatusText');
+            const quickBacktestHintEl = document.getElementById('quickBacktestHint');
+
+            if (quickBacktestBtn && quickBacktestKeywordEl && quickBacktestStatusTextEl) {
+                const QUICK_DEFAULT = { keyword: '台積電', code: '2330', market: 'TWSE', name: '台積電' };
+                const quickBacktestState = {
+                    keyword: QUICK_DEFAULT.keyword,
+                    resolution: { code: QUICK_DEFAULT.code, market: QUICK_DEFAULT.market, name: QUICK_DEFAULT.name },
+                };
+                let progressInterval = null;
                 let currentProgress = 0;
-                
-                quickBacktestBtn.addEventListener('click', function() {
-                    // 禁用按鈕並改變樣式
-                    quickBacktestBtn.disabled = true;
-                    quickBacktestBtn.style.opacity = '0.7';
-                    currentProgress = 0;
-                    
-                    // 更新按鈕內容為回測中狀態
-                    const updateProgress = () => {
-                        currentProgress += Math.random() * 15 + 5; // 隨機增加 5-20%
-                        if (currentProgress > 95) currentProgress = 95; // 最多到 95%
-                        
-                        quickBacktestBtn.innerHTML = `
+
+                const refreshLucideIcons = () => {
+                    if (typeof lucide !== 'undefined') {
+                        lucide.createIcons();
+                    }
+                };
+
+                const refreshButtonLabel = () => {
+                    quickBacktestBtn.setAttribute(
+                        'aria-label',
+                        `一鍵回測${quickBacktestState.keyword || QUICK_DEFAULT.keyword}（可編輯）`
+                    );
+                };
+
+                const setCaretVisibility = (isHidden) => {
+                    if (!quickBacktestCaretEl) return;
+                    if (isHidden) {
+                        quickBacktestCaretEl.classList.add('is-hidden');
+                    } else {
+                        quickBacktestCaretEl.classList.remove('is-hidden');
+                    }
+                };
+
+                const sanitizeQuickKeyword = (raw) => {
+                    if (typeof raw !== 'string') return '';
+                    return raw
+                        .replace(/[\n\r\t]+/g, ' ')
+                        .replace(/\u00A0/g, ' ')
+                        .replace(/\s{2,}/g, ' ')
+                        .trim()
+                        .slice(0, 18);
+                };
+
+                const toggleButtonState = (state, options = {}) => {
+                    quickBacktestBtn.dataset.state = state;
+                    if (state === 'idle') {
+                        quickBacktestBtn.disabled = false;
+                        quickBacktestBtn.style.opacity = '1';
+                        quickBacktestStatusTextEl.classList.add('hidden');
+                        if (quickBacktestDefaultLabelEl) {
+                            quickBacktestDefaultLabelEl.classList.remove('hidden');
+                        }
+                        quickBacktestStatusTextEl.innerHTML = '';
+                        refreshLucideIcons();
+                        return;
+                    }
+
+                    if (state === 'progress') {
+                        quickBacktestBtn.disabled = true;
+                        quickBacktestBtn.style.opacity = '0.7';
+                        if (quickBacktestDefaultLabelEl) {
+                            quickBacktestDefaultLabelEl.classList.add('hidden');
+                        }
+                        quickBacktestStatusTextEl.classList.remove('hidden');
+                        const progressText = Math.round(options.progress ?? 0);
+                        quickBacktestStatusTextEl.innerHTML = `
                             <i data-lucide="loader-2" class="lucide mr-3 animate-spin"></i>
-                            回測中...${Math.round(currentProgress)}%
+                            回測中...${progressText}%
                         `;
-                        
-                        // 重新初始化圖標
-                        if (typeof lucide !== 'undefined') {
-                            lucide.createIcons();
+                        refreshLucideIcons();
+                        return;
+                    }
+
+                    if (state === 'success') {
+                        quickBacktestBtn.disabled = false;
+                        quickBacktestBtn.style.opacity = '1';
+                        if (quickBacktestDefaultLabelEl) {
+                            quickBacktestDefaultLabelEl.classList.add('hidden');
+                        }
+                        quickBacktestStatusTextEl.classList.remove('hidden');
+                        const message = options.message || '完成！請看下面績效表現';
+                        quickBacktestStatusTextEl.innerHTML = `
+                            <i data-lucide="check-circle" class="lucide mr-3"></i>
+                            ${message}
+                        `;
+                        refreshLucideIcons();
+                        return;
+                    }
+
+                    if (state === 'error') {
+                        quickBacktestBtn.disabled = false;
+                        quickBacktestBtn.style.opacity = '1';
+                        if (quickBacktestDefaultLabelEl) {
+                            quickBacktestDefaultLabelEl.classList.remove('hidden');
+                        }
+                        quickBacktestStatusTextEl.classList.add('hidden');
+                        quickBacktestStatusTextEl.innerHTML = '';
+                        refreshLucideIcons();
+                    }
+                };
+
+                const updateHintDisplay = (resolution) => {
+                    if (!quickBacktestHintEl) return;
+                    if (resolution && resolution.code) {
+                        const marketLabel = resolution.market && typeof getMarketDisplayName === 'function'
+                            ? getMarketDisplayName(resolution.market)
+                            : resolution.market || '';
+                        const marketText = marketLabel ? `（${marketLabel}）` : '';
+                        const displayName = resolution.name
+                            ? resolution.name
+                            : (resolution.code !== quickBacktestState.keyword ? quickBacktestState.keyword : '');
+                        const nameText = displayName ? `（${displayName}）` : '';
+                        quickBacktestHintEl.textContent = `將使用 ${resolution.code}${nameText}${marketText}進行一鍵回測。`;
+                        quickBacktestHintEl.dataset.status = 'resolved';
+                    } else {
+                        quickBacktestHintEl.textContent = `找不到「${quickBacktestState.keyword}」對應的官方代碼，將以原文字嘗試回測。`;
+                        quickBacktestHintEl.dataset.status = 'unresolved';
+                    }
+                };
+
+                const setStockInputValue = (stockCode, options = {}) => {
+                    const stockInput = document.getElementById('stockNo');
+                    if (!stockInput) return;
+                    const normalized = options.keepCase
+                        ? (stockCode || '').trim()
+                        : (stockCode || '').trim().toUpperCase();
+                    if (!normalized) return;
+                    if (stockInput.value.trim() === normalized) return;
+                    stockInput.value = normalized;
+                    stockInput.dispatchEvent(new Event('input', { bubbles: true }));
+                };
+
+                const updateMarketSelect = (market) => {
+                    if (!market) return;
+                    const marketSelect = document.getElementById('marketSelect');
+                    if (!marketSelect) return;
+                    if (marketSelect.value === market) return;
+                    marketSelect.value = market;
+                    marketSelect.dispatchEvent(new Event('change', { bubbles: true }));
+                };
+
+                const detectDirectStockCode = (keyword) => {
+                    const raw = (keyword || '').trim();
+                    if (!raw) return null;
+                    const upper = raw.toUpperCase();
+                    if (/^\d{4}$/.test(upper)) {
+                        return { code: upper, market: 'TWSE' };
+                    }
+                    if (/^\d{5,6}$/.test(upper)) {
+                        return { code: upper, market: upper.startsWith('00') ? 'TWSE' : null };
+                    }
+                    if (/^\d{4}[A-Z]$/.test(upper)) {
+                        return { code: upper, market: null };
+                    }
+                    if (/^[A-Z]{1,6}(?:\.[A-Z]{1,3}|-[A-Z]{1,2})?$/.test(upper)) {
+                        return { code: upper, market: 'US' };
+                    }
+                    return null;
+                };
+
+                const resolveKeywordToStock = async (keyword) => {
+                    const trimmed = (keyword || '').trim();
+                    if (!trimmed) {
+                        return { ...QUICK_DEFAULT };
+                    }
+
+                    const direct = detectDirectStockCode(trimmed);
+                    if (direct) {
+                        const cached = typeof resolveCachedStockNameInfo === 'function'
+                            ? resolveCachedStockNameInfo(direct.code, direct.market)
+                            : null;
+                        return {
+                            code: direct.code,
+                            market: cached?.market || direct.market || null,
+                            name: cached?.info?.name || null,
+                        };
+                    }
+
+                    if (trimmed.length < 2) {
+                        return null;
+                    }
+
+                    const tokens = trimmed
+                        .replace(/[，、,]+/g, ' ')
+                        .split(/\s+/)
+                        .map((token) => token.trim())
+                        .filter(Boolean);
+
+                    if (tokens.length === 0) {
+                        return null;
+                    }
+
+                    if (typeof ensureTaiwanDirectoryReady === 'function') {
+                        try {
+                            await ensureTaiwanDirectoryReady({});
+                        } catch (error) {
+                            console.warn(`[${QUICK_BACKTEST_VERSION}] 台股官方清單載入失敗:`, error);
+                        }
+                    }
+
+                    const directoryEntries = (typeof taiwanDirectoryState !== 'undefined'
+                        && taiwanDirectoryState.entries instanceof Map)
+                        ? Array.from(taiwanDirectoryState.entries.values())
+                        : [];
+
+                    let bestMatch = null;
+                    for (const entry of directoryEntries) {
+                        if (!entry || !entry.name || !entry.stockId) continue;
+                        const entryName = entry.name;
+                        const normalizedName = entryName.replace(/\s+/g, '');
+                        const upperId = entry.stockId.toUpperCase();
+                        let score = 0;
+                        for (const token of tokens) {
+                            const upperToken = token.toUpperCase();
+                            if (upperId.includes(upperToken)) {
+                                score += 6;
+                            }
+                            if (entryName.includes(token)) {
+                                score += entryName.startsWith(token) ? 6 : 4;
+                            } else if (normalizedName.includes(token)) {
+                                score += 3;
+                            }
+                        }
+                        if (score > 0) {
+                            if (!bestMatch || score > bestMatch.score || (
+                                score === bestMatch.score
+                                && upperId < bestMatch.entry.stockId
+                            )) {
+                                bestMatch = { entry, score };
+                            }
+                        }
+                    }
+
+                    if (!bestMatch) {
+                        return null;
+                    }
+
+                    return {
+                        code: bestMatch.entry.stockId,
+                        market: bestMatch.entry.market || null,
+                        name: bestMatch.entry.name || null,
+                    };
+                };
+
+                const commitQuickKeyword = async (options = {}) => {
+                    const rawValue = quickBacktestKeywordEl.textContent || '';
+                    const sanitized = sanitizeQuickKeyword(rawValue);
+                    if (sanitized !== rawValue) {
+                        quickBacktestKeywordEl.textContent = sanitized;
+                    }
+                    const keyword = sanitized || QUICK_DEFAULT.keyword;
+                    if (!sanitized) {
+                        quickBacktestKeywordEl.textContent = QUICK_DEFAULT.keyword;
+                    }
+                    quickBacktestState.keyword = keyword;
+                    refreshButtonLabel();
+
+                    const resolution = await resolveKeywordToStock(keyword);
+                    if (resolution && resolution.code) {
+                        quickBacktestState.resolution = resolution;
+                        quickBacktestKeywordEl.removeAttribute('aria-invalid');
+                        updateHintDisplay(resolution);
+                        setStockInputValue(resolution.code);
+                        updateMarketSelect(resolution.market);
+                        return resolution;
+                    }
+
+                    quickBacktestState.resolution = { code: null, market: null, name: null };
+                    quickBacktestKeywordEl.setAttribute('aria-invalid', 'true');
+                    updateHintDisplay(null);
+                    setStockInputValue(keyword, { keepCase: true });
+                    if (!options.silent && typeof showStockName === 'function') {
+                        showStockName(`找不到「${keyword}」對應的代碼`, 'error');
+                    }
+                    return null;
+                };
+
+                const startProgressCycle = () => {
+                    currentProgress = 0;
+                    toggleButtonState('progress', { progress: currentProgress });
+                    if (progressInterval) {
+                        clearInterval(progressInterval);
+                    }
+                    progressInterval = setInterval(() => {
+                        currentProgress += Math.random() * 15 + 5;
+                        if (currentProgress > 95) {
+                            currentProgress = 95;
+                        }
+                        toggleButtonState('progress', { progress: currentProgress });
+                    }, 800);
+                };
+
+                const stopProgressCycle = () => {
+                    if (progressInterval) {
+                        clearInterval(progressInterval);
+                        progressInterval = null;
+                    }
+                };
+
+                const scheduleCompletionWatcher = () => {
+                    const checkBacktestComplete = () => {
+                        const resultElement = document.getElementById('backtest-result');
+                        if (resultElement && resultElement.textContent.trim() !== '執行回測後將顯示詳細結果') {
+                            stopProgressCycle();
+                            toggleButtonState('success');
+                            setTimeout(() => {
+                                toggleButtonState('idle');
+                            }, 3000);
+                        } else {
+                            setTimeout(checkBacktestComplete, 500);
                         }
                     };
-                    
-                    // 立即顯示進度並開始定期更新
-                    updateProgress();
-                    progressInterval = setInterval(updateProgress, 800);
-                    
-                    // 設定台積電的默認參數
-                    const stockInput = document.getElementById('stockInput');
-                    if (stockInput) {
-                        stockInput.value = '2330';
+                    setTimeout(checkBacktestComplete, 1800);
+                };
+
+                quickBacktestKeywordEl.addEventListener('focus', () => {
+                    setCaretVisibility(true);
+                });
+
+                quickBacktestKeywordEl.addEventListener('blur', () => {
+                    setCaretVisibility(false);
+                    commitQuickKeyword({ silent: true });
+                });
+
+                quickBacktestKeywordEl.addEventListener('keydown', (event) => {
+                    event.stopPropagation();
+                    if (event.key === 'Enter') {
+                        event.preventDefault();
+                        quickBacktestKeywordEl.blur();
                     }
-                    
-                    // 設定默認日期範圍（最近一年）
+                });
+
+                quickBacktestKeywordEl.addEventListener('input', () => {
+                    const sanitized = sanitizeQuickKeyword(quickBacktestKeywordEl.textContent || '');
+                    if (quickBacktestKeywordEl.textContent !== sanitized) {
+                        quickBacktestKeywordEl.textContent = sanitized;
+                        const range = document.createRange();
+                        range.selectNodeContents(quickBacktestKeywordEl);
+                        range.collapse(false);
+                        const selection = window.getSelection();
+                        selection.removeAllRanges();
+                        selection.addRange(range);
+                    }
+                    quickBacktestState.keyword = sanitized || QUICK_DEFAULT.keyword;
+                    refreshButtonLabel();
+                });
+
+                quickBacktestKeywordEl.addEventListener('paste', (event) => {
+                    event.preventDefault();
+                    const text = sanitizeQuickKeyword((event.clipboardData || window.clipboardData).getData('text') || '');
+                    const selection = window.getSelection();
+                    if (!selection || selection.rangeCount === 0) return;
+                    const range = selection.getRangeAt(0);
+                    range.deleteContents();
+                    range.insertNode(document.createTextNode(text));
+                    range.collapse(false);
+                    quickBacktestKeywordEl.dispatchEvent(new Event('input'));
+                });
+
+                quickBacktestKeywordEl.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                });
+
+                quickBacktestBtn.addEventListener('click', async () => {
+                    if (quickBacktestBtn.dataset.state === 'progress') {
+                        return;
+                    }
+
+                    stopProgressCycle();
+                    await commitQuickKeyword({ silent: false });
+                    const stockInput = document.getElementById('stockNo');
+                    const targetCode = stockInput ? stockInput.value.trim() : '';
+                    if (!targetCode) {
+                        toggleButtonState('error');
+                        return;
+                    }
+
+                    startProgressCycle();
+
                     const endDate = new Date();
                     const startDate = new Date();
                     startDate.setFullYear(endDate.getFullYear() - 1);
-                    
+
                     const startDateInput = document.getElementById('startDate');
                     const endDateInput = document.getElementById('endDate');
                     if (startDateInput) {
@@ -2138,63 +2505,28 @@
                     if (endDateInput) {
                         endDateInput.value = endDate.toISOString().split('T')[0];
                     }
-                    
-                    // 監聽回測完成事件
-                    const checkBacktestComplete = () => {
-                        const resultElement = document.getElementById('backtest-result');
-                        const tradeResultsElement = document.getElementById('trade-results');
-                        
-                        // 檢查是否有結果顯示（簡單檢查文本內容是否改變）
-                        if (resultElement && resultElement.textContent.trim() !== '執行回測後將顯示詳細結果') {
-                            // 回測完成
-                            clearInterval(progressInterval);
-                            
-                            // 顯示完成狀態
-                            quickBacktestBtn.innerHTML = `
-                                <i data-lucide="check-circle" class="lucide mr-3"></i>
-                                完成！請看下面績效表現
-                            `;
-                            
-                            // 重新初始化圖標
-                            if (typeof lucide !== 'undefined') {
-                                lucide.createIcons();
-                            }
-                            
-                            // 3秒後恢復原始狀態
-                            setTimeout(() => {
-                                quickBacktestBtn.innerHTML = originalButtonContent;
-                                quickBacktestBtn.disabled = false;
-                                quickBacktestBtn.style.opacity = '1';
-                                if (typeof lucide !== 'undefined') {
-                                    lucide.createIcons();
-                                }
-                            }, 3000);
-                            
-                        } else {
-                            // 繼續檢查
-                            setTimeout(checkBacktestComplete, 500);
-                        }
-                    };
-                    
-                    // 觸發回測
+
                     const backtestBtn = document.getElementById('backtestBtn');
                     if (backtestBtn) {
-                        // 滾動到左邊畫面的開始回測按鈕
-                        backtestBtn.scrollIntoView({ 
-                            behavior: 'smooth', 
+                        backtestBtn.scrollIntoView({
+                            behavior: 'smooth',
                             block: 'center',
                             inline: 'nearest'
                         });
-                        
-                        // 稍微延遲後觸發回測，確保滾動完成
                         setTimeout(() => {
                             backtestBtn.click();
+                            scheduleCompletionWatcher();
                         }, 800);
-                        
-                        // 開始檢查回測狀態
-                        setTimeout(checkBacktestComplete, 1800);
+                    } else {
+                        stopProgressCycle();
+                        toggleButtonState('idle');
                     }
                 });
+
+                // 初始化提示與輸入框狀態
+                quickBacktestKeywordEl.textContent = QUICK_DEFAULT.keyword;
+                refreshButtonLabel();
+                updateHintDisplay(quickBacktestState.resolution);
             }
             
             // Tab switching functionality with updated design

--- a/log.md
+++ b/log.md
@@ -657,3 +657,9 @@
 - **Fix**: 在按鈕內嵌可編輯欄位與閃爍光標，支援即時輸入並透過台股官方清單比對關鍵字，自動更新股票代碼與市場設定；回測進度改以狀態區塊呈現避免破壞可編輯元件，同步新增提示文案。
 - **Diagnostics**: 驗證 `resolveKeywordToStock` 能對照台股清單並回傳市場資訊，`updateHintDisplay` 會顯示最終代碼與名稱；測試清空、中文名稱、台/美股代碼皆能更新 `#stockNo` 並觸發名稱查詢。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
+## 2025-11-13 — Patch LB-QUICK-KEYIN-20251113A
+- **Issue recap**: 一鍵回測按鈕內的可編輯區域仍偏窄，行動裝置上難以察覺可點擊範圍，亦容易誤觸其他按鈕。
+- **Fix**: 擴大可編輯區最小寬度與高度、補強內距與間距並加入聚焦陰影，確保輸入區塊在桌機與手機皆有明確點擊範圍，同時調整預設標籤間距。
+- **Diagnostics**: 本地檢視首頁 Hero 區塊確認輸入欄位維持底線樣式但寬度顯著放大，聚焦時顯示色塊與陰影提示，光標與提示文案位置穩定。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`

--- a/log.md
+++ b/log.md
@@ -651,3 +651,9 @@
 - **Fix**: 保留上一輪趨勢原始資料快照並在缺少 `rawData` 時回填，`prepareRegimeBaseData` 支援使用快照與既有基礎資料，確保重新回測仍能以同一組 HMM 輸入校準；滑桿預設值因此穩定映射到最佳平均信心。
 - **Diagnostics**: 多次以相同標的重跑確認 `trendAnalysisState.calibration.bestSlider` 與預設值維持一致，且 `captureTrendAnalysisSource` 在缺資料時會沿用同日期序列的上一版快照。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
+## 2025-11-12 — Patch LB-QUICK-KEYIN-20251112A
+- **Issue recap**: 首頁「一鍵回測台積電」按鈕文字固定且無輸入提示，使用者難以察覺可替換標的；就算輸入其他名稱也無法同步至代碼欄，回測仍鎖在 2330。
+- **Fix**: 在按鈕內嵌可編輯欄位與閃爍光標，支援即時輸入並透過台股官方清單比對關鍵字，自動更新股票代碼與市場設定；回測進度改以狀態區塊呈現避免破壞可編輯元件，同步新增提示文案。
+- **Diagnostics**: 驗證 `resolveKeywordToStock` 能對照台股清單並回傳市場資訊，`updateHintDisplay` 會顯示最終代碼與名稱；測試清空、中文名稱、台/美股代碼皆能更新 `#stockNo` 並觸發名稱查詢。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`

--- a/log.md
+++ b/log.md
@@ -663,3 +663,9 @@
 - **Fix**: 擴大可編輯區最小寬度與高度、補強內距與間距並加入聚焦陰影，確保輸入區塊在桌機與手機皆有明確點擊範圍，同時調整預設標籤間距。
 - **Diagnostics**: 本地檢視首頁 Hero 區塊確認輸入欄位維持底線樣式但寬度顯著放大，聚焦時顯示色塊與陰影提示，光標與提示文案位置穩定。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
+## 2025-11-14 — Patch LB-QUICK-KEYIN-20251114A
+- **Issue recap**: 快捷回測輸入欄的閃爍指示仍位於底線之外，使用者無法直覺理解「台積電」三字可自訂，亦與底線分離造成視覺跳動。
+- **Fix**: 改以可編輯欄位的偽元素呈現插入符號，讓光標緊貼關鍵字結尾並隨聚焦狀態自動隱藏，維持底線整體性且避免額外節點。
+- **Diagnostics**: 在桌機與行動版檢視英雄區，確認未聚焦時插入符號緊貼最後一字且共享底線，聚焦後交還原生輸入游標、失焦時恢復動畫。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`

--- a/log.md
+++ b/log.md
@@ -669,3 +669,9 @@
 - **Fix**: 改以可編輯欄位的偽元素呈現插入符號，讓光標緊貼關鍵字結尾並隨聚焦狀態自動隱藏，維持底線整體性且避免額外節點。
 - **Diagnostics**: 在桌機與行動版檢視英雄區，確認未聚焦時插入符號緊貼最後一字且共享底線，聚焦後交還原生輸入游標、失焦時恢復動畫。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
+## 2025-11-15 — Patch LB-QUICK-KEYIN-20251115A
+- **Issue recap**: 快捷回測預設範例「台積電」與使用者輸入在底線區塊內偏向左側，未能直觀呈現可編輯範圍的中心位置。
+- **Fix**: 將可編輯區設定為置中對齊並同步調整空狀態的提示對齊方式，確保範例字與使用者輸入皆落在底線中央。
+- **Diagnostics**: 在桌機與行動尺寸檢視英雄區，確認輸入框於不同字數與清空狀態下都維持置中排版且光標與底線對齊。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`


### PR DESCRIPTION
## Summary
- embed an editable keyword, caret indicator, and stateful status label inside the quick backtest CTA so users can change the target and see progress without losing the input
- add styling for the inline editor and helper hint to clarify that the keyword is modifiable
- record patch LB-QUICK-KEYIN-20251112A in the changelog

## Testing
- `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`


------
https://chatgpt.com/codex/tasks/task_e_68d61fb380fc8324bea0e3ef4d07f50a