### PR TITLE
Refine forecast GA to use MSE threshold correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,6 +330,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom"></script>
     <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.14.0/dist/tf.min.js"></script>
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," /> <!-- From UI file -->
 </head>
 <body class="bg-white group/design-root" style='font-family: Inter, "Noto Sans", sans-serif;'>
@@ -1219,6 +1220,13 @@
                                             <button
                                                 class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
                                                 style="color: var(--muted-foreground);"
+                                                data-tab="forecast"
+                                            >
+                                                <i data-lucide="line-chart" class="lucide-sm inline mr-1"></i>預測
+                                            </button>
+                                            <button
+                                                class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
+                                                style="color: var(--muted-foreground);"
                                                 data-tab="staging-optimizer"
                                             >
                                                 <i data-lucide="wand-2" class="lucide-sm inline mr-1"></i>分段優化
@@ -1401,6 +1409,81 @@
                                 </div>
 
                                 <!-- Summary Results -->
+                            </div>
+
+                            <!-- Forecast Tab -->
+                            <div class="tab-content hidden space-y-6" id="forecast-tab">
+                                <div class="card shadow-lg">
+                                    <div class="card-header pb-3 space-y-2">
+                                        <div class="flex items-center justify-between flex-wrap gap-3">
+                                            <h3 class="card-title flex items-center gap-2">
+                                                <i data-lucide="line-chart" class="lucide text-primary" style="color: var(--primary);"></i>
+                                                LSTM+GA 預測模擬
+                                            </h3>
+                                            <span id="forecastVersion" class="text-[11px] font-medium px-2 py-1 rounded-full border"
+                                                style="border-color: var(--border); color: var(--muted-foreground);">版本載入中...</span>
+                                        </div>
+                                        <p class="card-description text-xs leading-relaxed" style="color: var(--muted-foreground);">
+                                            依照回測區間的收盤價建立 LSTM 時序模型，並以遺傳演算法尋找最佳誤差校正閾值，產出隔日收盤價的方向命中率與報酬分布。
+                                        </p>
+                                    </div>
+                                    <div class="card-content space-y-5">
+                                        <div class="flex flex-wrap items-center gap-3">
+                                            <button
+                                                id="runForecastBtn"
+                                                class="btn-primary px-5 py-2.5 rounded-lg font-semibold flex items-center gap-2"
+                                                style="background: linear-gradient(135deg, var(--primary), color-mix(in srgb, var(--primary) 40%, var(--accent)));"
+                                            >
+                                                <i data-lucide="play" class="lucide-sm"></i>
+                                                產生預測
+                                            </button>
+                                            <span id="forecastSamples" class="text-xs font-medium" style="color: var(--muted-foreground);">尚未建立樣本</span>
+                                            <span id="forecastStatus" class="text-xs" style="color: var(--muted-foreground);">請先完成回測，再啟動預測模擬。</span>
+                                        </div>
+                                        <div class="grid gap-4 md:grid-cols-3" id="forecastMetrics">
+                                            <div class="p-4 rounded-lg border shadow-sm" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 6%, transparent);">
+                                                <p class="text-xs font-semibold" style="color: var(--primary);">隔日漲跌命中率</p>
+                                                <p id="forecastHitRate" class="text-2xl font-bold" style="color: var(--foreground);">--</p>
+                                                <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">以隔日收盤價與前一日相比，評估方向命中比例。</p>
+                                            </div>
+                                            <div class="p-4 rounded-lg border shadow-sm" style="border-color: var(--border); background-color: color-mix(in srgb, #10b981 8%, transparent);">
+                                                <p class="text-xs font-semibold" style="color: #047857;">平均漲幅</p>
+                                                <p id="forecastAvgGain" class="text-2xl font-bold" style="color: #047857;">--</p>
+                                                <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">測試期間內，實際上漲日的平均百分比變動。</p>
+                                            </div>
+                                            <div class="p-4 rounded-lg border shadow-sm" style="border-color: var(--border); background-color: color-mix(in srgb, #ef4444 8%, transparent);">
+                                                <p class="text-xs font-semibold" style="color: #b91c1c;">平均跌幅</p>
+                                                <p id="forecastAvgLoss" class="text-2xl font-bold" style="color: #b91c1c;">--</p>
+                                                <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">測試期間內，實際下跌日的平均百分比變動。</p>
+                                            </div>
+                                        </div>
+                                        <div class="grid gap-4 md:grid-cols-2" id="forecastErrorMetrics">
+                                            <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: color-mix(in srgb, var(--muted) 10%, transparent);">
+                                                <p class="text-xs font-semibold" style="color: var(--muted-foreground);">MSE（收盤價）</p>
+                                                <p id="forecastMse" class="text-xl font-bold" style="color: var(--foreground);">--</p>
+                                                <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">以均方誤差評估 LSTM+GA 誤差校正後的收盤價預測。</p>
+                                            </div>
+                                            <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: color-mix(in srgb, var(--muted) 6%, transparent);">
+                                                <p class="text-xs font-semibold" style="color: var(--muted-foreground);">MAE（收盤價）</p>
+                                                <p id="forecastMae" class="text-xl font-bold" style="color: var(--foreground);">--</p>
+                                                <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">LSTM+GA 修正後的絕對誤差平均值。</p>
+                                            </div>
+                                        </div>
+                                        <div class="space-y-2">
+                                            <h4 class="text-sm font-semibold" style="color: var(--foreground);">預測曲線</h4>
+                                            <div class="h-96 bg-muted/10 rounded-lg border" style="border-color: var(--border);">
+                                                <canvas id="forecastChart"></canvas>
+                                            </div>
+                                        </div>
+                                        <div class="p-4 rounded-lg border bg-background" style="border-color: var(--border);">
+                                            <h5 class="text-xs font-semibold mb-2" style="color: var(--foreground);">GA 誤差校正閥值</h5>
+                                            <p id="forecastCorrectionSummary" class="text-xs leading-relaxed" style="color: var(--muted-foreground);">尚未建立校正閥值。</p>
+                                        </div>
+                                        <p class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">
+                                            注意：本功能僅為歷史資料模擬，實際投資仍需自行判斷。模型採用訓練區間的統計值進行標準化，預測時僅使用當下可取得的歷史資料，不會回頭修正既有資料。
+                                        </p>
+                                    </div>
+                                </div>
                             </div>
 
                             <!-- Staging Optimizer Tab -->
@@ -2124,6 +2207,7 @@
     <script src="js/config.js"></script>
     <script src="js/main.js"></script>
     <script src="js/backtest.js"></script>
+    <script src="js/forecast.js"></script>
     <script src="js/loader.js"></script>
     <script src="js/batch-optimization.js"></script>
     <script src="js/rolling-test.js"></script>

--- a/js/forecast.js
+++ b/js/forecast.js
@@ -1,0 +1,605 @@
+const FORECAST_VERSION_CODE = 'LB-FORECAST-LSTMGA-20251114B';
+let forecastChartInstance = null;
+
+function updateForecastStatus(message, type = 'info') {
+    const statusEl = document.getElementById('forecastStatus');
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    const colorMap = {
+        info: 'var(--muted-foreground)',
+        success: '#047857',
+        error: '#b91c1c',
+        warning: '#b45309',
+    };
+    statusEl.style.color = colorMap[type] || 'var(--muted-foreground)';
+}
+
+function setForecastSamples(trainSamples, testSamples) {
+    const el = document.getElementById('forecastSamples');
+    if (!el) return;
+    if (!Number.isFinite(trainSamples) || !Number.isFinite(testSamples)) {
+        el.textContent = '尚未建立樣本';
+        return;
+    }
+    el.textContent = `訓練樣本 ${trainSamples} 筆 ｜ 測試樣本 ${testSamples} 筆`;
+    el.style.color = 'var(--muted-foreground)';
+}
+
+function setForecastVersion() {
+    const el = document.getElementById('forecastVersion');
+    if (el) {
+        el.textContent = FORECAST_VERSION_CODE;
+        el.style.color = 'var(--muted-foreground)';
+    }
+}
+
+function formatRatio(value, digits = 1) {
+    if (!Number.isFinite(value)) return '--';
+    return `${(value * 100).toFixed(digits)}%`;
+}
+
+function formatChange(value, digits = 2) {
+    if (!Number.isFinite(value)) return '--';
+    const sign = value > 0 ? '+' : '';
+    return `${sign}${value.toFixed(digits)}%`;
+}
+
+function formatNumber(value, digits = 2) {
+    if (!Number.isFinite(value)) return '--';
+    return value.toFixed(digits);
+}
+
+function describeCorrectionSummary(summary) {
+    if (!summary || !Number.isFinite(summary.delta)) {
+        return '尚未建立校正閥值。';
+    }
+    const parts = [`閥值 δ = ${formatRatio(summary.delta, 2)}`];
+    if (Number.isFinite(summary.trainingCumulative)) {
+        parts.push(`訓練累積誤差 ${formatNumber(summary.trainingCumulative, 4)}`);
+    }
+    if (Number.isFinite(summary.finalCumulative)) {
+        parts.push(`測試期累積誤差 ${formatNumber(summary.finalCumulative, 4)}`);
+    }
+    if (Number.isFinite(summary.trainingTriggers)) {
+        parts.push(`訓練觸發 ${summary.trainingTriggers} 次`);
+    }
+    if (Number.isFinite(summary.testTriggers)) {
+        parts.push(`測試觸發 ${summary.testTriggers} 次`);
+    }
+    return parts.join(' ｜ ');
+}
+
+function resolveCloseValue(row) {
+    const candidates = [row?.close, row?.adjustedClose, row?.adjClose, row?.rawClose, row?.price];
+    for (const candidate of candidates) {
+        const numeric = typeof candidate === 'string' ? Number(candidate) : candidate;
+        if (Number.isFinite(numeric)) {
+            return numeric;
+        }
+    }
+    return null;
+}
+
+function extractForecastRows() {
+    if (!Array.isArray(window.visibleStockData) || window.visibleStockData.length === 0) {
+        return [];
+    }
+    const dedup = new Map();
+    window.visibleStockData.forEach((row) => {
+        const dateText = row?.date ? String(row.date).trim() : '';
+        if (!dateText) return;
+        const closeValue = resolveCloseValue(row);
+        if (!Number.isFinite(closeValue)) return;
+        const dateObj = new Date(dateText);
+        if (Number.isNaN(dateObj.getTime())) return;
+        const iso = dateObj.toISOString().slice(0, 10);
+        dedup.set(iso, closeValue);
+    });
+    const sorted = Array.from(dedup.entries())
+        .map(([date, close]) => ({ date, close }))
+        .sort((a, b) => new Date(a.date) - new Date(b.date));
+    return sorted;
+}
+
+function computeStats(values) {
+    const valid = values.filter((v) => Number.isFinite(v));
+    if (valid.length === 0) {
+        return { mean: 0, std: 1 };
+    }
+    const mean = valid.reduce((sum, v) => sum + v, 0) / valid.length;
+    const variance = valid.reduce((sum, v) => sum + (v - mean) ** 2, 0) / valid.length;
+    const std = Math.sqrt(Math.max(variance, 1e-8));
+    return { mean, std };
+}
+
+function normalizeValue(value, stats) {
+    return (value - stats.mean) / (stats.std || 1);
+}
+
+function denormalizeValue(value, stats) {
+    return value * (stats.std || 1) + stats.mean;
+}
+
+function createLstmModel(sequenceLength) {
+    const model = tf.sequential();
+    model.add(tf.layers.lstm({ units: 32, inputShape: [sequenceLength, 1], returnSequences: false }));
+    model.add(tf.layers.dropout({ rate: 0.1 }));
+    model.add(tf.layers.dense({ units: 1 }));
+    model.compile({ optimizer: tf.train.adam(0.01), loss: 'meanSquaredError' });
+    return model;
+}
+
+async function ensureTensorflowReady() {
+    if (typeof tf === 'undefined' || typeof tf.ready !== 'function') {
+        throw new Error('TensorFlow.js 尚未載入，請稍後再試。');
+    }
+    await tf.ready();
+}
+
+function buildTrainingTensors(normalizedSeries, sequenceLength, trainCount) {
+    const sequences = [];
+    const targets = [];
+    for (let idx = sequenceLength; idx < trainCount; idx += 1) {
+        const windowSlice = normalizedSeries.slice(idx - sequenceLength, idx);
+        if (windowSlice.length !== sequenceLength) continue;
+        sequences.push(windowSlice.map((v) => [v]));
+        targets.push([normalizedSeries[idx]]);
+    }
+    if (sequences.length === 0) {
+        throw new Error('訓練資料不足，無法建立序列樣本。');
+    }
+    const trainX = tf.tensor3d(sequences);
+    const trainY = tf.tensor2d(targets);
+    return { trainX, trainY, sampleCount: sequences.length };
+}
+
+async function fitLstmModel(model, trainX, trainY, sampleCount) {
+    const epochs = Math.min(160, Math.max(60, Math.round(sampleCount * 1.2)));
+    let batchSize = Math.max(8, Math.floor(sampleCount / 4));
+    if (batchSize > 32) batchSize = 32;
+    if (batchSize > sampleCount) batchSize = sampleCount;
+    batchSize = Math.max(4, batchSize);
+
+    await model.fit(trainX, trainY, {
+        epochs,
+        batchSize,
+        shuffle: false,
+        callbacks: {
+            onEpochEnd: (epoch, logs) => {
+                if ((epoch + 1) % 10 === 0) {
+                    updateForecastStatus(`訓練模型中（${epoch + 1}/${epochs}） loss=${formatNumber(logs?.loss, 4)}`, 'info');
+                }
+            },
+        },
+    });
+}
+
+async function predictSequential(model, normalizedSeries, closes, startIndex, sequenceLength, stats, rows) {
+    const predicted = [];
+    const actuals = [];
+    const dates = [];
+    for (let idx = startIndex; idx < normalizedSeries.length; idx += 1) {
+        const windowSlice = normalizedSeries.slice(idx - sequenceLength, idx);
+        if (windowSlice.length !== sequenceLength) continue;
+        const inputTensor = tf.tensor3d([windowSlice.map((v) => [v])]);
+        const outputTensor = model.predict(inputTensor);
+        const predNormArray = await outputTensor.data();
+        const predNorm = predNormArray[0];
+        inputTensor.dispose();
+        outputTensor.dispose();
+        predicted.push(denormalizeValue(predNorm, stats));
+        actuals.push(closes[idx]);
+        dates.push(rows[idx]?.date || '');
+    }
+    return { predicted, actuals, dates };
+}
+
+function computeMse(predicted, actuals) {
+    if (!Array.isArray(predicted) || !Array.isArray(actuals) || predicted.length !== actuals.length || predicted.length === 0) {
+        return NaN;
+    }
+    let sumSq = 0;
+    let count = 0;
+    for (let idx = 0; idx < predicted.length; idx += 1) {
+        const pred = predicted[idx];
+        const actual = actuals[idx];
+        if (!Number.isFinite(pred) || !Number.isFinite(actual)) continue;
+        const diff = pred - actual;
+        sumSq += diff * diff;
+        count += 1;
+    }
+    return count > 0 ? sumSq / count : NaN;
+}
+
+function computeMae(predicted, actuals) {
+    if (!Array.isArray(predicted) || !Array.isArray(actuals) || predicted.length !== actuals.length || predicted.length === 0) {
+        return NaN;
+    }
+    let sumAbs = 0;
+    let count = 0;
+    for (let idx = 0; idx < predicted.length; idx += 1) {
+        const pred = predicted[idx];
+        const actual = actuals[idx];
+        if (!Number.isFinite(pred) || !Number.isFinite(actual)) continue;
+        sumAbs += Math.abs(pred - actual);
+        count += 1;
+    }
+    return count > 0 ? sumAbs / count : NaN;
+}
+
+function applyThresholdCorrection(rawPreds, actuals, initialCumulative = 0, delta = 0.01) {
+    if (!Array.isArray(rawPreds) || !Array.isArray(actuals) || rawPreds.length !== actuals.length) {
+        return { corrected: Array.isArray(rawPreds) ? rawPreds.slice() : [], finalCumulative: initialCumulative, triggerCount: 0 };
+    }
+    const corrected = [];
+    let cumulative = Number.isFinite(initialCumulative) ? initialCumulative : 0;
+    let triggerCount = 0;
+    for (let idx = 0; idx < rawPreds.length; idx += 1) {
+        const basePred = rawPreds[idx];
+        const actual = actuals[idx];
+        if (!Number.isFinite(basePred) || !Number.isFinite(actual)) {
+            corrected.push(Number.isFinite(basePred) ? basePred + cumulative : NaN);
+            continue;
+        }
+        const correctedValue = basePred + cumulative;
+        corrected.push(correctedValue);
+        const residual = actual - correctedValue;
+        const thresholdBasis = Math.max(Math.abs(actual), 1);
+        const threshold = thresholdBasis * Math.max(delta, 0);
+        if (Math.abs(residual) > threshold) {
+            cumulative += residual;
+            triggerCount += 1;
+        }
+    }
+    return { corrected, finalCumulative: cumulative, triggerCount };
+}
+
+function runGeneticOptimization({ rawPreds, actuals, initialCumulative = 0 }) {
+    if (!Array.isArray(rawPreds) || rawPreds.length === 0 || !Array.isArray(actuals) || actuals.length !== rawPreds.length) {
+        return { delta: 0, score: NaN };
+    }
+    const populationSize = 32;
+    const generations = 36;
+    const mutationRate = 0.25;
+    const mutationScale = 0.02;
+    const minDelta = 0;
+    const maxDelta = 0.2;
+
+    const randomDelta = () => Math.random() * (maxDelta - minDelta) + minDelta;
+
+    const clamp = (value) => {
+        if (!Number.isFinite(value)) return minDelta;
+        if (value < minDelta) return minDelta;
+        if (value > maxDelta) return maxDelta;
+        return value;
+    };
+
+    const evaluate = (delta) => {
+        const { corrected } = applyThresholdCorrection(rawPreds, actuals, initialCumulative, delta);
+        const mse = computeMse(corrected, actuals);
+        return Number.isFinite(mse) ? mse : Infinity;
+    };
+
+    const population = Array.from({ length: populationSize }, randomDelta);
+    let bestDelta = population[0];
+    let bestScore = evaluate(bestDelta);
+
+    const selectParent = (scores) => {
+        const tournamentSize = 3;
+        let chosenDelta = population[0];
+        let chosenScore = Infinity;
+        for (let i = 0; i < tournamentSize; i += 1) {
+            const candidateIndex = Math.floor(Math.random() * population.length);
+            const candidateScore = scores[candidateIndex];
+            if (candidateScore < chosenScore) {
+                chosenScore = candidateScore;
+                chosenDelta = population[candidateIndex];
+            }
+        }
+        return chosenDelta;
+    };
+
+    for (let generation = 0; generation < generations; generation += 1) {
+        const scores = population.map(evaluate);
+        scores.forEach((score, idx) => {
+            if (score < bestScore) {
+                bestScore = score;
+                bestDelta = population[idx];
+            }
+        });
+
+        const nextPopulation = [];
+        while (nextPopulation.length < populationSize) {
+            const parentA = selectParent(scores);
+            const parentB = selectParent(scores);
+            let child = (parentA + parentB) / 2;
+            if (Math.random() < mutationRate) {
+                child += (Math.random() * 2 - 1) * mutationScale;
+            }
+            nextPopulation.push(clamp(child));
+        }
+        population.splice(0, population.length, ...nextPopulation);
+    }
+
+    return { delta: clamp(bestDelta), score: bestScore };
+}
+
+function computeDirectionMetrics(predicted, actuals, closes, startIndex) {
+    if (!Array.isArray(predicted) || !Array.isArray(actuals) || predicted.length !== actuals.length || predicted.length === 0) {
+        return { hitRate: NaN, avgGain: NaN, avgLoss: NaN };
+    }
+    const gains = [];
+    const losses = [];
+    let hits = 0;
+    for (let idx = 0; idx < predicted.length; idx += 1) {
+        const dataIndex = startIndex + idx;
+        const prevClose = closes[dataIndex - 1];
+        const actualClose = actuals[idx];
+        const predictedClose = predicted[idx];
+        if (!Number.isFinite(prevClose) || !Number.isFinite(actualClose) || !Number.isFinite(predictedClose)) {
+            continue;
+        }
+        const actualChange = ((actualClose - prevClose) / prevClose) * 100;
+        const predictedChange = ((predictedClose - prevClose) / prevClose) * 100;
+        if (actualChange > 0) gains.push(actualChange);
+        if (actualChange < 0) losses.push(actualChange);
+        const actualDirection = actualChange >= 0 ? 1 : -1;
+        const predictedDirection = predictedChange >= 0 ? 1 : -1;
+        if (actualDirection === predictedDirection) {
+            hits += 1;
+        }
+    }
+    const total = predicted.length;
+    const avgGain = gains.length > 0 ? gains.reduce((sum, v) => sum + v, 0) / gains.length : NaN;
+    const avgLoss = losses.length > 0 ? losses.reduce((sum, v) => sum + v, 0) / losses.length : NaN;
+    return {
+        hitRate: total > 0 ? hits / total : NaN,
+        avgGain,
+        avgLoss,
+    };
+}
+
+function renderForecastChart({ dates, actual, baseline, corrected }) {
+    const canvas = document.getElementById('forecastChart');
+    if (!canvas) return;
+    if (forecastChartInstance) {
+        forecastChartInstance.destroy();
+        forecastChartInstance = null;
+    }
+    const rootStyles = getComputedStyle(document.documentElement);
+    const primaryColor = rootStyles.getPropertyValue('--primary')?.trim() || '#0ea5a4';
+    const accentColor = rootStyles.getPropertyValue('--accent')?.trim() || '#f59e0b';
+    const foregroundColor = rootStyles.getPropertyValue('--foreground')?.trim() || '#1f2937';
+
+    forecastChartInstance = new Chart(canvas, {
+        type: 'line',
+        data: {
+            labels: dates,
+            datasets: [
+                {
+                    label: '實際收盤價',
+                    data: actual,
+                    borderColor: foregroundColor,
+                    borderWidth: 2,
+                    tension: 0.2,
+                    fill: false,
+                },
+                {
+                    label: 'LSTM 預測',
+                    data: baseline,
+                    borderColor: accentColor,
+                    borderWidth: 1.5,
+                    borderDash: [6, 4],
+                    tension: 0.2,
+                    fill: false,
+                },
+                {
+                    label: 'LSTM + 誤差校正',
+                    data: corrected,
+                    borderColor: primaryColor,
+                    borderWidth: 2,
+                    tension: 0.2,
+                    fill: false,
+                },
+            ],
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            scales: {
+                x: {
+                    ticks: { maxRotation: 0, autoSkip: true },
+                    grid: { display: false },
+                },
+                y: {
+                    ticks: { callback: (value) => value.toFixed ? value.toFixed(0) : value },
+                    grid: { color: 'rgba(148, 163, 184, 0.2)' },
+                },
+            },
+            plugins: {
+                legend: {
+                    labels: { usePointStyle: true },
+                },
+                tooltip: {
+                    callbacks: {
+                        label: (context) => `${context.dataset.label}: ${formatNumber(context.parsed.y, 2)}`,
+                    },
+                },
+            },
+        },
+    });
+}
+
+function updateForecastMetrics(result) {
+    const { metrics } = result;
+    const hitRateEl = document.getElementById('forecastHitRate');
+    const gainEl = document.getElementById('forecastAvgGain');
+    const lossEl = document.getElementById('forecastAvgLoss');
+    const mseEl = document.getElementById('forecastMse');
+    const maeEl = document.getElementById('forecastMae');
+    const correctionEl = document.getElementById('forecastCorrectionSummary');
+
+    if (hitRateEl) hitRateEl.textContent = formatRatio(metrics.hitRate);
+    if (gainEl) gainEl.textContent = formatChange(metrics.avgGain);
+    if (lossEl) lossEl.textContent = formatChange(metrics.avgLoss);
+    if (mseEl) mseEl.textContent = `${formatNumber(metrics.mse, 2)} （基準 ${formatNumber(metrics.baselineMse, 2)}）`;
+    if (maeEl) maeEl.textContent = `${formatNumber(metrics.mae, 2)} （基準 ${formatNumber(metrics.baselineMae, 2)}）`;
+    if (correctionEl) correctionEl.textContent = describeCorrectionSummary(result.correction);
+}
+
+function summariseForecastCompletion(result) {
+    const durationSeconds = Number.isFinite(result.durationMs) ? result.durationMs / 1000 : 0;
+    const summary = `完成預測：命中率 ${formatRatio(result.metrics.baselineHitRate)} → ${formatRatio(result.metrics.hitRate)}，MSE ${formatNumber(result.metrics.baselineMse, 2)} → ${formatNumber(result.metrics.mse, 2)}，耗時 ${formatNumber(durationSeconds, 1)} 秒。`;
+    updateForecastStatus(summary, 'success');
+}
+
+async function runForecastWorkflow() {
+    await ensureTensorflowReady();
+    const rows = extractForecastRows();
+    if (rows.length < 80) {
+        throw new Error('資料不足，請拉長回測區間（至少 80 筆有效收盤價）。');
+    }
+    const closes = rows.map((row) => row.close);
+
+    let sequenceLength = 20;
+    if (rows.length < 160) {
+        sequenceLength = Math.max(12, Math.floor(rows.length * 0.15));
+    }
+    sequenceLength = Math.min(40, Math.max(12, sequenceLength));
+
+    let trainCount = Math.floor(rows.length * 0.75);
+    if (trainCount < sequenceLength + 15) {
+        trainCount = sequenceLength + 15;
+    }
+    if (trainCount > rows.length - 5) {
+        trainCount = rows.length - 5;
+    }
+    if (trainCount <= sequenceLength) {
+        throw new Error('資料區間過短，無法建立訓練樣本。');
+    }
+
+    const stats = computeStats(closes.slice(0, trainCount));
+    const normalizedSeries = closes.map((value) => normalizeValue(value, stats));
+    const { trainX, trainY, sampleCount } = buildTrainingTensors(normalizedSeries, sequenceLength, trainCount);
+
+    const model = createLstmModel(sequenceLength);
+    await fitLstmModel(model, trainX, trainY, sampleCount);
+
+    const trainPredTensor = model.predict(trainX);
+    const trainPredNormArray = Array.from(await trainPredTensor.data());
+    trainPredTensor.dispose();
+
+    trainX.dispose();
+    trainY.dispose();
+
+    const trainPredActuals = trainPredNormArray.map((value) => denormalizeValue(value, stats));
+    const trainActuals = closes.slice(sequenceLength, trainCount);
+
+    const optimization = trainPredActuals.length >= 5
+        ? runGeneticOptimization({ rawPreds: trainPredActuals, actuals: trainActuals })
+        : { delta: 0, score: NaN };
+    const delta = Number.isFinite(optimization.delta) ? optimization.delta : 0;
+
+    const trainingCorrection = applyThresholdCorrection(trainPredActuals, trainActuals, 0, delta);
+
+    const testResult = await predictSequential(model, normalizedSeries, closes, trainCount, sequenceLength, stats, rows);
+    const baselineMse = computeMse(testResult.predicted, testResult.actuals);
+    const baselineMae = computeMae(testResult.predicted, testResult.actuals);
+
+    const correctedResult = applyThresholdCorrection(
+        testResult.predicted,
+        testResult.actuals,
+        trainingCorrection.finalCumulative,
+        delta,
+    );
+
+    const mse = computeMse(correctedResult.corrected, testResult.actuals);
+    const mae = computeMae(correctedResult.corrected, testResult.actuals);
+
+    const directionMetrics = computeDirectionMetrics(
+        correctedResult.corrected,
+        testResult.actuals,
+        closes,
+        trainCount,
+    );
+
+    const baselineDirection = computeDirectionMetrics(
+        testResult.predicted,
+        testResult.actuals,
+        closes,
+        trainCount,
+    );
+
+    const chartPayload = {
+        dates: testResult.dates,
+        actual: testResult.actuals,
+        baseline: testResult.predicted,
+        corrected: correctedResult.corrected,
+    };
+
+    const correctionSummary = {
+        delta,
+        trainingCumulative: trainingCorrection.finalCumulative,
+        finalCumulative: correctedResult.finalCumulative,
+        trainingTriggers: trainingCorrection.triggerCount,
+        testTriggers: correctedResult.triggerCount,
+        optimizationScore: optimization.score,
+    };
+
+    return {
+        version: FORECAST_VERSION_CODE,
+        sequenceLength,
+        trainSamples: sampleCount,
+        testSamples: testResult.actuals.length,
+        correction: correctionSummary,
+        durationMs: 0,
+        metrics: {
+            hitRate: directionMetrics.hitRate,
+            avgGain: directionMetrics.avgGain,
+            avgLoss: directionMetrics.avgLoss,
+            mse,
+            mae,
+            baselineMse,
+            baselineMae,
+            baselineHitRate: baselineDirection.hitRate,
+        },
+        chart: chartPayload,
+    };
+}
+
+async function handleForecastRequest(button) {
+    if (!Array.isArray(window.visibleStockData) || window.visibleStockData.length === 0) {
+        updateForecastStatus('請先執行一次回測以取得股價資料。', 'warning');
+        return;
+    }
+    button.disabled = true;
+    button.style.opacity = '0.7';
+    updateForecastStatus('準備資料並載入 TensorFlow.js...', 'info');
+    try {
+        const start = performance.now();
+        const result = await runForecastWorkflow();
+        result.durationMs = performance.now() - start;
+        setForecastSamples(result.trainSamples, result.testSamples);
+        updateForecastMetrics(result);
+        renderForecastChart(result.chart);
+        summariseForecastCompletion(result);
+    } catch (error) {
+        console.error('[Forecast] Failed to generate prediction', error);
+        updateForecastStatus(`預測失敗：${error.message}`, 'error');
+    } finally {
+        button.disabled = false;
+        button.style.opacity = '1';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    setForecastVersion();
+    const runBtn = document.getElementById('runForecastBtn');
+    if (runBtn) {
+        runBtn.addEventListener('click', () => handleForecastRequest(runBtn));
+    }
+    if (!Array.isArray(window.visibleStockData) || window.visibleStockData.length === 0) {
+        updateForecastStatus('請先完成回測，再啟動預測模擬。', 'info');
+    }
+});

--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+## 2025-11-13 — Patch LB-FORECAST-LSTMGA-20251113A
+- **Scope**: 新增預測分頁，提供 LSTM 與遺傳演算法誤差校正的隔日收盤價模擬。
+- **Forecast Tab**: 建立「預測」分頁、指標卡、GA 權重摘要與折線圖，導入版本章 `FORECAST_VERSION_CODE` 便於追蹤。
+- **ML Pipeline**: 以回測區間的可視價格序列訓練 TensorFlow.js LSTM 模型，並以 GA 最佳化殘差權重，計算命中率、RMSE/MAE 與平均漲跌幅指標。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/forecast.js'].forEach((file)=>{new vm.Script(fs.readFileSync(file,'utf8'),{filename:file});});console.log('scripts compile');NODE`
+
 ## 2025-11-12 — Patch LB-TRADE-ENTRY-20251112A
 - **Issue recap**: 分段進場在全部出場後，`buildAggregatedLongEntry` 仍以已被清零的 `longPositionCost*` 值計算，導致交易紀錄中的買入價格被顯示為 0。
 - **Fix**: 改用每段進場快照的 `originalCost`／`originalCostWithoutFee` 與 `originalShares` 彙總平均成本，確保整併後的買入價格維持原始交易成本。
@@ -757,3 +763,9 @@
 - **Fix**: 將 `#loadingGif` 的 Tenor Post ID 更新為 `1718069610368761676`，同步清除 SVG fallback，僅保留使用者提供的 Hachiware GIF 來源，並將 Sanitiser 版本碼提升為 `LB-PROGRESS-MASCOT-20251205B` 以確保快取重新套用。
 - **Diagnostics**: 於本地載入頁面確認初始 `<img>` 即為指定 GIF，並觀察 `dataset.lbMascotSource` 會在 Tenor API 成功後更新為 `tenor:https://media.tenor.com/...`，確保不再回退到 SVG。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/backtest.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
+## 2025-12-08 — Patch LB-FORECAST-LSTMGA-20251114B
+- **Issue recap**: LSTM+GA 模擬採用均方根誤差與多重殘差權重，無法對照研究要求的誤差閥值調校與 MSE 評估，導致成果難以重現。
+- **Fix**: 以均方誤差作為遺傳演算法的適應函數，演化出誤差校正閥值 δ；根據實際股價逐日判斷是否超過 `R_t × δ` 並累積校正值套用於下一期預測，同步更新 UI 卡片顯示 MSE 與閥值摘要。
+- **Diagnostics**: 本地使用 2330、0050 等案例跑預測流程，確認誤差修正僅依當下資訊更新、不回頭覆寫歷史，並檢視狀態摘要呈現基準與修正後 MSE 差異。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/forecast.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`


### PR DESCRIPTION
## Summary
- replace the residual weight optimizer with an MSE-based GA that evolves the correction threshold δ and applies cumulative error updates sequentially
- surface the new MSE metric and GA threshold summary in the forecast tab UI and bump the forecast module version code
- document release LB-FORECAST-LSTMGA-20251114B with local diagnostics and compilation checks

## Testing
- `node - <<'NODE' const fs = require('fs'); const vm = require('vm'); ['js/backtest.js','js/main.js','js/forecast.js'].forEach((file)=>{ const code = fs.readFileSync(file,'utf8'); new vm.Script(code,{filename:file}); }); console.log('scripts compile'); NODE`


------
https://chatgpt.com/codex/tasks/task_e_68d96753b488832496c0dd1283d5b473