### PR TITLE
Add AI prediction tab with LSTM Kelly simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1258,6 +1258,13 @@
                                             >
                                                 <i data-lucide="repeat" class="lucide-sm inline mr-1"></i>滾動測試
                                             </button>
+                                            <button
+                                                class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
+                                                style="color: var(--muted-foreground);"
+                                                data-tab="ai-predict"
+                                            >
+                                                <i data-lucide="brain" class="lucide-sm inline mr-1"></i>AI 預測
+                                            </button>
                                         </nav>
                                     </div>
                                 </div>
@@ -2057,6 +2064,112 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="tab-content hidden space-y-6" id="ai-predict-tab">
+                                <div class="card shadow-lg">
+                                    <div class="card-header">
+                                        <div class="flex items-center justify-between gap-3">
+                                            <h3 class="card-title flex items-center gap-2">
+                                                <i data-lucide="brain" class="lucide-sm"></i>
+                                                AI 預測實驗室
+                                            </h3>
+                                            <span id="aiPredictVersionLabel" class="text-[11px] font-medium uppercase tracking-wide" style="color: var(--muted-foreground);"></span>
+                                        </div>
+                                    </div>
+                                    <div class="card-content space-y-4 text-sm" style="color: var(--muted-foreground);">
+                                        <p class="leading-relaxed">
+                                            參考近期 LSTM 於金融市場預測的研究（Fischer &amp; Krauss, 2018；Nelson et al., 2017；Hoseinzade &amp; Haratizadeh, 2019），我們設計一個以台股日收盤價為核心的序列模型，透過 TensorFlow.js 在瀏覽器端即時訓練，判斷隔日收盤價是否相對今日上漲至少 2 元。
+                                        </p>
+                                        <p class="leading-relaxed">
+                                            模型將回測區間的有效交易資料依時間切分為 2:1 的訓練／測試集合，並以凱利公式（Kelly, 1956）計算每次多單進場應投入的資金比例，僅在預測隔日上漲時於今日收盤價買入，隔日收盤價全數出清以計算實測績效。
+                                        </p>
+                                        <div class="border border-dashed rounded-lg p-4" style="border-color: var(--border);">
+                                            <h4 class="font-semibold text-foreground text-sm mb-2">操作說明</h4>
+                                            <ul class="space-y-1 text-xs">
+                                                <li>• 先執行一般回測取得價格資料，再切換到「AI 預測」分頁。</li>
+                                                <li>• 點擊下方按鈕即會在本機訓練 LSTM，計算預測勝率、凱利資金與模擬報酬。</li>
+                                                <li>• 若資料不足或缺乏連續收盤價，系統會提示補齊回測區間。</li>
+                                            </ul>
+                                        </div>
+                                        <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+                                            <button id="aiPredictRunBtn" class="btn-primary px-6 py-3 rounded-lg font-semibold flex items-center justify-center gap-2" type="button">
+                                                <i data-lucide="play" class="lucide-sm"></i>
+                                                執行 AI 預測
+                                            </button>
+                                            <span id="aiPredictStatus" class="text-xs" style="color: var(--muted-foreground);" aria-live="polite"></span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="card shadow-lg">
+                                    <div class="card-header">
+                                        <h3 class="card-title">模型評估與凱利資金配置</h3>
+                                    </div>
+                                    <div class="card-content">
+                                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm" id="aiPredictMetrics" style="color: var(--muted-foreground);">
+                                            <div class="p-3 rounded-lg border" style="border-color: var(--border);">
+                                                <div class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">訓練準確率</div>
+                                                <div class="text-2xl font-semibold text-foreground" id="aiTrainAccuracy">-</div>
+                                            </div>
+                                            <div class="p-3 rounded-lg border" style="border-color: var(--border);">
+                                                <div class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">訓練勝率（預測為上漲時）</div>
+                                                <div class="text-2xl font-semibold text-foreground" id="aiTrainWinRate">-</div>
+                                            </div>
+                                            <div class="p-3 rounded-lg border" style="border-color: var(--border);">
+                                                <div class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">測試準確率</div>
+                                                <div class="text-2xl font-semibold text-foreground" id="aiTestAccuracy">-</div>
+                                            </div>
+                                            <div class="p-3 rounded-lg border" style="border-color: var(--border);">
+                                                <div class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">測試勝率（預測為上漲時）</div>
+                                                <div class="text-2xl font-semibold text-foreground" id="aiTestWinRate">-</div>
+                                            </div>
+                                            <div class="p-3 rounded-lg border" style="border-color: var(--border);">
+                                                <div class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">凱利建議投入比例</div>
+                                                <div class="text-2xl font-semibold text-foreground" id="aiKellyFraction">-</div>
+                                            </div>
+                                            <div class="p-3 rounded-lg border" style="border-color: var(--border);">
+                                                <div class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">平均單筆獲利</div>
+                                                <div class="text-2xl font-semibold text-foreground" id="aiAverageProfit">-</div>
+                                            </div>
+                                            <div class="p-3 rounded-lg border" style="border-color: var(--border);">
+                                                <div class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">總報酬率</div>
+                                                <div class="text-2xl font-semibold text-foreground" id="aiTotalReturn">-</div>
+                                            </div>
+                                            <div class="p-3 rounded-lg border" style="border-color: var(--border);">
+                                                <div class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">執行交易次數</div>
+                                                <div class="text-2xl font-semibold text-foreground" id="aiTradeCount">-</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="card shadow-lg">
+                                    <div class="card-header flex items-center justify-between">
+                                        <h3 class="card-title">交易模擬結果（僅做多）</h3>
+                                        <button id="aiPredictExportBtn" class="text-xs px-2 py-1 rounded border" style="border-color: var(--border); color: var(--muted-foreground);" type="button">匯出 CSV</button>
+                                    </div>
+                                    <div class="card-content overflow-x-auto">
+                                        <table class="min-w-full text-xs" id="aiPredictTradesTable">
+                                            <thead style="background-color: var(--muted); color: var(--foreground);">
+                                                <tr>
+                                                    <th class="px-3 py-2 text-left font-semibold">買進日期</th>
+                                                    <th class="px-3 py-2 text-right font-semibold">買進價</th>
+                                                    <th class="px-3 py-2 text-right font-semibold">隔日收盤價</th>
+                                                    <th class="px-3 py-2 text-right font-semibold">價格差</th>
+                                                    <th class="px-3 py-2 text-right font-semibold">報酬率</th>
+                                                    <th class="px-3 py-2 text-right font-semibold">預測機率</th>
+                                                    <th class="px-3 py-2 text-right font-semibold">投入資金</th>
+                                                    <th class="px-3 py-2 text-right font-semibold">損益</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="aiPredictTradesBody" class="divide-y" style="border-color: var(--border); color: var(--muted-foreground);">
+                                                <tr>
+                                                    <td colspan="8" class="px-3 py-4 text-center text-xs">尚未執行 AI 預測或無符合條件的交易。</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -2124,9 +2237,11 @@
     <script src="js/config.js"></script>
     <script src="js/main.js"></script>
     <script src="js/backtest.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.20.0/dist/tf.min.js"></script>
     <script src="js/loader.js"></script>
     <script src="js/batch-optimization.js"></script>
     <script src="js/rolling-test.js"></script>
+    <script src="js/ai-predict.js"></script>
     
     <script>
         // Initialize Lucide icons

--- a/js/ai-predict.js
+++ b/js/ai-predict.js
@@ -1,0 +1,561 @@
+/* global tf, lastOverallResult, cachedStockData, trendAnalysisState */
+// --- AI 預測模組 - 版本碼 LB-AI-PREDICT-20250921A ---
+(function initAIPredictor() {
+    const VERSION_CODE = 'LB-AI-PREDICT-20250921A';
+    const WINDOW_SIZE = 20;
+    const EPOCHS = 40;
+    const BATCH_SIZE = 32;
+    const POSITIVE_GAP = 2; // 元
+    const PREDICTION_THRESHOLD = 0.5;
+
+    const percentFormatter = new Intl.NumberFormat('zh-TW', {
+        style: 'percent',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    });
+    const currencyFormatter = new Intl.NumberFormat('zh-TW', {
+        style: 'currency',
+        currency: 'TWD',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+    });
+    const decimalFormatter = new Intl.NumberFormat('zh-TW', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    });
+
+    const state = {
+        running: false,
+        trades: [],
+        elements: {
+            runBtn: null,
+            status: null,
+            version: null,
+            metrics: {
+                trainAccuracy: null,
+                trainWinRate: null,
+                testAccuracy: null,
+                testWinRate: null,
+                kellyFraction: null,
+                averageProfit: null,
+                totalReturn: null,
+                tradeCount: null,
+            },
+            tradesBody: null,
+            exportBtn: null,
+        },
+        kellyFraction: 0,
+        initialCapital: 0,
+    };
+
+    function formatPercent(value) {
+        if (!Number.isFinite(value)) return '-';
+        return percentFormatter.format(value);
+    }
+
+    function formatPercentFromRatio(value) {
+        if (!Number.isFinite(value)) return '-';
+        return `${decimalFormatter.format(value * 100)}%`;
+    }
+
+    function formatCurrency(value) {
+        if (!Number.isFinite(value)) return '-';
+        return currencyFormatter.format(value);
+    }
+
+    function formatNumber(value, fractionDigits = 4) {
+        if (!Number.isFinite(value)) return '-';
+        return Number(value).toFixed(fractionDigits);
+    }
+
+    function getElement(id) {
+        return document.getElementById(id);
+    }
+
+    function setStatus(message, type = 'info') {
+        if (!state.elements.status) return;
+        const colorMap = {
+            success: 'var(--primary)',
+            error: 'var(--destructive)',
+            warning: 'var(--secondary)',
+            progress: 'var(--primary)',
+            info: 'var(--muted-foreground)',
+        };
+        state.elements.status.textContent = message || '';
+        state.elements.status.style.color = colorMap[type] || 'var(--muted-foreground)';
+    }
+
+    function setMetric(key, value) {
+        const target = state.elements.metrics[key];
+        if (target) target.textContent = value;
+    }
+
+    function resetMetrics() {
+        Object.keys(state.elements.metrics).forEach((key) => {
+            setMetric(key, '-');
+        });
+        if (state.elements.tradesBody) {
+            state.elements.tradesBody.innerHTML = `
+                <tr>
+                    <td colspan="8" class="px-3 py-4 text-center text-xs">尚未執行 AI 預測或無符合條件的交易。</td>
+                </tr>`;
+        }
+        state.trades = [];
+        state.kellyFraction = 0;
+    }
+
+    function setRunning(running) {
+        state.running = running;
+        if (state.elements.runBtn) {
+            state.elements.runBtn.disabled = running;
+            state.elements.runBtn.classList.toggle('opacity-70', running);
+            state.elements.runBtn.classList.toggle('cursor-wait', running);
+        }
+    }
+
+    function sanitizeRow(row) {
+        if (!row || typeof row !== 'object') return null;
+        const date = typeof row.date === 'string' ? row.date.slice(0, 10) : null;
+        const close = Number(row.close ?? row.Close ?? NaN);
+        if (!date || !Number.isFinite(close)) return null;
+        return { date, close };
+    }
+
+    function collectRawRows() {
+        const sources = [];
+        if (typeof trendAnalysisState === 'object' && trendAnalysisState && trendAnalysisState.result && Array.isArray(trendAnalysisState.result.rawData)) {
+            sources.push(trendAnalysisState.result.rawData);
+        }
+        if (lastOverallResult) {
+            if (Array.isArray(lastOverallResult.rawData)) sources.push(lastOverallResult.rawData);
+            if (Array.isArray(lastOverallResult.rawDataUsed)) sources.push(lastOverallResult.rawDataUsed);
+        }
+        if (Array.isArray(cachedStockData)) {
+            sources.push(cachedStockData);
+        }
+        for (let i = 0; i < sources.length; i += 1) {
+            const rows = sources[i];
+            if (Array.isArray(rows) && rows.length > 0) {
+                return rows;
+            }
+        }
+        return [];
+    }
+
+    function extractDataset() {
+        const rawRows = collectRawRows();
+        const allowedDates = Array.isArray(lastOverallResult?.dates)
+            ? new Set(lastOverallResult.dates.filter((d) => typeof d === 'string'))
+            : null;
+        const seen = new Set();
+        const sanitized = [];
+        rawRows.forEach((row) => {
+            const sanitizedRow = sanitizeRow(row);
+            if (!sanitizedRow) return;
+            if (allowedDates && !allowedDates.has(sanitizedRow.date)) return;
+            if (seen.has(sanitizedRow.date)) return;
+            seen.add(sanitizedRow.date);
+            sanitized.push(sanitizedRow);
+        });
+        sanitized.sort((a, b) => new Date(a.date) - new Date(b.date));
+        return sanitized;
+    }
+
+    function buildSamples(rows) {
+        const sequences = [];
+        const labels = [];
+        const meta = [];
+        for (let i = WINDOW_SIZE - 1; i < rows.length - 1; i += 1) {
+            const windowSlice = rows.slice(i - WINDOW_SIZE + 1, i + 1);
+            if (windowSlice.some((item) => !Number.isFinite(item.close))) {
+                continue;
+            }
+            const today = rows[i];
+            const tomorrow = rows[i + 1];
+            if (!Number.isFinite(today.close) || !Number.isFinite(tomorrow.close)) {
+                continue;
+            }
+            const sequence = windowSlice.map((item) => item.close);
+            const priceDiff = tomorrow.close - today.close;
+            const label = priceDiff >= POSITIVE_GAP ? 1 : 0;
+            sequences.push(sequence);
+            labels.push(label);
+            meta.push({
+                today,
+                tomorrow,
+                priceDiff,
+            });
+        }
+        return { sequences, labels, meta };
+    }
+
+    function splitData(sequences, labels, meta) {
+        const total = sequences.length;
+        if (total < 2) {
+            return null;
+        }
+        let trainCount = Math.floor((total * 2) / 3);
+        trainCount = Math.max(1, Math.min(total - 1, trainCount));
+        const testCount = total - trainCount;
+        const train = {
+            sequences: sequences.slice(0, trainCount),
+            labels: labels.slice(0, trainCount),
+            meta: meta.slice(0, trainCount),
+        };
+        const test = {
+            sequences: sequences.slice(trainCount),
+            labels: labels.slice(trainCount),
+            meta: meta.slice(trainCount),
+        };
+        return { train, test };
+    }
+
+    function normalizeSequences(trainSeqs, testSeqs) {
+        const flatten = trainSeqs.flat();
+        const valid = flatten.filter((value) => Number.isFinite(value));
+        const mean = valid.reduce((sum, value) => sum + value, 0) / valid.length;
+        const variance = valid.reduce((sum, value) => {
+            const diff = value - mean;
+            return sum + diff * diff;
+        }, 0) / valid.length;
+        const std = Math.sqrt(Math.max(variance, 1e-9));
+        const normalize = (seq) => seq.map((value) => (value - mean) / std);
+        return {
+            train: trainSeqs.map(normalize),
+            test: testSeqs.map(normalize),
+            mean,
+            std,
+        };
+    }
+
+    function sequencesToTensor(sequences) {
+        const data = sequences.map((sequence) => sequence.map((value) => [value]));
+        return tf.tensor3d(data, [sequences.length, WINDOW_SIZE, 1]);
+    }
+
+    function labelsToTensor(labels) {
+        return tf.tensor2d(labels, [labels.length, 1]);
+    }
+
+    function createModel() {
+        const model = tf.sequential();
+        model.add(tf.layers.lstm({
+            units: 32,
+            inputShape: [WINDOW_SIZE, 1],
+            returnSequences: false,
+        }));
+        model.add(tf.layers.dropout({ rate: 0.2 }));
+        model.add(tf.layers.dense({ units: 16, activation: 'relu' }));
+        model.add(tf.layers.dense({ units: 1, activation: 'sigmoid' }));
+        model.compile({
+            optimizer: tf.train.adam(0.001),
+            loss: 'binaryCrossentropy',
+            metrics: ['accuracy'],
+        });
+        return model;
+    }
+
+    function computeTradeOutcomes(predictions, labels, meta) {
+        const trades = [];
+        let wins = 0;
+        let totalPredicted = 0;
+        predictions.forEach((probability, index) => {
+            const predictedPositive = probability >= PREDICTION_THRESHOLD;
+            if (!predictedPositive) return;
+            totalPredicted += 1;
+            const label = labels[index] === 1;
+            if (label) wins += 1;
+            const today = meta[index].today;
+            const tomorrow = meta[index].tomorrow;
+            const buyPrice = today.close;
+            const sellPrice = tomorrow.close;
+            const priceDiff = sellPrice - buyPrice;
+            const returnPct = Number.isFinite(buyPrice) && buyPrice !== 0 ? priceDiff / buyPrice : 0;
+            trades.push({
+                date: today.date,
+                buyPrice,
+                sellPrice,
+                priceDiff,
+                returnPct,
+                probability,
+                actualWin: label,
+            });
+        });
+        const winRate = totalPredicted > 0 ? wins / totalPredicted : 0;
+        return { trades, winRate, totalPredicted };
+    }
+
+    function computeKelly(trades) {
+        if (trades.length === 0) {
+            return {
+                fraction: 0,
+                winProbability: 0,
+                avgGain: 0,
+                avgLoss: 0,
+            };
+        }
+        const winning = trades.filter((trade) => trade.actualWin);
+        const losing = trades.filter((trade) => !trade.actualWin);
+        const avgGain = winning.length > 0
+            ? winning.reduce((sum, trade) => sum + trade.returnPct, 0) / winning.length
+            : 0;
+        const avgLoss = losing.length > 0
+            ? Math.abs(losing.reduce((sum, trade) => sum + trade.returnPct, 0) / losing.length)
+            : 0;
+        const winProbability = winning.length / trades.length;
+        const b = avgLoss > 0 ? avgGain / avgLoss : null;
+        const fraction = b && Number.isFinite(b)
+            ? Math.max(0, Math.min(1, winProbability - (1 - winProbability) / b))
+            : 0;
+        return {
+            fraction,
+            winProbability,
+            avgGain,
+            avgLoss,
+        };
+    }
+
+    function simulateKellyTrades(trades, initialCapital, fraction) {
+        const results = [];
+        let capital = initialCapital;
+        trades.forEach((trade) => {
+            const invest = capital * fraction;
+            const profit = invest * trade.returnPct;
+            capital += profit;
+            results.push({
+                ...trade,
+                invested: invest,
+                profit,
+                capitalAfter: capital,
+            });
+        });
+        const totalReturn = initialCapital > 0 ? (capital - initialCapital) / initialCapital : 0;
+        const averageProfit = trades.length > 0
+            ? results.reduce((sum, trade) => sum + trade.profit, 0) / trades.length
+            : 0;
+        return {
+            results,
+            totalReturn,
+            averageProfit,
+            finalCapital: capital,
+        };
+    }
+
+    function renderTrades(trades) {
+        if (!state.elements.tradesBody) return;
+        if (!Array.isArray(trades) || trades.length === 0) {
+            state.elements.tradesBody.innerHTML = `
+                <tr>
+                    <td colspan="8" class="px-3 py-4 text-center text-xs">模型於測試集未產生符合條件的交易。</td>
+                </tr>`;
+            return;
+        }
+        const rows = trades.map((trade) => `
+            <tr>
+                <td class="px-3 py-2 text-left">${trade.date}</td>
+                <td class="px-3 py-2 text-right">${formatCurrency(trade.buyPrice)}</td>
+                <td class="px-3 py-2 text-right">${formatCurrency(trade.sellPrice)}</td>
+                <td class="px-3 py-2 text-right">${formatCurrency(trade.priceDiff)}</td>
+                <td class="px-3 py-2 text-right">${formatPercentFromRatio(trade.returnPct)}</td>
+                <td class="px-3 py-2 text-right">${formatPercent(trade.probability)}</td>
+                <td class="px-3 py-2 text-right">${formatCurrency(trade.invested)}</td>
+                <td class="px-3 py-2 text-right">${formatCurrency(trade.profit)}</td>
+            </tr>
+        `);
+        state.elements.tradesBody.innerHTML = rows.join('');
+    }
+
+    function getInitialCapital() {
+        const input = document.getElementById('initialCapital');
+        const value = Number(input?.value);
+        if (Number.isFinite(value) && value > 0) return value;
+        return 100000;
+    }
+
+    function exportCsv() {
+        if (!Array.isArray(state.trades) || state.trades.length === 0) {
+            setStatus('目前沒有可匯出的 AI 預測交易。', 'warning');
+            return;
+        }
+        const headers = [
+            '買進日期',
+            '買進價',
+            '隔日收盤價',
+            '價格差',
+            '報酬率',
+            '預測機率',
+            '投入資金',
+            '損益',
+            '是否達成 +2 元',
+        ];
+        const rows = state.trades.map((trade) => [
+            trade.date,
+            trade.buyPrice.toFixed(2),
+            trade.sellPrice.toFixed(2),
+            trade.priceDiff.toFixed(2),
+            (trade.returnPct * 100).toFixed(2),
+            (trade.probability * 100).toFixed(2),
+            trade.invested.toFixed(2),
+            trade.profit.toFixed(2),
+            trade.actualWin ? '是' : '否',
+        ].join(','));
+        const csvContent = `${headers.join(',')}\n${rows.join('\n')}`;
+        const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `ai_predict_${Date.now()}.csv`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(() => URL.revokeObjectURL(url), 0);
+        setStatus('已匯出 AI 預測交易明細。', 'success');
+    }
+
+    async function runPrediction() {
+        if (state.running) return;
+        try {
+            setRunning(true);
+            setStatus('準備資料與 TensorFlow.js 執行環境...', 'progress');
+            if (typeof tf === 'undefined' || typeof tf.ready !== 'function') {
+                throw new Error('TensorFlow.js 未成功載入，請確認網路連線後再試。');
+            }
+            await tf.ready();
+            if (!lastOverallResult || !Array.isArray(lastOverallResult.dates) || lastOverallResult.dates.length === 0) {
+                throw new Error('請先於主頁籤完成一次回測，以取得訓練所需的歷史資料。');
+            }
+            const dataset = extractDataset();
+            if (!Array.isArray(dataset) || dataset.length < WINDOW_SIZE + 2) {
+                throw new Error('資料筆數不足，請拉長回測區間或確認資料來源完整。');
+            }
+            const samples = buildSamples(dataset);
+            if (!samples.sequences.length) {
+                throw new Error('無法從資料中建立有效樣本，可能是收盤價缺漏或非交易日。');
+            }
+            const split = splitData(samples.sequences, samples.labels, samples.meta);
+            if (!split) {
+                throw new Error('可用樣本不足以切分訓練／測試集，請放寬回測期間。');
+            }
+            const normalized = normalizeSequences(split.train.sequences, split.test.sequences);
+            const xTrain = sequencesToTensor(normalized.train);
+            const yTrain = labelsToTensor(split.train.labels);
+            const xTest = sequencesToTensor(normalized.test);
+            const yTest = labelsToTensor(split.test.labels);
+            const model = createModel();
+            const totalEpochs = EPOCHS;
+            await model.fit(xTrain, yTrain, {
+                epochs: totalEpochs,
+                batchSize: Math.min(BATCH_SIZE, split.train.sequences.length),
+                shuffle: false,
+                validationSplit: 0.1,
+                callbacks: {
+                    onEpochEnd: async (epoch, logs) => {
+                        const loss = formatNumber(logs?.loss, 4);
+                        const acc = Number.isFinite(logs?.acc) ? formatPercent(logs.acc) : (Number.isFinite(logs?.accuracy) ? formatPercent(logs.accuracy) : '');
+                        setStatus(`訓練中（${epoch + 1}/${totalEpochs}）：loss=${loss}${acc ? `，accuracy=${acc}` : ''}`, 'progress');
+                        await tf.nextFrame();
+                    },
+                },
+            });
+
+            const trainEval = await model.evaluate(xTrain, yTrain, { batchSize: Math.min(BATCH_SIZE, split.train.sequences.length), verbose: 0 });
+            const testEval = await model.evaluate(xTest, yTest, { batchSize: Math.min(BATCH_SIZE, split.test.sequences.length), verbose: 0 });
+            const trainAccTensor = Array.isArray(trainEval) ? trainEval[1] : null;
+            const testAccTensor = Array.isArray(testEval) ? testEval[1] : null;
+            const trainAccuracy = Number(trainAccTensor ? (await trainAccTensor.data())[0] : 0);
+            const testAccuracy = Number(testAccTensor ? (await testAccTensor.data())[0] : 0);
+
+            const trainPredTensor = model.predict(xTrain);
+            const testPredTensor = model.predict(xTest);
+            const trainPredictions = Array.from(await trainPredTensor.data());
+            const testPredictions = Array.from(await testPredTensor.data());
+
+            if (Array.isArray(trainEval)) trainEval.forEach((tensor) => tensor.dispose());
+            else if (trainEval && typeof trainEval.dispose === 'function') trainEval.dispose();
+            if (Array.isArray(testEval)) testEval.forEach((tensor) => tensor.dispose());
+            else if (testEval && typeof testEval.dispose === 'function') testEval.dispose();
+            trainPredTensor.dispose();
+            testPredTensor.dispose();
+            xTrain.dispose();
+            yTrain.dispose();
+            xTest.dispose();
+            yTest.dispose();
+            model.dispose();
+
+            const trainTrades = computeTradeOutcomes(trainPredictions, split.train.labels, split.train.meta);
+            const testTrades = computeTradeOutcomes(testPredictions, split.test.labels, split.test.meta);
+            const kelly = computeKelly(testTrades.trades);
+            const initialCapital = getInitialCapital();
+            const simulation = simulateKellyTrades(testTrades.trades, initialCapital, kelly.fraction);
+
+            state.trades = simulation.results;
+            state.kellyFraction = kelly.fraction;
+            state.initialCapital = initialCapital;
+
+            setMetric('trainAccuracy', formatPercent(trainAccuracy));
+            setMetric('trainWinRate', formatPercent(trainTrades.winRate));
+            setMetric('testAccuracy', formatPercent(testAccuracy));
+            setMetric('testWinRate', formatPercent(testTrades.winRate));
+            setMetric('kellyFraction', formatPercent(kelly.fraction));
+            setMetric('averageProfit', simulation.results.length > 0 ? formatCurrency(simulation.averageProfit) : '-');
+            setMetric('totalReturn', formatPercent(simulation.totalReturn));
+            setMetric('tradeCount', simulation.results.length.toString());
+
+            renderTrades(simulation.results);
+
+            if (simulation.results.length === 0) {
+                setStatus('模型於測試集未觸發任何符合 2 元漲幅的做多交易。', 'warning');
+            } else {
+                const summary = `AI 預測完成，測試集共觸發 ${simulation.results.length} 筆交易，凱利建議投入 ${formatPercent(kelly.fraction)}。`;
+                setStatus(summary, 'success');
+            }
+        } catch (error) {
+            console.error('[AI Predict] 執行失敗：', error);
+            setStatus(error?.message || 'AI 預測過程發生未知錯誤。', 'error');
+            resetMetrics();
+        } finally {
+            setRunning(false);
+        }
+    }
+
+    function setup() {
+        state.elements.runBtn = getElement('aiPredictRunBtn');
+        state.elements.status = getElement('aiPredictStatus');
+        state.elements.version = getElement('aiPredictVersionLabel');
+        state.elements.metrics.trainAccuracy = getElement('aiTrainAccuracy');
+        state.elements.metrics.trainWinRate = getElement('aiTrainWinRate');
+        state.elements.metrics.testAccuracy = getElement('aiTestAccuracy');
+        state.elements.metrics.testWinRate = getElement('aiTestWinRate');
+        state.elements.metrics.kellyFraction = getElement('aiKellyFraction');
+        state.elements.metrics.averageProfit = getElement('aiAverageProfit');
+        state.elements.metrics.totalReturn = getElement('aiTotalReturn');
+        state.elements.metrics.tradeCount = getElement('aiTradeCount');
+        state.elements.tradesBody = getElement('aiPredictTradesBody');
+        state.elements.exportBtn = getElement('aiPredictExportBtn');
+
+        if (!state.elements.runBtn) {
+            return;
+        }
+        if (state.elements.version) {
+            state.elements.version.textContent = VERSION_CODE;
+        }
+        resetMetrics();
+        setStatus('準備就緒，請先於主頁籤完成回測再執行 AI 預測。', 'info');
+        state.elements.runBtn.addEventListener('click', runPrediction);
+        if (state.elements.exportBtn) {
+            state.elements.exportBtn.addEventListener('click', exportCsv);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', setup);
+    } else {
+        setup();
+    }
+
+    window.lazybacktestAIPredictor = {
+        version: VERSION_CODE,
+        run: runPrediction,
+        reset: resetMetrics,
+    };
+})();

--- a/log.md
+++ b/log.md
@@ -764,3 +764,9 @@
 - **Diagnostics**: 於本地載入頁面確認初始 `<img>` 即為指定 GIF，並觀察 `dataset.lbMascotSource` 會在 Tenor API 成功後更新為 `tenor:https://media.tenor.com/...`，確保不再回退到 SVG。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/backtest.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
 
+## 2025-12-12 — Patch LB-AI-PREDICT-20250921A
+- **Issue recap**: 缺乏原生 AI 預測分頁協助使用者快速檢視以 LSTM 為核心的隔日漲幅（≥2 元）判斷與凱利公式資金配置，導致想評估深度學習策略的使用者需另行撰寫腳本。
+- **Fix**: 新增「AI 預測」頁籤與 `js/ai-predict.js` 模組，導入 TensorFlow.js LSTM（20 日視窗、2:1 時序切分）即時訓練，計算訓練/測試勝率、凱利投入比例、以今日收盤買進隔日賣出的模擬報酬，並提供 CSV 匯出功能；同步在 UI 顯示版本碼 `LB-AI-PREDICT-20250921A` 與使用說明。
+- **Diagnostics**: 確認未執行回測時會顯示提示、資料不足時提示補抓，並於測試集觸發交易後更新指標卡與交易表。
+- **Testing**: `node - <<'NODE' const fs=require('fs');['js/ai-predict.js'].forEach((file)=>{new Function(fs.readFileSync(file,'utf8'));});console.log('ai predictor script ok');NODE`
+


### PR DESCRIPTION
## Summary
- add an AI 預測 tab that explains the LSTM + Kelly workflow and exposes controls, metrics, and CSV export for predictions
- load TensorFlow.js and implement `js/ai-predict.js` to train a 20日視窗 LSTM, split data 2:1, evaluate, size trades with Kelly, and render table metrics
- document the new capability in `log.md` with patch note `LB-AI-PREDICT-20250921A`

## Testing
- `node - <<'NODE' const fs=require('fs');['js/ai-predict.js'].forEach((file)=>{new Function(fs.readFileSync(file,'utf8'));});console.log('ai predictor script ok');NODE`

------
https://chatgpt.com/codex/tasks/task_e_68db7e0f00c4832489ac968d3fb835e3