### PR TITLE
Add per-strategy OFI scoring and surface robustness controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1854,15 +1854,26 @@
                                             <div id="batch-optimization-results" class="hidden">
                                                 <div class="card bg-background border border-border" style="background-color: var(--background); border-color: var(--border);">
                                                     <div class="card-header">
-                                                        <div class="flex items-center justify-between">
-                                                            <h4 class="card-title text-lg font-semibold">優化結果</h4>
-                                                            <div class="flex items-center gap-2">
+                                                        <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                                            <div class="flex flex-col">
+                                                                <h4 class="card-title text-lg font-semibold">優化結果</h4>
+                                                                <span id="ofi-version-label" class="text-xs text-muted-foreground" style="color: var(--muted-foreground);">OFI 指標載入中…</span>
+                                                            </div>
+                                                            <div class="flex flex-wrap items-center gap-2 justify-end">
+                                                                <button id="batch-ofi-sort" class="px-3 py-1 text-xs font-medium rounded border border-border text-foreground hover:bg-accent/20" style="border-color: var(--border); color: var(--foreground);">策略穩健度排序</button>
+                                                                <button id="batch-filter-spa" class="px-3 py-1 text-xs font-medium rounded border border-border text-foreground hover:bg-accent/20" style="border-color: var(--border); color: var(--foreground);">只看通過 SPA/MCS</button>
                                                                 <label class="text-xs text-muted-foreground" style="color: var(--muted-foreground);">排序依據:</label>
                                                                 <select id="batch-sort-key" class="px-3 py-1 border border-border rounded text-sm bg-input text-foreground" style="border-color: var(--border); background-color: var(--input); color: var(--foreground);">
                                                                     <option value="annualizedReturn">年化報酬率</option>
                                                                     <option value="sharpeRatio">夏普比率</option>
                                                                     <option value="maxDrawdown">最大回撤</option>
                                                                     <option value="tradeCount">交易次數</option>
+                                                                    <option value="ofiScore">穩健度 (OFI)</option>
+                                                                    <option value="ofiCPBO">cPBO 逆分數</option>
+                                                                    <option value="ofiMedianOOS">OOS 中位</option>
+                                                                    <option value="ofiIQR">OOS IQR</option>
+                                                                    <option value="ofiIsland">Island Score</option>
+                                                                    <option value="ofiDSR">DSR</option>
                                                                 </select>
                                                                 <button id="batch-sort-direction" class="px-2 py-1 btn-outline rounded text-sm">
                                                                     <i data-lucide="arrow-down" class="lucide"></i>
@@ -1879,6 +1890,7 @@
                                                                         <th class="px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider" style="color: var(--muted-foreground);">類型</th>
                                                                         <th class="px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider" style="color: var(--muted-foreground);">買入策略</th>
                                                                         <th class="px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider" style="color: var(--muted-foreground);">賣出策略</th>
+                                                                        <th class="px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider" style="color: var(--muted-foreground);">過擬合風險 (OFI)</th>
                                                                         <th class="px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider" style="color: var(--muted-foreground);">年化報酬率</th>
                                                                         <th class="px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider" style="color: var(--muted-foreground);">夏普比率</th>
                                                                         <th class="px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider" style="color: var(--muted-foreground);">索提諾比率</th>

--- a/log.md
+++ b/log.md
@@ -692,6 +692,12 @@
 - **Diagnostics**: 在桌機與行動尺寸檢視英雄區，確認輸入框於不同字數與清空狀態下都維持置中排版且光標與底線對齊。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
 
+## 2025-12-12 — Patch LB-OFI-20251212A
+- **Issue recap**: 批量優化結果缺乏逐策略的過擬合風險評分，僅能依單一績效指標排序，無法呼應 PBO/DSR 等學術指標，亦缺少對 SPA/MCS 合格策略的一鍵篩選。
+- **Fix**: 新增 `recomputeBatchOFIMetrics` 以 CSCV+DSR 組合計算 `OFI`（含 cPBO、OOS 分位、IslandScore、DSR）；在結果表格顯示 OFI 明細、版本與 SPA/MCS 標示，並加入「策略穩健度排序」與「只看通過 SPA/MCS」控制；更新排序/濾器狀態與 UI 元件。
+- **Diagnostics**: 以測試資料驗證 OFI 組成、排序與 SPA 篩選狀態切換，確認 `batch-ofi-sort` 與 `batch-filter-spa` 可驅動重新渲染並顯示版本碼 `LB-OFI-20251212A`；交叉優化結果也會重新計算 OFI。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/batch-optimization.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
 ## 2025-11-16 — Patch LB-PROGRESS-PIPELINE-20251116A
 - **Issue recap**: 回測進度條會自動衝到 100% 但後端流程仍在跑，且遇到 Netlify Blob 首次未命中時進度訊息卡在「檢查 Netlify Blob 範圍快取...」。
 - **Fix**: 以階段化動畫取代舊自動補數邏輯，進度僅依實際回報推進並同步於狀態文字顯示百分比；同時在 Blob 快取落空後立即發布轉換訊息，縮短停留時間。


### PR DESCRIPTION
## Summary
- implement CSCV-driven OFI computation with cPBO, OOS quantiles, island robustness, and DSR aggregation for every batch result
- expose OFI metrics in the batch optimization table with quick sorting, SPA/MCS filters, and version labeling
- document release LB-OFI-20251212A and compilation check in the changelog

## Testing
- node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/backtest.js','js/main.js','js/batch-optimization.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68db49e207108324b741e5a39cf5e6b9