### PR TITLE
Fix trade record entry price calculation

### DIFF
--- a/js/worker.js
+++ b/js/worker.js
@@ -5781,22 +5781,36 @@ function runStrategy(data, params, options = {}) {
     const buildAggregatedLongEntry = () => {
       if (currentLongEntryBreakdown.length === 0) return null;
       const totalShares = currentLongEntryBreakdown.reduce(
-        (sum, info) => sum + (info.shares || 0),
+        (sum, info) => sum + (info.originalShares || info.shares || 0),
         0,
       );
       const totalPercent = currentLongEntryBreakdown.reduce(
         (sum, info) => sum + (info.allocationPercent || 0),
         0,
       );
+      const totalCostWithFee = currentLongEntryBreakdown.reduce(
+        (sum, info) =>
+          sum + (info.originalCost ?? info.cost ?? info.remainingCost ?? 0),
+        0,
+      );
+      const totalCostWithoutFee = currentLongEntryBreakdown.reduce(
+        (sum, info) =>
+          sum +
+          (info.originalCostWithoutFee ??
+            info.costWithoutFee ??
+            info.remainingCostWithoutFee ??
+            0),
+        0,
+      );
       const averageEntryPrice =
-        totalShares > 0 ? longPositionCostWithoutFee / totalShares : 0;
+        totalShares > 0 ? totalCostWithoutFee / totalShares : 0;
       return {
         type: "buy",
         date: currentLongEntryBreakdown[0]?.date || null,
         price: averageEntryPrice,
         shares: totalShares,
-        cost: longPositionCostWithFee,
-        costWithoutFee: longPositionCostWithoutFee,
+        cost: totalCostWithFee,
+        costWithoutFee: totalCostWithoutFee,
         averageEntryPrice,
         stageCount: currentLongEntryBreakdown.length,
         cumulativeStagePercent: totalPercent,

--- a/log.md
+++ b/log.md
@@ -1,3 +1,8 @@
+## 2025-11-12 — Patch LB-TRADE-ENTRY-20251112A
+- **Issue recap**: 分段進場在全部出場後，`buildAggregatedLongEntry` 仍以已被清零的 `longPositionCost*` 值計算，導致交易紀錄中的買入價格被顯示為 0。
+- **Fix**: 改用每段進場快照的 `originalCost`／`originalCostWithoutFee` 與 `originalShares` 彙總平均成本，確保整併後的買入價格維持原始交易成本。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
 ## 2025-11-11 — Patch LB-PRICE-INSPECTOR-20251111A
 - **Issue recap**: 區間價格檢視按鈕搬移到淨值卡片後，打開彈窗時未初始化 `sourceLabel`，在填入價格來源欄位時觸發 `ReferenceError`，導致彈窗仍維持隱藏狀態、使用者看不到表格。
 - **Fix**: 於 `openPriceInspectorModal` 重新導入 `resolvePriceInspectorSourceLabel()` 的結果，確保渲染價格來源欄位時具備預設值，避免錯誤中斷。


### PR DESCRIPTION
## Summary
- aggregate staged long entries using original cost snapshots so trade records keep the actual buy price
- log version LB-TRADE-ENTRY-20251112A documenting the trade record correction

## Testing
- node - <<'NODE' const fs = require('fs'); const vm = require('vm'); ['js/backtest.js','js/main.js','js/worker.js'].forEach((file) => { const code = fs.readFileSync(file, 'utf8'); new vm.Script(code, { filename: file }); }); console.log('scripts compile'); NODE

------
https://chatgpt.com/codex/tasks/task_e_68d655211c8c8324b4c1c33f3ab74dcc