### PR TITLE
feat: unify lucide icons with tokens and accessibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,37 @@
 /* --- 自訂 CSS --- */
+.lucide {
+    width: var(--icon-size-md);
+    height: var(--icon-size-md);
+    stroke: currentColor;
+    color: var(--icon-color);
+    vertical-align: middle;
+    transition: color 0.2s ease, stroke-width 0.2s ease;
+}
+
+.lucide-sm {
+    width: var(--icon-size-sm);
+    height: var(--icon-size-sm);
+}
+
+.lucide-md {
+    width: var(--icon-size-md);
+    height: var(--icon-size-md);
+}
+
+.lucide-lg {
+    width: var(--icon-size-lg);
+    height: var(--icon-size-lg);
+}
+
+button .lucide,
+button:focus .lucide,
+button:hover .lucide,
+[role="button"] .lucide,
+.interactive-toggle .lucide {
+    stroke-width: 1.75;
+    color: var(--icon-color);
+}
+
 .tooltip { position: relative; display: inline-block; vertical-align: middle; }
 .tooltip .tooltiptext { visibility: hidden; width: 250px; background-color: #333; color: #fff; text-align: left; border-radius: 6px; padding: 10px; position: absolute; z-index: 50; bottom: 135%; left: 50%; transform: translateX(-50%); opacity: 0; transition: opacity 0.3s; font-size: 13px; line-height: 1.5; pointer-events: none; box-shadow: 0 2px 8px rgba(0,0,0,0.5); }
 .tooltip:hover .tooltiptext { visibility: visible; opacity: 1; }

--- a/index.html
+++ b/index.html
@@ -46,6 +46,10 @@
         --input: #ffffff;
         --ring: rgba(8, 145, 178, 0.5);
         --radius: 0.5rem;
+        --icon-size-sm: 1rem;
+        --icon-size-md: 1.5rem;
+        --icon-size-lg: 3rem;
+        --icon-color: #000000;
       }
       
       .card {
@@ -386,8 +390,9 @@
                                     id="quickBacktestBtn"
                                     class="btn-primary px-8 py-4 text-lg font-semibold rounded-lg transition duration-150 ease-in-out flex items-center justify-center"
                                     style="background-color: var(--primary); color: var(--primary-foreground); border: 1px solid var(--primary);"
+                                    aria-label="一鍵回測台積電"
                                 >
-                                    <i data-lucide="zap" class="lucide mr-3"></i>
+                                    <i data-lucide="zap" class="lucide mr-3" aria-hidden="true"></i>
                                     一鍵回測台積電
                                 </button>
 
@@ -398,8 +403,9 @@
                                     style="color: var(--foreground); border: 1px solid var(--border); background-color: var(--input);"
                                     aria-expanded="false"
                                     aria-controls="developerAreaWrapper"
+                                    aria-label="切換開發者區域"
                                 >
-                                    <i data-lucide="wrench" class="lucide mr-2"></i>
+                                    <i data-lucide="wrench" class="lucide mr-2" aria-hidden="true"></i>
                                     開發者區域
                                 </button>
                             </div>
@@ -412,7 +418,7 @@
                                 <div class="card hero-developer-card" id="developerAreaCard">
                                     <div class="card-header">
                                         <h3 class="card-title flex items-center gap-2">
-                                            <i data-lucide="wrench" class="lucide text-primary" style="color: var(--primary);"></i>
+                                            <i data-lucide="wrench" class="lucide" aria-hidden="true"></i>
                                             開發者區域
                                         </h3>
                                         <p class="card-description">診斷資料流程、測試來源與 Blob 用量</p>
@@ -424,8 +430,9 @@
                                                 type="button"
                                                 class="px-3 py-2 text-xs font-medium rounded-md border flex items-center gap-1 transition-colors"
                                                 style="color: var(--foreground); border-color: var(--border); background-color: var(--background);"
+                                                aria-label="切換資料來源測試面板"
                                             >
-                                                <i data-lucide="radar" class="lucide w-4 h-4"></i>
+                                                <i data-lucide="radar" class="lucide lucide-sm" aria-hidden="true"></i>
                                                 測試資料來源
                                             </button>
                                             <div id="dataSourceTester" class="hidden border rounded-md bg-white/70 shadow-sm" style="border-color: var(--border);">
@@ -446,8 +453,9 @@
                                                 type="button"
                                                 class="px-3 py-2 text-xs font-medium rounded-md border flex items-center gap-1 transition-colors"
                                                 style="color: var(--foreground); border-color: var(--border); background-color: var(--background);"
+                                                aria-label="切換資料暖身診斷面板"
                                             >
-                                                <i data-lucide="bug" class="lucide w-4 h-4"></i>
+                                                <i data-lucide="bug" class="lucide lucide-sm" aria-hidden="true"></i>
                                                 診斷資料暖身
                                             </button>
                                             <div id="dataDiagnosticsPanel" class="hidden border rounded-md bg-white/70 shadow-sm" style="border-color: var(--border);">
@@ -496,7 +504,7 @@
                                         <div class="space-y-2" id="dataSourceSummaryContainer">
                                             <div class="flex items-center justify-between">
                                                 <div class="text-sm font-medium flex items-center gap-2" style="color: var(--foreground);">
-                                                    <i data-lucide="layers" class="lucide w-4 h-4"></i>
+                                                    <i data-lucide="layers" class="lucide lucide-sm" aria-hidden="true"></i>
                                                     數據來源摘要
                                                 </div>
                                                 <span id="dataSourceSummaryTag" class="text-[11px] text-muted-foreground" style="color: var(--muted-foreground);"></span>
@@ -508,7 +516,7 @@
                                         <div class="space-y-2" id="todaySuggestionLogContainer">
                                             <div class="flex items-center justify-between">
                                                 <div class="text-sm font-medium flex items-center gap-2" style="color: var(--foreground);">
-                                                    <i data-lucide="message-square-warning" class="lucide w-4 h-4"></i>
+                                                    <i data-lucide="message-square-warning" class="lucide lucide-sm" aria-hidden="true"></i>
                                                     今日建議記錄
                                                 </div>
                                                 <div class="flex items-center gap-2">
@@ -519,6 +527,7 @@
                                                         style="color: var(--foreground); border-color: var(--border); background-color: var(--background);"
                                                         aria-expanded="false"
                                                         aria-controls="todaySuggestionLogPanel"
+                                                        aria-label="切換今日建議記錄面板"
                                                     >
                                                         <span class="toggle-indicator">＋</span>
                                                         <span class="toggle-label">展開</span>
@@ -528,6 +537,7 @@
                                                         type="button"
                                                         class="px-2 py-1 text-[11px] rounded-md border transition-colors"
                                                         style="color: var(--muted-foreground); border-color: var(--border); background-color: var(--background);"
+                                                        aria-label="清除今日建議記錄"
                                                     >
                                                         清除紀錄
                                                     </button>
@@ -549,7 +559,7 @@
                                         <div class="space-y-2">
                                             <div class="flex items-center justify-between">
                                                 <div class="text-sm font-medium flex items-center gap-2" style="color: var(--foreground);">
-                                                    <i data-lucide="database" class="lucide w-4 h-4"></i>
+                                                    <i data-lucide="database" class="lucide lucide-sm" aria-hidden="true"></i>
                                                     Blob 使用監控
                                                 </div>
                                                 <div id="blobUsageUpdatedAt" class="text-[11px]" style="color: var(--muted-foreground);"></div>
@@ -576,7 +586,7 @@
                                 <div class="card">
                                     <div class="card-header">
                                         <h3 class="card-title flex items-center gap-2">
-                                            <i data-lucide="settings" class="lucide text-primary" style="color: var(--primary);"></i>
+                                            <i data-lucide="settings" class="lucide" aria-hidden="true"></i>
                                             <span class="tooltip">
                                                 基本設定
                                                 <span class="tooltiptext">更改代碼或日期範圍會觸發重新獲取數據。</span>
@@ -688,7 +698,7 @@
                                 <div class="card">
                                     <div class="card-header">
                                         <h3 class="card-title flex items-center gap-2">
-                                            <i data-lucide="trending-up" class="lucide text-accent" style="color: var(--accent);"></i>
+                                            <i data-lucide="trending-up" class="lucide" aria-hidden="true"></i>
                                             交易設定
                                         </h3>
                                         <p class="card-description">設定交易時機和手續費</p>
@@ -736,7 +746,7 @@
                                 <div class="card">
                                     <div class="card-header">
                                         <h3 class="card-title flex items-center gap-2">
-                                            <i data-lucide="shield" class="lucide text-destructive" style="color: var(--destructive);"></i>
+                                            <i data-lucide="shield" class="lucide" aria-hidden="true"></i>
                                             風險管理
                                         </h3>
                                         <p class="card-description">設定部位大小和停損停利 (多空共用)</p>
@@ -872,7 +882,7 @@
                                 <div class="card">
                                     <div class="card-header">
                                         <h3 class="card-title flex items-center gap-2">
-                                            <i data-lucide="target" class="lucide text-primary" style="color: var(--primary);"></i>
+                                            <i data-lucide="target" class="lucide" aria-hidden="true"></i>
                                             策略設定
                                         </h3>
                                         <p class="card-description">設定進場和出場條件</p>
@@ -881,7 +891,7 @@
                                         <div class="grid md:grid-cols-2 gap-6">
                                             <div>
                                                 <label for="entryStrategy" class="block text-xs font-medium text-foreground mb-2" style="color: var(--foreground);">
-                                                    <i data-lucide="arrow-up-circle" class="lucide-sm inline mr-1 text-green-600"></i>
+                                                    <i data-lucide="arrow-up-circle" class="lucide lucide-sm inline mr-1" aria-hidden="true"></i>
                                                     做多進場策略
                                                 </label>
                                                 <select
@@ -905,7 +915,7 @@
 
                                             <div class="space-y-3">
                                                 <label for="exitStrategy" class="block text-xs font-medium text-foreground mb-2" style="color: var(--foreground);">
-                                                    <i data-lucide="arrow-down-circle" class="lucide-sm inline mr-1 text-red-600"></i>
+                                                    <i data-lucide="arrow-down-circle" class="lucide lucide-sm inline mr-1" aria-hidden="true"></i>
                                                     做多出場策略
                                                 </label>
                                                 <select
@@ -935,7 +945,7 @@
                                             <label class="flex items-center mb-4">
                                                 <input type="checkbox" id="enableShortSelling" class="mr-2" />
                                                 <span class="text-xs font-medium text-foreground" style="color: var(--foreground);">
-                                                    <i data-lucide="trending-down" class="lucide-sm inline mr-1 text-red-600"></i>
+                                                    <i data-lucide="trending-down" class="lucide lucide-sm inline mr-1" aria-hidden="true"></i>
                                                     啟用做空交易
                                                 </span>
                                             </label>
@@ -994,7 +1004,7 @@
                             <div class="card">
                                 <div class="card-header">
                                     <h3 class="card-title flex items-center gap-2">
-                                        <i data-lucide="file-text" class="lucide text-accent" style="color: var(--accent);"></i>
+                                        <i data-lucide="file-text" class="lucide" aria-hidden="true"></i>
                                         <span class="tooltip">
                                             策略管理
                                             <span class="tooltiptext">儲存、載入、刪除您的回測策略設定 (包含風險管理)。指標會儲存最後回測結果。</span>
@@ -1010,13 +1020,13 @@
                                     </div>
                                     <div class="flex flex-wrap gap-2">
                                         <button id="saveStrategyBtn" class="px-3 py-2 bg-transparent text-primary hover:bg-accent border border-primary text-sm rounded-md transition duration-150 ease-in-out flex-grow sm:flex-grow-0" style="color: var(--primary); border-color: var(--primary);">
-                                            <i data-lucide="save" class="lucide-sm mr-1"></i>儲存目前
+                                            <i data-lucide="save" class="lucide lucide-sm mr-1" aria-hidden="true"></i>儲存目前
                                         </button>
                                         <button id="loadStrategyBtn" class="px-3 py-2 bg-transparent text-primary hover:bg-accent border border-primary text-sm rounded-md transition duration-150 ease-in-out flex-grow sm:flex-grow-0" style="color: var(--primary); border-color: var(--primary);">
-                                            <i data-lucide="folder-open" class="lucide-sm mr-1"></i>載入選定
+                                            <i data-lucide="folder-open" class="lucide lucide-sm mr-1" aria-hidden="true"></i>載入選定
                                         </button>
                                         <button id="deleteStrategyBtn" class="px-3 py-2 bg-transparent text-primary hover:bg-accent border border-primary text-sm rounded-md transition duration-150 ease-in-out flex-grow sm:flex-grow-0" style="color: var(--primary); border-color: var(--primary);">
-                                            <i data-lucide="trash-2" class="lucide-sm mr-1"></i>刪除選定
+                                            <i data-lucide="trash-2" class="lucide lucide-sm mr-1" aria-hidden="true"></i>刪除選定
                                         </button>
                                     </div>
                                 </div>
@@ -1026,7 +1036,7 @@
                             <div class="card">
                                 <div class="card-header">
                                     <h3 class="card-title flex items-center gap-2">
-                                        <i data-lucide="zap" class="lucide text-accent" style="color: var(--accent);"></i>
+                                        <i data-lucide="zap" class="lucide" aria-hidden="true"></i>
                                         快速結果
                                     </h3>
                                 </div>
@@ -1045,7 +1055,7 @@
                             <div class="card hidden" id="today-suggestion-area" aria-live="polite">
                                 <div class="card-header pb-2">
                                     <h3 class="card-title flex items-center gap-2">
-                                        <i data-lucide="lightbulb" class="lucide text-accent" style="color: var(--accent);"></i>
+                                        <i data-lucide="lightbulb" class="lucide" aria-hidden="true"></i>
                                         今日建議
                                     </h3>
                                 </div>
@@ -1126,7 +1136,7 @@
                             <div class="card shadow-lg border-2 border-primary/20" style="border-color: color-mix(in srgb, var(--primary) 20%, transparent);">
                                 <div class="card-header">
                                     <h3 class="card-title flex items-center gap-2 text-primary" style="color: var(--primary);">
-                                        <i data-lucide="play" class="lucide"></i>
+                                        <i data-lucide="play" class="lucide" aria-hidden="true"></i>
                                         執行回測
                                     </h3>
                                 </div>
@@ -1135,17 +1145,17 @@
                                         id="backtestBtn"
                                         class="w-full btn-primary text-lg py-6 rounded-lg font-semibold transition duration-150 ease-in-out flex items-center justify-center"
                                     >
-                                        <i data-lucide="play" class="lucide mr-2"></i>
+                                        <i data-lucide="play" class="lucide mr-2" aria-hidden="true"></i>
                                         開始回測
                                     </button>
 
                                     <div class="grid grid-cols-1 gap-2">
                                         <button id="resetBtn" class="btn-outline text-sm py-2 rounded-md font-medium transition duration-150 ease-in-out flex items-center justify-center">
-                                            <i data-lucide="refresh-cw" class="lucide-sm mr-1"></i>
+                                            <i data-lucide="refresh-cw" class="lucide lucide-sm mr-1" aria-hidden="true"></i>
                                             重置設定
                                         </button>
                                         <button id="randomizeBtn" class="btn-outline text-sm py-2 rounded-md font-medium transition duration-150 ease-in-out flex items-center justify-center">
-                                            <i data-lucide="shuffle" class="lucide-sm mr-1"></i>
+                                            <i data-lucide="shuffle" class="lucide lucide-sm mr-1" aria-hidden="true"></i>
                                             隨機參數
                                         </button>
                                     </div>
@@ -1165,49 +1175,49 @@
                                                 data-tab="summary"
                                                 aria-current="page"
                                             >
-                                                <i data-lucide="clipboard-list" class="lucide-sm inline mr-1"></i>摘要
+                                                <i data-lucide="clipboard-list" class="lucide lucide-sm inline mr-1" aria-hidden="true"></i>摘要
                                             </button>
                                             <button
                                                 class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
                                                 style="color: var(--muted-foreground);"
                                                 data-tab="staging-optimizer"
                                             >
-                                                <i data-lucide="wand-2" class="lucide-sm inline mr-1"></i>分段優化
+                                                <i data-lucide="wand-2" class="lucide lucide-sm inline mr-1" aria-hidden="true"></i>分段優化
                                             </button>
                                             <button
                                                 class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
                                                 style="color: var(--muted-foreground);"
                                                 data-tab="performance"
                                             >
-                                                <i data-lucide="bar-chart-3" class="lucide-sm inline mr-1"></i>績效分析
+                                                <i data-lucide="bar-chart-3" class="lucide lucide-sm inline mr-1" aria-hidden="true"></i>績效分析
                                             </button>
                                             <button
                                                 class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
                                                 style="color: var(--muted-foreground);"
                                                 data-tab="trades"
                                             >
-                                                <i data-lucide="receipt" class="lucide-sm inline mr-1"></i>交易記錄
+                                                <i data-lucide="receipt" class="lucide lucide-sm inline mr-1" aria-hidden="true"></i>交易記錄
                                             </button>
                                             <button
                                                 class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
                                                 style="color: var(--muted-foreground);"
                                                 data-tab="optimization"
                                             >
-                                                <i data-lucide="sliders-horizontal" class="lucide-sm inline mr-1"></i>參數優化
+                                                <i data-lucide="sliders-horizontal" class="lucide lucide-sm inline mr-1" aria-hidden="true"></i>參數優化
                                             </button>
                                             <button
                                                 class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
                                                 style="color: var(--muted-foreground);"
                                                 data-tab="batch-optimization"
                                             >
-                                                <i data-lucide="users" class="lucide-sm inline mr-1"></i>批量優化
+                                                <i data-lucide="users" class="lucide lucide-sm inline mr-1" aria-hidden="true"></i>批量優化
                                             </button>
                                             <button
                                                 class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
                                                 style="color: var(--muted-foreground);"
                                                 data-tab="rolling-test"
                                             >
-                                                <i data-lucide="repeat" class="lucide-sm inline mr-1"></i>滾動測試
+                                                <i data-lucide="repeat" class="lucide lucide-sm inline mr-1" aria-hidden="true"></i>滾動測試
                                             </button>
                                         </nav>
                                     </div>
@@ -1247,7 +1257,7 @@
                                         <div id="chart-container" class="h-96 bg-muted/20 rounded-lg flex items-center justify-center border-2 border-dashed relative" style="background-color: color-mix(in srgb, var(--muted) 20%, transparent); border-color: var(--card);">
                                             <canvas id="chart" class="w-full h-full absolute inset-0"></canvas>
                                             <div class="text-muted text-center" style="color: var(--muted-foreground);">
-                                                <i data-lucide="bar-chart-3" class="lucide w-12 h-12 mx-auto mb-2 opacity-50"></i>
+                                                <i data-lucide="bar-chart-3" class="lucide mx-auto mb-2 opacity-50 lucide-lg" aria-hidden="true"></i>
                                                 <p>執行回測後將顯示淨值曲線</p>
                                             </div>
                                         </div>
@@ -1294,7 +1304,7 @@
                                         >
                                             <span class="card-title flex items-center gap-3">
                                                 <span class="trend-toggle-indicator" aria-hidden="true">＋</span>
-                                                <i data-lucide="line-chart" class="lucide-sm" aria-hidden="true"></i>
+                                                <i data-lucide="line-chart" class="lucide lucide-sm" aria-hidden="true"></i>
                                                 <span>趨勢區間評估</span>
                                             </span>
                                             <span class="text-xs text-muted-foreground" data-trend-toggle-label>展開分析</span>
@@ -1359,7 +1369,7 @@
                                 <div class="card shadow-lg mb-6">
                                     <div class="card-header">
                                         <h3 class="card-title flex items-center gap-2">
-                                            <i data-lucide="sparkles" class="lucide text-accent" style="color: var(--accent);"></i>
+                                            <i data-lucide="sparkles" class="lucide" aria-hidden="true"></i>
                                             分段優化助手
                                         </h3>
                                         <p class="card-description">自動評估多組進場與出場分段，尋找較佳的資金配置方式</p>
@@ -1373,7 +1383,7 @@
                                                 id="stagingOptimizationBtn"
                                                 class="btn-primary flex items-center gap-2 text-sm px-4 py-2 rounded-md font-semibold"
                                             >
-                                                <i data-lucide="play-circle" class="lucide-sm"></i>
+                                                <i data-lucide="play-circle" class="lucide lucide-sm" aria-hidden="true"></i>
                                                 一鍵優化分段策略
                                             </button>
                                             <button
@@ -1381,7 +1391,7 @@
                                                 class="btn-outline flex items-center gap-2 text-sm px-4 py-2 rounded-md font-medium"
                                                 disabled
                                             >
-                                                <i data-lucide="check" class="lucide-sm"></i>
+                                                <i data-lucide="check" class="lucide lucide-sm" aria-hidden="true"></i>
                                                 套用推薦分段
                                             </button>
                                             <span class="text-[11px]" style="color: var(--muted-foreground);">
@@ -1474,7 +1484,7 @@
                                 <div class="card shadow-lg">
                                     <div class="card-header">
                                         <h3 class="card-title flex items-center gap-2">
-                                            <i data-lucide="zap" class="lucide text-accent" style="color: var(--accent);"></i>
+                                            <i data-lucide="zap" class="lucide" aria-hidden="true"></i>
                                             參數優化
                                         </h3>
                                         <p class="card-description">自動尋找最佳參數組合</p>
@@ -1484,7 +1494,7 @@
                                         <div class="card bg-background border border-border" style="background-color: var(--background); border-color: var(--border);">
                                             <div class="card-header">
                                                 <h4 class="card-title flex items-center gap-2">
-                                                    <i data-lucide="sliders-horizontal" class="lucide text-primary" style="color: var(--primary);"></i>
+                                                    <i data-lucide="sliders-horizontal" class="lucide" aria-hidden="true"></i>
                                                     優化控制
                                                 </h4>
                                             </div>
@@ -1495,7 +1505,7 @@
                                                     <div class="grid md:grid-cols-3 gap-4">
                                                         <div class="flex items-center border border-border rounded-md" style="border-color: var(--border);">
                                                             <button id="optimizeEntryBtn" class="btn-primary text-sm font-medium rounded-l-md px-4 py-2 flex items-center whitespace-nowrap border-r border-border" style="border-color: var(--border);">
-                                                                <i data-lucide="settings" class="lucide-sm mr-1"></i>
+                                                                <i data-lucide="settings" class="lucide lucide-sm mr-1" aria-hidden="true"></i>
                                                                 優化進場
                                                             </button>
                                                             <select
@@ -1507,7 +1517,7 @@
 
                                                         <div class="flex items-center border border-border rounded-md" style="border-color: var(--border);">
                                                             <button id="optimizeExitBtn" class="btn-secondary text-sm font-medium rounded-l-md px-4 py-2 flex items-center whitespace-nowrap border-r border-border" style="border-color: var(--border);">
-                                                                <i data-lucide="wrench" class="lucide-sm mr-1"></i>
+                                                                <i data-lucide="wrench" class="lucide lucide-sm mr-1" aria-hidden="true"></i>
                                                                 優化出場
                                                             </button>
                                                             <select
@@ -1519,7 +1529,7 @@
 
                                                         <div class="flex items-center border border-border rounded-md" style="border-color: var(--border);">
                                                             <button id="optimizeRiskBtn" class="btn-outline text-sm font-medium rounded-l-md px-4 py-2 flex items-center whitespace-nowrap border-r border-border" style="border-color: var(--border);">
-                                                                <i data-lucide="sliders-horizontal" class="lucide-sm mr-1"></i>
+                                                                <i data-lucide="sliders-horizontal" class="lucide lucide-sm mr-1" aria-hidden="true"></i>
                                                                 優化風控
                                                             </button>
                                                             <select
@@ -1540,7 +1550,7 @@
                                                     <div class="grid md:grid-cols-2 gap-4">
                                                         <div class="flex items-center border border-border rounded-md" style="border-color: var(--border);">
                                                             <button id="optimizeShortEntryBtn" class="btn-outline text-sm font-medium rounded-l-md px-4 py-2 flex items-center whitespace-nowrap border-r border-border" style="border-color: var(--border);">
-                                                                <i data-lucide="trending-down" class="lucide-sm mr-1"></i>
+                                                                <i data-lucide="trending-down" class="lucide lucide-sm mr-1" aria-hidden="true"></i>
                                                                 優化做空進場
                                                             </button>
                                                             <select
@@ -1551,7 +1561,7 @@
                                                         </div>
                                                         <div class="flex items-center border border-border rounded-md" style="border-color: var(--border);">
                                                             <button id="optimizeShortExitBtn" class="btn-outline text-sm font-medium rounded-l-md px-4 py-2 flex items-center whitespace-nowrap border-r border-border" style="border-color: var(--border);">
-                                                                <i data-lucide="trending-up" class="lucide-sm mr-1"></i>
+                                                                <i data-lucide="trending-up" class="lucide lucide-sm mr-1" aria-hidden="true"></i>
                                                                 優化回補出場
                                                             </button>
                                                             <select
@@ -1569,7 +1579,7 @@
                                         <div id="optimization-progress-section" class="card bg-primary/5 border-2 border-primary/20 hidden" style="background-color: color-mix(in srgb, var(--primary) 5%, transparent); border-color: color-mix(in srgb, var(--primary) 20%, transparent);">
                                             <div class="card-header">
                                                 <h4 class="card-title flex items-center gap-2">
-                                                    <i data-lucide="loader" class="lucide text-primary animate-spin" style="color: var(--primary);"></i>
+                                                    <i data-lucide="loader" class="lucide animate-spin" aria-hidden="true"></i>
                                                     優化進行中
                                                 </h4>
                                             </div>
@@ -1594,7 +1604,7 @@
                                         <div class="card bg-background border border-border" style="background-color: var(--background); border-color: var(--border);">
                                             <div class="card-header">
                                                 <h4 id="optimization-title" class="card-title flex items-center gap-2">
-                                                    <i data-lucide="trending-up" class="lucide text-primary" style="color: var(--primary);"></i>
+                                                    <i data-lucide="trending-up" class="lucide" aria-hidden="true"></i>
                                                     優化結果
                                                 </h4>
                                             </div>
@@ -1613,7 +1623,7 @@
                                 <div class="card shadow-lg">
                                     <div class="card-header">
                                         <h3 class="card-title flex items-center gap-2">
-                                            <i data-lucide="users" class="lucide text-primary" style="color: var(--primary);"></i>
+                                            <i data-lucide="users" class="lucide" aria-hidden="true"></i>
                                             批量策略優化
                                         </h3>
                                         <p class="card-description">同時測試多種策略組合</p>
@@ -1625,7 +1635,7 @@
                                                 <div class="card bg-background border border-border" style="background-color: var(--background); border-color: var(--border);">
                                                     <div class="card-header">
                                                         <h4 class="card-title flex items-center gap-2">
-                                                            <i data-lucide="settings" class="lucide text-primary" style="color: var(--primary);"></i>
+                                                            <i data-lucide="settings" class="lucide" aria-hidden="true"></i>
                                                             策略組合選擇
                                                         </h4>
                                                     </div>
@@ -1656,7 +1666,7 @@
                                                 <div class="card bg-background border border-border" style="background-color: var(--background); border-color: var(--border);">
                                                     <div class="card-header">
                                                         <h4 class="card-title flex items-center gap-2">
-                                                            <i data-lucide="sliders-horizontal" class="lucide text-accent" style="color: var(--accent);"></i>
+                                                            <i data-lucide="sliders-horizontal" class="lucide" aria-hidden="true"></i>
                                                             優化設定
                                                         </h4>
                                                     </div>
@@ -1706,11 +1716,11 @@
                                             <!-- 執行按鈕 -->
                                             <div class="flex justify-center gap-4 mb-6 mt-6">
                                                 <button id="start-batch-optimization" class="btn-primary px-8 py-3 rounded-lg font-semibold transition duration-150 ease-in-out flex items-center" style="background: linear-gradient(135deg, var(--primary), var(--accent));">
-                                                    <i data-lucide="rocket" class="lucide mr-2"></i>
+                                                    <i data-lucide="rocket" class="lucide mr-2" aria-hidden="true"></i>
                                                     開始批量優化
                                                 </button>
                                                 <button id="stop-batch-optimization" class="btn-outline px-8 py-3 rounded-lg font-semibold transition duration-150 ease-in-out flex items-center hidden" style="border-color: var(--destructive); color: var(--destructive);">
-                                                    <i data-lucide="square" class="lucide mr-2"></i>
+                                                    <i data-lucide="square" class="lucide mr-2" aria-hidden="true"></i>
                                                     停止優化
                                                 </button>
                                             </div>
@@ -1721,7 +1731,7 @@
                                                     <div class="card-header pb-3">
                                                         <div class="flex items-center justify-between">
                                                             <h5 class="card-title text-sm font-medium flex items-center">
-                                                                <i id="batch-progress-hourglass" data-lucide="hourglass" class="lucide mr-2 animate-spin text-primary" style="color: var(--primary);"></i>
+                                                                <i id="batch-progress-hourglass" data-lucide="hourglass" class="lucide mr-2 animate-spin" aria-hidden="true"></i>
                                                                 優化進度
                                                             </h5>
                                                             <span id="batch-progress-text" class="text-sm text-primary" style="color: var(--primary);">0%</span>
@@ -1736,7 +1746,7 @@
                                                             <div id="batch-progress-combination" class="font-medium text-primary" style="color: var(--primary);"></div>
                                                             <div id="batch-time-estimate" class="font-medium text-foreground" style="color: var(--foreground);"></div>
                                                             <div id="batch-long-wait-notice" class="hidden p-2 bg-accent/10 border border-accent/20 rounded text-accent" style="background-color: color-mix(in srgb, var(--accent) 10%, transparent); border-color: color-mix(in srgb, var(--accent) 20%, transparent); color: var(--accent);">
-                                                                <i data-lucide="clock" class="lucide mr-1"></i>
+                                                                <i data-lucide="clock" class="lucide mr-1" aria-hidden="true"></i>
                                                                 由於測試次數與選擇策略較多，預估需要較長等待時間，請耐心等候...
                                                             </div>
                                                         </div>
@@ -1782,7 +1792,7 @@
                                                     <div class="card-header pb-3">
                                                         <div class="flex items-center justify-between">
                                                             <h5 class="card-title text-sm font-medium flex items-center">
-                                                                <i id="cross-progress-icon" data-lucide="arrow-right-left" class="lucide mr-2 animate-pulse text-accent" style="color: var(--accent);"></i>
+                                                                <i id="cross-progress-icon" data-lucide="arrow-right-left" class="lucide mr-2 animate-pulse" aria-hidden="true"></i>
                                                                 交叉優化進度
                                                             </h5>
                                                             <span id="cross-progress-text" class="text-sm text-accent" style="color: var(--accent);">0%</span>
@@ -1816,7 +1826,7 @@
                                                                     <option value="tradeCount">交易次數</option>
                                                                 </select>
                                                                 <button id="batch-sort-direction" class="px-2 py-1 btn-outline rounded text-sm">
-                                                                    <i data-lucide="arrow-down" class="lucide"></i>
+                                                                    <i data-lucide="arrow-down" class="lucide" aria-hidden="true"></i>
                                                                 </button>
                                                             </div>
                                                         </div>
@@ -1942,11 +1952,11 @@
                                             </div>
                                             <div class="flex items-center gap-3">
                                                 <button id="start-rolling-test" class="btn-primary px-6 py-2.5 rounded-lg font-semibold flex items-center gap-2" style="background: linear-gradient(135deg, var(--primary), color-mix(in srgb, var(--accent) 60%, var(--primary)));">
-                                                    <i data-lucide="shuffle" class="lucide w-4 h-4"></i>
+                                                    <i data-lucide="shuffle" class="lucide lucide-sm" aria-hidden="true"></i>
                                                     開始滾動測試
                                                 </button>
                                                 <button id="stop-rolling-test" class="btn-outline px-6 py-2.5 rounded-lg font-semibold hidden" style="border-color: var(--destructive); color: var(--destructive);">
-                                                    <i data-lucide="square" class="lucide w-4 h-4"></i>
+                                                    <i data-lucide="square" class="lucide lucide-sm" aria-hidden="true"></i>
                                                     停止
                                                 </button>
                                             </div>
@@ -2105,7 +2115,7 @@
                         if (currentProgress > 95) currentProgress = 95; // 最多到 95%
                         
                         quickBacktestBtn.innerHTML = `
-                            <i data-lucide="loader-2" class="lucide mr-3 animate-spin"></i>
+                            <i data-lucide="loader-2" class="lucide mr-3 animate-spin" aria-hidden="true"></i>
                             回測中...${Math.round(currentProgress)}%
                         `;
                         
@@ -2151,7 +2161,7 @@
                             
                             // 顯示完成狀態
                             quickBacktestBtn.innerHTML = `
-                                <i data-lucide="check-circle" class="lucide mr-3"></i>
+                                <i data-lucide="check-circle" class="lucide mr-3" aria-hidden="true"></i>
                                 完成！請看下面績效表現
                             `;
                             

--- a/log.md
+++ b/log.md
@@ -1,3 +1,10 @@
+## 2025-11-12 — Patch LB-ICON-A11Y-20251112A
+- **Scope**: 全域圖示設計 token 與互動可及性調整。
+- **Design Tokens**: 新增 `--icon-size-sm/md/lg` 與 `--icon-color`，建立 `.lucide-sm/.lucide-md/.lucide-lg` 統一控管尺寸並維持黑色筆畫。
+- **UI Alignment**: 將功能卡片與進度面板的 Lucide 圖示改用語意化尺寸類別、移除舊有 `w-4 h-4` 與色彩樣式，確保 hover/active 狀態與主題一致。
+- **Accessibility**: 為主要切換按鈕補齊 `aria-label`，所有裝飾性圖示改以 `aria-hidden="true"` 隱藏，保持螢幕閱讀器指引精簡。
+- **Testing**: 手動檢視桌機與行動視窗佈局，確認圖示尺寸、顏色與互動狀態一致，無自動化測試腳本可執行。
+
 ## 2025-11-11 — Patch LB-PRICE-INSPECTOR-20251111A
 - **Issue recap**: 區間價格檢視按鈕搬移到淨值卡片後，打開彈窗時未初始化 `sourceLabel`，在填入價格來源欄位時觸發 `ReferenceError`，導致彈窗仍維持隱藏狀態、使用者看不到表格。
 - **Fix**: 於 `openPriceInspectorModal` 重新導入 `resolvePriceInspectorSourceLabel()` 的結果，確保渲染價格來源欄位時具備預設值，避免錯誤中斷。


### PR DESCRIPTION
## Summary
- introduce shared icon size and color design tokens with new `.lucide-sm/.lucide-md/.lucide-lg` helpers
- update lucide icon markup to drop Tailwind sizing, enforce black strokes, and add aria-hidden for decorative glyphs
- add aria labels to key toggle buttons and document the change in `log.md`

## Testing
- Manual desktop and mobile layout inspection

------
https://chatgpt.com/codex/tasks/task_e_68d68491bd08832494206119fa1b4601