### PR TITLE
Add AI prediction tab with LSTM and Kelly position sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1258,6 +1258,13 @@
                                             >
                                                 <i data-lucide="repeat" class="lucide-sm inline mr-1"></i>滾動測試
                                             </button>
+                                            <button
+                                                class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
+                                                style="color: var(--muted-foreground);"
+                                                data-tab="ai-prediction"
+                                            >
+                                                <i data-lucide="bot" class="lucide-sm inline mr-1"></i>AI預測
+                                            </button>
                                         </nav>
                                     </div>
                                 </div>
@@ -2057,6 +2064,135 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="tab-content hidden" id="ai-prediction-tab">
+                                <div class="space-y-6">
+                                    <div class="card" data-ai-prediction-version="LB-AI-LSTM-20251120A">
+                                        <div class="card-header flex flex-col gap-2">
+                                            <h3 class="card-title text-base">AI 預測 — LSTM × 凱利資金管理</h3>
+                                            <p class="text-xs leading-relaxed" style="color: var(--muted-foreground);">
+                                                參考 Fischer &amp; Krauss (2018) 對台股量化可行性的序列模型，以及 Sirignano &amp; Cont (2019)
+                                                強調的非線性市場結構，本模組使用長短期記憶網路（LSTM）分析今日至過去多日的收盤價變化，
+                                                判斷隔日收盤價是否有機會比今日高出 2 元以上。結果僅供量化研究，實際交易請再自行審慎評估。
+                                            </p>
+                                        </div>
+                                        <div class="card-content text-[11px] leading-relaxed" style="color: var(--muted-foreground);">
+                                            <p>流程包含：建立時間序列視窗 → 訓練集與測試集依 2:1 比例分割 → 使用 LSTM 分類器估計隔日漲幅達 2 元的機率 → 以凱利公式決定資金權重 → 依實際隔日收盤價回測。</p>
+                                        </div>
+                                    </div>
+                                    <div class="card">
+                                        <div class="card-header flex flex-col gap-2">
+                                            <h3 class="card-title text-base">模型參數</h3>
+                                            <p class="text-xs" style="color: var(--muted-foreground);">
+                                                預設視窗 20 日、閾值 0.55 來降低過度交易的風險；可依策略彈性調整。
+                                            </p>
+                                        </div>
+                                        <div class="card-content space-y-4">
+                                            <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4 text-xs" style="color: var(--foreground);">
+                                                <label class="flex flex-col gap-1">
+                                                    視窗長度（日）
+                                                    <input id="ai-window-size" type="number" min="10" max="90" step="1" value="20" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">多數文獻以 15~30 日捕捉短期動量。</span>
+                                                </label>
+                                                <label class="flex flex-col gap-1">
+                                                    訓練週期（Epoch）
+                                                    <input id="ai-training-epochs" type="number" min="10" max="200" step="5" value="60" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">愈多 Epoch 收斂愈充分，但訓練時間亦增加。</span>
+                                                </label>
+                                                <label class="flex flex-col gap-1">
+                                                    進場閾值（預測機率）
+                                                    <input id="ai-entry-threshold" type="number" min="0.5" max="0.9" step="0.01" value="0.55" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">高於閾值才執行買入，避免低信心訊號。</span>
+                                                </label>
+                                                <label class="flex flex-col gap-1">
+                                                    初始資金（依主回測單位）
+                                                    <input id="ai-initial-capital" type="number" min="10000" step="1000" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">若留空，系統會沿用左側主回測設定。</span>
+                                                </label>
+                                            </div>
+                                            <div class="flex flex-wrap items-center gap-3">
+                                                <button id="ai-run-prediction" class="btn-primary px-5 py-2.5 rounded-lg font-semibold flex items-center gap-2" style="background: linear-gradient(135deg, var(--primary), color-mix(in srgb, var(--accent) 60%, var(--primary)));">
+                                                    <i data-lucide="cpu" class="lucide w-4 h-4"></i>
+                                                    訓練並回測
+                                                </button>
+                                                <span id="ai-status" class="text-xs" style="color: var(--muted-foreground);">等待資料...</span>
+                                            </div>
+                                            <div id="ai-progress-bar" class="w-full h-2 rounded-full bg-muted hidden" style="background-color: color-mix(in srgb, var(--muted) 20%, transparent);">
+                                                <div id="ai-progress-indicator" class="h-2 rounded-full" style="background-color: var(--primary); width: 0%;"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="card">
+                                        <div class="card-header flex flex-col gap-2">
+                                            <h3 class="card-title text-base">模型摘要</h3>
+                                            <p class="text-xs" style="color: var(--muted-foreground);">訓練集與測試集依時間序列切割，勝率與報酬皆以預測為依據，不含交易成本。</p>
+                                        </div>
+                                        <div class="card-content">
+                                            <dl class="grid gap-4 md:grid-cols-2 xl:grid-cols-3 text-xs" style="color: var(--foreground);">
+                                                <div>
+                                                    <dt class="font-medium">訓練樣本數</dt>
+                                                    <dd id="ai-train-samples" class="text-lg font-semibold">--</dd>
+                                                </div>
+                                                <div>
+                                                    <dt class="font-medium">測試樣本數</dt>
+                                                    <dd id="ai-test-samples" class="text-lg font-semibold">--</dd>
+                                                </div>
+                                                <div>
+                                                    <dt class="font-medium">訓練進場勝率</dt>
+                                                    <dd id="ai-train-winrate" class="text-lg font-semibold">--</dd>
+                                                </div>
+                                                <div>
+                                                    <dt class="font-medium">測試預測準確率</dt>
+                                                    <dd id="ai-test-accuracy" class="text-lg font-semibold">--</dd>
+                                                </div>
+                                                <div>
+                                                    <dt class="font-medium">凱利建議投入比</dt>
+                                                    <dd id="ai-kelly-ratio" class="text-lg font-semibold">--</dd>
+                                                </div>
+                                                <div>
+                                                    <dt class="font-medium">平均單筆獲利</dt>
+                                                    <dd id="ai-average-profit" class="text-lg font-semibold">--</dd>
+                                                </div>
+                                            </dl>
+                                            <div class="mt-4 text-[11px] leading-relaxed" style="color: var(--muted-foreground);">
+                                                <p id="ai-summary-note">尚未產生模型結果。</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="card">
+                                        <div class="card-header flex flex-col gap-2">
+                                            <h3 class="card-title text-base">交易模擬</h3>
+                                            <p class="text-xs" style="color: var(--muted-foreground);">僅在模型預測隔日漲幅 ≥ 2 元且機率超過閾值時進場，採隔日收盤出場。</p>
+                                        </div>
+                                        <div class="card-content space-y-3">
+                                            <div class="flex flex-wrap items-center gap-3 text-xs" style="color: var(--foreground);">
+                                                <span>總投入次數：<strong id="ai-trade-count">0</strong></span>
+                                                <span>最終資金：<strong id="ai-final-capital">--</strong></span>
+                                                <span>總報酬率：<strong id="ai-total-return">--</strong></span>
+                                                <span>測試勝率：<strong id="ai-test-winrate">--</strong></span>
+                                            </div>
+                                            <div class="overflow-x-auto">
+                                                <table class="min-w-full divide-y divide-border text-xs" style="border-color: var(--border);">
+                                                    <thead class="bg-muted/40" style="background-color: color-mix(in srgb, var(--muted) 20%, transparent); color: var(--foreground);">
+                                                        <tr>
+                                                            <th class="px-3 py-2 text-left font-semibold">進場日</th>
+                                                            <th class="px-3 py-2 text-left font-semibold">出場日</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">進場價</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">出場價</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">投入資金</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">持股數</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">預測機率</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">凱利比重</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">單筆損益</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody id="ai-trade-table" class="divide-y divide-border" style="border-color: var(--border);"></tbody>
+                                                </table>
+                                            </div>
+                                            <p id="ai-trade-empty" class="text-[11px]" style="color: var(--muted-foreground);">尚未有模擬交易資料。</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -2119,7 +2255,7 @@
             </footer>
         </div>
     </div>
-
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.18.0/dist/tf.min.js"></script>
     <script src="js/shared-lookback.js"></script>
     <script src="js/config.js"></script>
     <script src="js/main.js"></script>
@@ -2127,6 +2263,7 @@
     <script src="js/loader.js"></script>
     <script src="js/batch-optimization.js"></script>
     <script src="js/rolling-test.js"></script>
+    <script src="js/ai-prediction.js"></script>
     
     <script>
         // Initialize Lucide icons

--- a/js/ai-prediction.js
+++ b/js/ai-prediction.js
@@ -1,0 +1,623 @@
+/* global tf, cachedStockData, cachedDataStore, getBacktestParams */
+(function () {
+    'use strict';
+
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return;
+    }
+
+    const VERSION_TAG = 'LB-AI-LSTM-20251120A';
+
+    const elements = {
+        windowSize: null,
+        epochs: null,
+        threshold: null,
+        capital: null,
+        runButton: null,
+        status: null,
+        progressBar: null,
+        progressIndicator: null,
+        trainSamples: null,
+        testSamples: null,
+        trainWinRate: null,
+        testAccuracy: null,
+        kellyRatio: null,
+        averageProfit: null,
+        summaryNote: null,
+        tradeCount: null,
+        finalCapital: null,
+        totalReturn: null,
+        testWinRate: null,
+        tradeTable: null,
+        tradeEmpty: null,
+    };
+
+    const state = {
+        running: false,
+        lastResult: null,
+    };
+
+    function assignElements() {
+        elements.windowSize = document.getElementById('ai-window-size');
+        elements.epochs = document.getElementById('ai-training-epochs');
+        elements.threshold = document.getElementById('ai-entry-threshold');
+        elements.capital = document.getElementById('ai-initial-capital');
+        elements.runButton = document.getElementById('ai-run-prediction');
+        elements.status = document.getElementById('ai-status');
+        elements.progressBar = document.getElementById('ai-progress-bar');
+        elements.progressIndicator = document.getElementById('ai-progress-indicator');
+        elements.trainSamples = document.getElementById('ai-train-samples');
+        elements.testSamples = document.getElementById('ai-test-samples');
+        elements.trainWinRate = document.getElementById('ai-train-winrate');
+        elements.testAccuracy = document.getElementById('ai-test-accuracy');
+        elements.kellyRatio = document.getElementById('ai-kelly-ratio');
+        elements.averageProfit = document.getElementById('ai-average-profit');
+        elements.summaryNote = document.getElementById('ai-summary-note');
+        elements.tradeCount = document.getElementById('ai-trade-count');
+        elements.finalCapital = document.getElementById('ai-final-capital');
+        elements.totalReturn = document.getElementById('ai-total-return');
+        elements.testWinRate = document.getElementById('ai-test-winrate');
+        elements.tradeTable = document.getElementById('ai-trade-table');
+        elements.tradeEmpty = document.getElementById('ai-trade-empty');
+    }
+
+    function setStatus(message, tone) {
+        if (!elements.status) {
+            return;
+        }
+        elements.status.textContent = message;
+        const palette = {
+            info: 'var(--muted-foreground)',
+            success: 'var(--primary)',
+            error: 'var(--destructive)',
+        };
+        elements.status.style.color = palette[tone] || palette.info;
+    }
+
+    function toggleProgress(visible) {
+        if (!elements.progressBar) return;
+        elements.progressBar.classList.toggle('hidden', !visible);
+        if (visible && elements.progressIndicator) {
+            elements.progressIndicator.style.width = '0%';
+        }
+    }
+
+    function setProgress(ratio) {
+        if (!elements.progressIndicator) return;
+        const percentage = Math.max(0, Math.min(1, Number(ratio) || 0)) * 100;
+        elements.progressIndicator.style.width = `${percentage.toFixed(1)}%`;
+    }
+
+    function parseNumber(input, options = {}) {
+        const { min = -Infinity, max = Infinity, fallback = null } = options;
+        if (!input) return fallback;
+        const value = Number.parseFloat(input.value);
+        if (!Number.isFinite(value)) return fallback;
+        const clamped = Math.min(Math.max(value, min), max);
+        if (clamped !== value) {
+            input.value = clamped.toString();
+        }
+        return clamped;
+    }
+
+    function getWindowSize() {
+        return parseNumber(elements.windowSize, { min: 10, max: 120, fallback: 20 });
+    }
+
+    function getEpochs() {
+        return Math.round(parseNumber(elements.epochs, { min: 10, max: 400, fallback: 60 }));
+    }
+
+    function getThreshold() {
+        const value = parseNumber(elements.threshold, { min: 0.5, max: 0.95, fallback: 0.55 });
+        return Number.isFinite(value) ? value : 0.55;
+    }
+
+    function getInitialCapital() {
+        const direct = parseNumber(elements.capital, { min: 1, fallback: null });
+        if (Number.isFinite(direct) && direct > 0) {
+            return direct;
+        }
+        if (typeof getBacktestParams === 'function') {
+            try {
+                const params = getBacktestParams();
+                if (params && Number.isFinite(params.initialCapital)) {
+                    return params.initialCapital;
+                }
+            } catch (error) {
+                console.warn('[AI Prediction] 無法讀取主回測資金設定：', error);
+            }
+        }
+        return 100000;
+    }
+
+    function toNumber(value) {
+        const num = Number.parseFloat(value);
+        return Number.isFinite(num) ? num : null;
+    }
+
+    function normalizeDate(dateString) {
+        if (!dateString) return '';
+        if (typeof dateString === 'string' && dateString.length >= 10) {
+            return dateString.slice(0, 10);
+        }
+        const date = new Date(dateString);
+        if (Number.isNaN(date.getTime())) return '';
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+    }
+
+    function getAvailableSeries() {
+        if (Array.isArray(window.cachedStockData) && window.cachedStockData.length > 0) {
+            return window.cachedStockData;
+        }
+        if (window.cachedDataStore instanceof Map) {
+            for (const entry of window.cachedDataStore.values()) {
+                if (entry && Array.isArray(entry.data) && entry.data.length > 0) {
+                    return entry.data;
+                }
+            }
+        }
+        return null;
+    }
+
+    function normalizeWindow(values) {
+        if (!Array.isArray(values) || values.length === 0) return [];
+        const mean = values.reduce((sum, val) => sum + val, 0) / values.length;
+        const variance = values.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) / values.length;
+        const std = variance > 0 ? Math.sqrt(variance) : 1;
+        return values.map((val) => (val - mean) / std);
+    }
+
+    function buildDataset(series, windowSize) {
+        if (!Array.isArray(series)) {
+            return { features: [], labels: [], meta: [] };
+        }
+        const sanitized = series
+            .map((row) => {
+                if (!row) return null;
+                const close = toNumber(row.close ?? row.Close);
+                const date = normalizeDate(row.date ?? row.Date);
+                if (!Number.isFinite(close) || !date) return null;
+                return { date, close };
+            })
+            .filter((item) => item)
+            .sort((a, b) => a.date.localeCompare(b.date));
+        if (sanitized.length <= windowSize) {
+            return { features: [], labels: [], meta: [] };
+        }
+        const features = [];
+        const labels = [];
+        const meta = [];
+        for (let idx = windowSize; idx < sanitized.length; idx += 1) {
+            const windowSlice = sanitized.slice(idx - windowSize, idx);
+            if (windowSlice.length !== windowSize) continue;
+            const today = windowSlice[windowSlice.length - 1];
+            const tomorrow = sanitized[idx];
+            if (!today || !tomorrow) continue;
+            if (!Number.isFinite(today.close) || !Number.isFinite(tomorrow.close)) continue;
+            const normalized = normalizeWindow(windowSlice.map((item) => item.close));
+            if (normalized.length !== windowSize) continue;
+            const diff = tomorrow.close - today.close;
+            const label = diff >= 2 ? 1 : 0;
+            features.push(normalized);
+            labels.push(label);
+            meta.push({
+                entryDate: today.date,
+                exitDate: tomorrow.date,
+                entryClose: today.close,
+                exitClose: tomorrow.close,
+                diff,
+                label,
+            });
+        }
+        return { features, labels, meta };
+    }
+
+    function splitDataset(dataset) {
+        const { features, labels, meta } = dataset;
+        if (!Array.isArray(features) || features.length === 0) {
+            return {
+                train: { features: [], labels: [], meta: [] },
+                test: { features: [], labels: [], meta: [] },
+            };
+        }
+        let splitIndex = Math.floor((features.length * 2) / 3);
+        splitIndex = Math.max(1, Math.min(splitIndex, features.length - 1));
+        return {
+            train: {
+                features: features.slice(0, splitIndex),
+                labels: labels.slice(0, splitIndex),
+                meta: meta.slice(0, splitIndex),
+            },
+            test: {
+                features: features.slice(splitIndex),
+                labels: labels.slice(splitIndex),
+                meta: meta.slice(splitIndex),
+            },
+        };
+    }
+
+    function tensorise(features, labels) {
+        const reshaped = features.map((window) => window.map((value) => [value]));
+        const featureTensor = tf.tensor3d(reshaped);
+        const labelTensor = tf.tensor2d(labels, [labels.length, 1]);
+        return { featureTensor, labelTensor };
+    }
+
+    function createModel(windowSize) {
+        const model = tf.sequential();
+        model.add(tf.layers.lstm({ units: 32, inputShape: [windowSize, 1], returnSequences: false }));
+        model.add(tf.layers.dropout({ rate: 0.2 }));
+        model.add(tf.layers.dense({ units: 16, activation: 'relu' }));
+        model.add(tf.layers.dropout({ rate: 0.1 }));
+        model.add(tf.layers.dense({ units: 1, activation: 'sigmoid' }));
+        model.compile({ optimizer: tf.train.adam(0.001), loss: 'binaryCrossentropy' });
+        return model;
+    }
+
+    function mean(values) {
+        if (!Array.isArray(values) || values.length === 0) return NaN;
+        const total = values.reduce((sum, val) => sum + val, 0);
+        return total / values.length;
+    }
+
+    function computeTradeStats(predictions, labels, threshold) {
+        let selected = 0;
+        let wins = 0;
+        let probabilitySum = 0;
+        predictions.forEach((prob, index) => {
+            if (!Number.isFinite(prob)) return;
+            if (prob >= threshold) {
+                selected += 1;
+                probabilitySum += prob;
+                if (labels[index] === 1) {
+                    wins += 1;
+                }
+            }
+        });
+        return {
+            selected,
+            wins,
+            winRate: selected > 0 ? wins / selected : 0,
+            averageProbability: selected > 0 ? probabilitySum / selected : 0,
+        };
+    }
+
+    function computeAccuracy(predictions, labels, threshold) {
+        if (!Array.isArray(labels) || labels.length === 0) return 0;
+        let correct = 0;
+        predictions.forEach((prob, index) => {
+            const predicted = Number.isFinite(prob) && prob >= threshold ? 1 : 0;
+            if (predicted === labels[index]) {
+                correct += 1;
+            }
+        });
+        return correct / labels.length;
+    }
+
+    function computeKellyOdds(meta) {
+        const successGains = [];
+        const failureLosses = [];
+        const failureShortfalls = [];
+        meta.forEach((item) => {
+            if (!item) return;
+            const gain = item.exitClose - item.entryClose;
+            if (item.label === 1) {
+                if (Number.isFinite(gain)) successGains.push(gain);
+            } else {
+                if (Number.isFinite(gain) && gain < 0) {
+                    failureLosses.push(-gain);
+                }
+                const shortfall = 2 - gain;
+                if (Number.isFinite(shortfall) && shortfall > 0) {
+                    failureShortfalls.push(shortfall);
+                }
+            }
+        });
+        const avgGain = mean(successGains);
+        const avgLossCandidate = Math.max(mean(failureLosses), mean(failureShortfalls));
+        const sanitizedGain = Number.isFinite(avgGain) && avgGain > 0 ? avgGain : 2;
+        const sanitizedLoss = Number.isFinite(avgLossCandidate) && avgLossCandidate > 0 ? avgLossCandidate : 2;
+        const odds = sanitizedGain / sanitizedLoss;
+        return {
+            avgGain: sanitizedGain,
+            avgLoss: sanitizedLoss,
+            odds,
+        };
+    }
+
+    function computeKellyFraction(probability, odds) {
+        if (!Number.isFinite(probability) || !Number.isFinite(odds) || odds <= 0) return 0;
+        const p = Math.min(Math.max(probability, 1e-6), 1 - 1e-6);
+        const q = 1 - p;
+        const fraction = (odds * p - q) / odds;
+        if (!Number.isFinite(fraction)) return 0;
+        return Math.min(Math.max(fraction, 0), 1);
+    }
+
+    function simulateTrades(predictions, meta, threshold, initialCapital, odds) {
+        let capital = initialCapital;
+        const trades = [];
+        const fractions = [];
+        predictions.forEach((prob, index) => {
+            if (!Number.isFinite(prob) || prob < threshold) return;
+            const info = meta[index];
+            if (!info) return;
+            const entryPrice = info.entryClose;
+            const exitPrice = info.exitClose;
+            if (!Number.isFinite(entryPrice) || !Number.isFinite(exitPrice) || entryPrice <= 0) return;
+            const kellyFraction = computeKellyFraction(prob, odds);
+            if (kellyFraction <= 0) return;
+            const amount = capital * kellyFraction;
+            if (!Number.isFinite(amount) || amount <= 0) return;
+            const shares = amount / entryPrice;
+            if (!Number.isFinite(shares) || shares <= 0) return;
+            const profit = shares * (exitPrice - entryPrice);
+            capital += profit;
+            trades.push({
+                entryDate: info.entryDate,
+                exitDate: info.exitDate,
+                entryPrice,
+                exitPrice,
+                amount,
+                shares,
+                probability: prob,
+                kellyFraction,
+                profit,
+                actualDiff: info.diff,
+            });
+            fractions.push(kellyFraction);
+        });
+        return { trades, finalCapital: capital, averageKelly: mean(fractions) };
+    }
+
+    function formatNumber(value, fractionDigits = 2) {
+        if (!Number.isFinite(value)) return '--';
+        return value.toLocaleString('zh-TW', {
+            minimumFractionDigits: fractionDigits,
+            maximumFractionDigits: fractionDigits,
+        });
+    }
+
+    function formatPercent(value) {
+        if (!Number.isFinite(value)) return '--';
+        return `${(value * 100).toFixed(2)}%`;
+    }
+
+    function renderTrades(trades) {
+        if (!elements.tradeTable || !elements.tradeEmpty) return;
+        elements.tradeTable.innerHTML = '';
+        if (!Array.isArray(trades) || trades.length === 0) {
+            elements.tradeEmpty.classList.remove('hidden');
+            elements.tradeEmpty.textContent = '尚未有模擬交易資料。';
+            return;
+        }
+        elements.tradeEmpty.classList.add('hidden');
+        trades.forEach((trade) => {
+            const row = document.createElement('tr');
+            const cells = [
+                trade.entryDate,
+                trade.exitDate,
+                formatNumber(trade.entryPrice),
+                formatNumber(trade.exitPrice),
+                formatNumber(trade.amount),
+                formatNumber(trade.shares, 4),
+                formatPercent(trade.probability),
+                formatPercent(trade.kellyFraction),
+                formatNumber(trade.profit),
+            ];
+            cells.forEach((value, idx) => {
+                const cell = document.createElement('td');
+                cell.className = idx >= 2 ? 'px-3 py-2 text-right whitespace-nowrap' : 'px-3 py-2 text-left whitespace-nowrap';
+                cell.textContent = value;
+                row.appendChild(cell);
+            });
+            elements.tradeTable.appendChild(row);
+        });
+    }
+
+    function updateMetrics(result) {
+        if (!result) return;
+        if (elements.trainSamples) elements.trainSamples.textContent = result.trainSamples.toString();
+        if (elements.testSamples) elements.testSamples.textContent = result.testSamples.toString();
+        if (elements.trainWinRate) elements.trainWinRate.textContent = formatPercent(result.trainWinRate);
+        if (elements.testAccuracy) elements.testAccuracy.textContent = formatPercent(result.testAccuracy);
+        if (elements.kellyRatio) elements.kellyRatio.textContent = formatPercent(result.averageKellyFraction);
+        if (elements.averageProfit) elements.averageProfit.textContent = formatNumber(result.averageProfit);
+        if (elements.tradeCount) elements.tradeCount.textContent = result.tradeCount.toString();
+        if (elements.finalCapital) elements.finalCapital.textContent = formatNumber(result.finalCapital);
+        if (elements.totalReturn) elements.totalReturn.textContent = formatPercent(result.totalReturn);
+        if (elements.testWinRate) elements.testWinRate.textContent = formatPercent(result.testTradeWinRate);
+        if (elements.summaryNote) {
+            elements.summaryNote.textContent = result.summaryNote;
+        }
+        renderTrades(result.trades);
+    }
+
+    async function runPrediction() {
+        if (state.running) return;
+        if (typeof tf === 'undefined' || !tf || typeof tf.sequential !== 'function') {
+            setStatus('尚未載入 TensorFlow.js，請檢查網路連線。', 'error');
+            return;
+        }
+        const windowSize = getWindowSize();
+        const epochs = getEpochs();
+        const threshold = getThreshold();
+        const initialCapital = getInitialCapital();
+        const series = getAvailableSeries();
+        if (!Array.isArray(series) || series.length < windowSize + 5) {
+            setStatus('請先在左側執行主回測，並確保快取中有足夠的價格資料。', 'error');
+            return;
+        }
+
+        state.running = true;
+        setStatus('準備資料中...', 'info');
+        toggleProgress(true);
+        setProgress(0);
+        if (elements.runButton) {
+            elements.runButton.disabled = true;
+            elements.runButton.classList.add('opacity-70', 'cursor-not-allowed');
+        }
+
+        await tf.ready();
+
+        const dataset = buildDataset(series, windowSize);
+        if (dataset.features.length < 30) {
+            setStatus('資料樣本不足，無法訓練可靠的 LSTM 模型。', 'error');
+            toggleProgress(false);
+            if (elements.runButton) {
+                elements.runButton.disabled = false;
+                elements.runButton.classList.remove('opacity-70', 'cursor-not-allowed');
+            }
+            state.running = false;
+            return;
+        }
+
+        const split = splitDataset(dataset);
+        const trainSamples = split.train.features.length;
+        const testSamples = split.test.features.length;
+        if (trainSamples < 10 || testSamples < 5) {
+            setStatus('資料切割後樣本仍不足，請拉長回測區間或縮短視窗。', 'error');
+            toggleProgress(false);
+            if (elements.runButton) {
+                elements.runButton.disabled = false;
+                elements.runButton.classList.remove('opacity-70', 'cursor-not-allowed');
+            }
+            state.running = false;
+            return;
+        }
+
+        let model = null;
+        let trainX;
+        let trainY;
+        let testX;
+        let testY;
+        let trainPredTensor;
+        let testPredTensor;
+
+        try {
+            const trainTensors = tensorise(split.train.features, split.train.labels);
+            const testTensors = tensorise(split.test.features, split.test.labels);
+            trainX = trainTensors.featureTensor;
+            trainY = trainTensors.labelTensor;
+            testX = testTensors.featureTensor;
+            testY = testTensors.labelTensor;
+
+            model = createModel(windowSize);
+
+            const batchSize = Math.max(8, Math.floor(trainSamples / 4));
+            const validationSplit = trainSamples > 60 ? 0.1 : 0;
+
+            await model.fit(trainX, trainY, {
+                epochs,
+                batchSize,
+                shuffle: false,
+                validationSplit,
+                callbacks: {
+                    onEpochEnd: async (epoch, logs) => {
+                        const loss = Number.isFinite(logs?.loss) ? logs.loss.toFixed(4) : '—';
+                        const valLoss = Number.isFinite(logs?.val_loss) ? `｜val ${logs.val_loss.toFixed(4)}` : '';
+                        setStatus(`Epoch ${epoch + 1}/${epochs} 完成，loss ${loss}${valLoss}`, 'info');
+                        setProgress((epoch + 1) / epochs);
+                        await tf.nextFrame();
+                    },
+                },
+            });
+
+            trainPredTensor = model.predict(trainX);
+            testPredTensor = model.predict(testX);
+            const trainPredArray = Array.from(await trainPredTensor.data());
+            const testPredArray = Array.from(await testPredTensor.data());
+
+            const trainStats = computeTradeStats(trainPredArray, split.train.labels, threshold);
+            const trainAccuracy = computeAccuracy(trainPredArray, split.train.labels, threshold);
+            const testAccuracy = computeAccuracy(testPredArray, split.test.labels, threshold);
+            const kelly = computeKellyOdds(split.train.meta);
+            const simulation = simulateTrades(testPredArray, split.test.meta, threshold, initialCapital, kelly.odds);
+            const trades = simulation.trades;
+            const testTradeWins = trades.filter((trade) => trade.actualDiff >= 2).length;
+            const averageProfit = trades.length > 0 ? trades.reduce((sum, trade) => sum + trade.profit, 0) / trades.length : 0;
+            const totalReturn = trades.length > 0 ? (simulation.finalCapital - initialCapital) / initialCapital : 0;
+
+            const summaryNote = trades.length > 0
+                ? `模型以 ${windowSize} 日視窗訓練 ${trainSamples} 筆樣本，訓練進場勝率 ${formatPercent(trainStats.winRate)}，平均預測機率 ${formatPercent(trainStats.averageProbability)}。依據凱利公式推估平均投入 ${formatPercent(simulation.averageKelly)} 的資金，測試期執行 ${trades.length} 筆交易，總報酬率 ${formatPercent(totalReturn)}。`
+                : `模型以 ${windowSize} 日視窗訓練 ${trainSamples} 筆樣本，訓練進場勝率 ${formatPercent(trainStats.winRate)}。測試階段未找到達到閾值的交易訊號，請調整參數後再試。`;
+
+            const result = {
+                version: VERSION_TAG,
+                windowSize,
+                epochs,
+                threshold,
+                initialCapital,
+                trainSamples,
+                testSamples,
+                trainWinRate: trainStats.winRate,
+                trainAccuracy,
+                testAccuracy,
+                averageKellyFraction: Number.isFinite(simulation.averageKelly) && simulation.averageKelly > 0 ? simulation.averageKelly : computeKellyFraction(trainStats.winRate, kelly.odds),
+                averageProfit,
+                trades,
+                tradeCount: trades.length,
+                finalCapital: simulation.finalCapital,
+                totalReturn,
+                testTradeWinRate: trades.length > 0 ? testTradeWins / trades.length : 0,
+                summaryNote,
+            };
+
+            state.lastResult = result;
+            updateMetrics(result);
+            setStatus('AI 預測完成，可以在下方檢視交易模擬結果。', 'success');
+        } catch (error) {
+            console.error('[AI Prediction] 執行失敗：', error);
+            setStatus(error?.message || '模型訓練或回測時發生錯誤。', 'error');
+        } finally {
+            if (trainPredTensor) trainPredTensor.dispose();
+            if (testPredTensor) testPredTensor.dispose();
+            if (trainX) trainX.dispose();
+            if (trainY) trainY.dispose();
+            if (testX) testX.dispose();
+            if (testY) testY.dispose();
+            if (model) model.dispose();
+            toggleProgress(false);
+            if (elements.runButton) {
+                elements.runButton.disabled = false;
+                elements.runButton.classList.remove('opacity-70', 'cursor-not-allowed');
+            }
+            state.running = false;
+        }
+    }
+
+    function init() {
+        assignElements();
+        if (!elements.runButton) {
+            console.warn('[AI Prediction] 無法找到操作按鈕，初始化中止。');
+            return;
+        }
+        if (elements.capital && !elements.capital.placeholder && typeof getBacktestParams === 'function') {
+            try {
+                const params = getBacktestParams();
+                if (params && Number.isFinite(params.initialCapital)) {
+                    elements.capital.placeholder = params.initialCapital.toString();
+                }
+            } catch (error) {
+                console.warn('[AI Prediction] 無法讀取主回測資金設定：', error);
+            }
+        }
+        setStatus('等待資料...', 'info');
+        elements.runButton.addEventListener('click', runPrediction);
+        window.lazybacktestAIPrediction = {
+            version: VERSION_TAG,
+            getState: () => ({ ...state }),
+            runPrediction,
+        };
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/log.md
+++ b/log.md
@@ -1,3 +1,8 @@
+## 2025-11-20 — Patch LB-AI-LSTM-20251120A
+- **Scope**: 新增「AI 預測」分頁，導入 LSTM 與凱利公式的隔日漲幅分析與資金管理模組。
+- **Features**: 建立 TensorFlow.js 訓練流程（20 日視窗預設）、依 2:1 分割訓練/測試資料、整合凱利權重模擬隔日買進賣出報酬、提供交易紀錄與摘要勝率。
+- **Testing**: `node - <<'NODE' const fs=require('fs');['js/backtest.js','js/main.js','js/worker.js','js/ai-prediction.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new (require('vm').Script)(code,{filename:file});});console.log('scripts compile');NODE`
+
 ## 2025-11-12 — Patch LB-TRADE-ENTRY-20251112A
 - **Issue recap**: 分段進場在全部出場後，`buildAggregatedLongEntry` 仍以已被清零的 `longPositionCost*` 值計算，導致交易紀錄中的買入價格被顯示為 0。
 - **Fix**: 改用每段進場快照的 `originalCost`／`originalCostWithoutFee` 與 `originalShares` 彙總平均成本，確保整併後的買入價格維持原始交易成本。


### PR DESCRIPTION
## Summary
- add an "AI預測" tab with controls and reporting for LSTM-based next-day price classification and Kelly-managed trade simulation
- implement ai-prediction.js using TensorFlow.js with a 2:1 train/test split, Kelly odds calibration, and tab-specific status rendering
- include the TensorFlow.js dependency and record the new LB-AI-LSTM-20251120A patch details in log.md

## Testing
- node - <<'NODE' const fs=require('fs');['js/backtest.js','js/main.js','js/worker.js','js/ai-prediction.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new (require('vm').Script)(code,{filename:file});});console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68db7e0f00c4832489ac968d3fb835e3