### PR TITLE
fix: restore transparent loading mascot fallback

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,11 @@
 /* --- 自訂 CSS --- */
 .loading-mascot-wrapper {
     background: none;
-    background-color: transparent !important;
+    background-color: inherit;
     border: none;
     box-shadow: none;
     padding: 0;
+    isolation: isolate;
 }
 
 .loading-mascot-canvas {
@@ -16,8 +17,8 @@
     justify-content: center;
     overflow: hidden;
     border-radius: 0.25rem;
-    background: transparent;
-    background-color: transparent !important;
+    background: none;
+    background-color: inherit;
     pointer-events: none;
 }
 
@@ -58,7 +59,8 @@
     height: 100%;
     object-fit: contain;
     display: block;
-    background: transparent;
+    background: none;
+    background-color: transparent !important;
     border: none;
     border-radius: 0;
     box-shadow: none;

--- a/index.html
+++ b/index.html
@@ -1139,11 +1139,12 @@
                                                     data-tenor-id="1718069610368761676"
                                                     data-tenor-api-key="LIVDSRZULELA"
                                                     data-tenor-client-key="lazybacktest-progress-mascot"
-                                                    data-tenor-fallback-src="https://media.tenor.com/m/1718069610368761676AAAAD/tenor.gif,https://media1.tenor.com/m/1718069610368761676AAAAD/tenor.gif,https://media.tenor.com/ghm6KFFitx4AAAAd/hachiware.gif"
+                                                    data-tenor-fallback-src="assets/mascot/hachiware-dance-fallback.svg,https://media.tenor.com/m/1718069610368761676AAAAD/tenor.gif,https://media1.tenor.com/m/1718069610368761676AAAAD/tenor.gif,https://media.tenor.com/ghm6KFFitx4AAAAd/hachiware.gif"
+                                                    data-mascot-local-src="assets/mascot/hachiware-dance-fallback.svg"
                                                 >
                                                     <img
                                                         class="loading-mascot-image"
-                                                        src="https://media.tenor.com/m/1718069610368761676AAAAD/tenor.gif"
+                                                        src="assets/mascot/hachiware-dance-fallback.svg"
                                                         alt="LazyBacktest 進度吉祥物動畫"
                                                         decoding="async"
                                                         loading="eager"

--- a/js/main.js
+++ b/js/main.js
@@ -1616,7 +1616,7 @@ function normaliseLoadingMessage(message) {
 }
 
 function initLoadingMascotSanitiser() {
-    const VERSION = 'LB-PROGRESS-MASCOT-20251205B';
+    const VERSION = 'LB-PROGRESS-MASCOT-20251210A';
     const MAX_PRIMARY_ATTEMPTS = 3;
     const MAX_LEGACY_ATTEMPTS = 2;
     const RETRY_DELAY_MS = 1200;
@@ -1633,6 +1633,7 @@ function initLoadingMascotSanitiser() {
     const postId = container.dataset.tenorId?.trim();
     const apiKey = container.dataset.tenorApiKey?.trim();
     const clientKey = container.dataset.tenorClientKey?.trim() || 'lazybacktest-progress-mascot';
+    const localFallback = container.dataset.mascotLocalSrc?.trim();
     const declaredFallbacks = (container.dataset.tenorFallbackSrc || '')
         .split(',')
         .map((src) => src.trim())
@@ -1655,7 +1656,10 @@ function initLoadingMascotSanitiser() {
     }
 
     const fallbackSources = [];
-    if (inlineSrc) {
+    if (localFallback) {
+        fallbackSources.push(localFallback);
+    }
+    if (inlineSrc && !fallbackSources.includes(inlineSrc)) {
         fallbackSources.push(inlineSrc);
     }
     for (const src of declaredFallbacks) {

--- a/log.md
+++ b/log.md
@@ -757,3 +757,9 @@
 - **Fix**: 將 `#loadingGif` 的 Tenor Post ID 更新為 `1718069610368761676`，同步清除 SVG fallback，僅保留使用者提供的 Hachiware GIF 來源，並將 Sanitiser 版本碼提升為 `LB-PROGRESS-MASCOT-20251205B` 以確保快取重新套用。
 - **Diagnostics**: 於本地載入頁面確認初始 `<img>` 即為指定 GIF，並觀察 `dataset.lbMascotSource` 會在 Tenor API 成功後更新為 `tenor:https://media.tenor.com/...`，確保不再回退到 SVG。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/backtest.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
+## 2025-12-10 — Patch LB-PROGRESS-MASCOT-20251210A
+- **Issue recap**: 企業網路阻擋 Tenor 時會落回官方嵌入或遠端 fallback，iframe 內建的白底覆蓋了透明像素，進度吉祥物在進度條旁變成白色方塊。
+- **Fix**: 重新導入本地 `assets/mascot/hachiware-dance-fallback.svg` 作為首選來源，於 Sanitiser 中優先載入並標記來源，同步讓容器繼承卡片底色、更新版本碼 `LB-PROGRESS-MASCOT-20251210A` 確保快取刷新。
+- **Diagnostics**: 阻擋 Tenor API 後確認 `#loadingGif` 即顯示本地 SVG 並標記 `fallback:assets/...`，恢復連線時覆寫為 Tenor GIF 仍維持透明背景；檢視元素樣式確保 wrapper 無額外白底。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/backtest.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`


### PR DESCRIPTION
## Summary
- start the loading mascot with the local transparent SVG and advertise it as the primary fallback so we no longer rely on white Tenor embeds
- update the mascot sanitiser to prioritise the local asset, refresh its version code, and document the change in the maintenance log
- let the mascot wrapper inherit the card background to avoid forcing an opaque box while keeping the image itself transparent

## Testing
- node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/backtest.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68d7ed366d148324aa8f229464cdce38