### PR TITLE
Add AI forecast tab with LSTM and Kelly sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1258,6 +1258,13 @@
                                             >
                                                 <i data-lucide="repeat" class="lucide-sm inline mr-1"></i>滾動測試
                                             </button>
+                                            <button
+                                                class="tab py-4 px-1 border-b-2 border-transparent text-muted hover:text-foreground font-medium text-xs whitespace-nowrap"
+                                                style="color: var(--muted-foreground);"
+                                                data-tab="ai-forecast"
+                                            >
+                                                <i data-lucide="bot" class="lucide-sm inline mr-1"></i>AI預測
+                                            </button>
                                         </nav>
                                     </div>
                                 </div>
@@ -2058,6 +2065,112 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="tab-content hidden space-y-6" id="ai-forecast-tab">
+                            <div class="card shadow-lg">
+                                <div class="card-header pb-4">
+                                    <div class="flex items-center justify-between flex-wrap gap-3">
+                                        <div>
+                                            <h3 class="card-title">AI 預測：隔日 ±2 元漲跌判讀</h3>
+                                            <p class="text-xs" style="color: var(--muted-foreground);">
+                                                版本 <span id="ai-forecast-version" class="font-semibold"></span>｜以 LSTM 與凱利公式推估隔日收盤價是否上漲 2 元以上，僅在預測上漲時模擬買入。
+                                            </p>
+                                        </div>
+                                        <button
+                                            type="button"
+                                            id="ai-forecast-run"
+                                            class="btn-primary px-4 py-2 rounded-md text-sm font-semibold flex items-center gap-2"
+                                            style="background-color: var(--primary); color: var(--primary-foreground); border: 1px solid var(--primary);"
+                                        >
+                                            <i data-lucide="brain" class="lucide-sm"></i>
+                                            啟動 AI 訓練
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="card-content space-y-4">
+                                    <div class="grid md:grid-cols-2 gap-4" id="ai-forecast-dataset-summary">
+                                        <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                                            <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">資料概況</p>
+                                            <p class="text-sm mt-2" style="color: var(--foreground);">等待回測資料同步...</p>
+                                        </div>
+                                        <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                                            <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">訓練狀態</p>
+                                            <p id="ai-forecast-status" class="text-sm mt-2" style="color: var(--muted-foreground);">尚未啟動訓練。</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="card shadow-lg" id="ai-forecast-metrics-card">
+                                <div class="card-header">
+                                    <h3 class="card-title">模型評估</h3>
+                                </div>
+                                <div class="card-content">
+                                    <div class="grid sm:grid-cols-3 gap-4">
+                                        <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                                            <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">訓練勝率</p>
+                                            <p id="ai-forecast-train-accuracy" class="text-2xl font-semibold" style="color: var(--foreground);">—</p>
+                                            <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">以 2:1 訓練/測試拆分取得之訓練資料分類準確率。</p>
+                                        </div>
+                                        <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                                            <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">測試勝率</p>
+                                            <p id="ai-forecast-test-accuracy" class="text-2xl font-semibold" style="color: var(--foreground);">—</p>
+                                            <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">Out-of-sample 測試資料分類準確率。</p>
+                                        </div>
+                                        <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                                            <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">下一交易日判讀</p>
+                                            <p id="ai-forecast-next-decision" class="text-2xl font-semibold" style="color: var(--foreground);">—</p>
+                                            <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">機率 <span id="ai-forecast-next-prob" class="font-semibold">—</span> ｜ 依據最新 20 日收盤報酬的 LSTM 輸出。</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="card shadow-lg" id="ai-forecast-backtest-card">
+                                <div class="card-header">
+                                    <h3 class="card-title">凱利公式資金配置與測試報酬</h3>
+                                </div>
+                                <div class="card-content space-y-4">
+                                    <div class="grid sm:grid-cols-2 gap-4">
+                                        <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                                            <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">回測總報酬率</p>
+                                            <p id="ai-forecast-total-return" class="text-2xl font-semibold" style="color: var(--foreground);">—</p>
+                                            <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">以凱利公式分配資金、僅在預測上漲時買入，隔日收盤平倉的累積報酬。</p>
+                                        </div>
+                                        <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                                            <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">平均單筆報酬</p>
+                                            <p id="ai-forecast-average-return" class="text-2xl font-semibold" style="color: var(--foreground);">—</p>
+        
+                                            <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">計入獲利與虧損後的幾何平均報酬。</p>
+                                        </div>
+                                    </div>
+                                    <div class="grid sm:grid-cols-2 gap-4">
+                                        <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                                            <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">執行交易次數</p>
+                                            <p id="ai-forecast-trade-count" class="text-2xl font-semibold" style="color: var(--foreground);">—</p>
+                                            <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">只統計預測上漲且成功下單的交易筆數。</p>
+                                        </div>
+                                        <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                                            <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">建議凱利投資比例</p>
+                                            <p id="ai-forecast-kelly-fraction" class="text-2xl font-semibold" style="color: var(--foreground);">—</p>
+                                            <p class="text-[11px] mt-1" style="color: var(--muted-foreground);">依訓練集勝率與盈虧比推算的基準資金配置。</p>
+                                        </div>
+                                    </div>
+                                    <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                                        <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">凱利公式說明</p>
+                                        <p class="text-sm mt-2" style="color: var(--muted-foreground); line-height: 1.6;">
+                                            以上資金配置採 MacLean、Thorp 與 Ziemba（2011）提出的凱利增長準則推導，使用訓練集估計的平均盈虧幅度計算最適下注比例，並限制於 0–100% 之間以避免過度槓桿。
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="card shadow-lg">
+                                <div class="card-header">
+                                    <h3 class="card-title">研究依據</h3>
+                                </div>
+                                <div class="card-content text-sm space-y-3" style="color: var(--muted-foreground); line-height: 1.7;">
+                                    <p>本頁 AI 模型以長短期記憶（LSTM）架構為核心，參考 Hochreiter &amp; Schmidhuber（1997）提出的門控記憶單元設計，以及 Fischer &amp; Krauss（2018）將 LSTM 應用於股票報酬方向預測的流程，並以近 20 日報酬序列作為特徵。</p>
+                                    <p>資金管理部分採用 MacLean、Thorp 與 Ziemba（2011）整理的凱利增長準則，將訓練集中估計的勝率與盈虧比帶入，以求得理論上的最佳下注比例，再於回測中動態調整資金部位。</p>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </main>
@@ -2124,6 +2237,8 @@
     <script src="js/config.js"></script>
     <script src="js/main.js"></script>
     <script src="js/backtest.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.12.0/dist/tf.min.js"></script>
+    <script src="js/ai-forecast.js"></script>
     <script src="js/loader.js"></script>
     <script src="js/batch-optimization.js"></script>
     <script src="js/rolling-test.js"></script>

--- a/js/ai-forecast.js
+++ b/js/ai-forecast.js
@@ -1,0 +1,659 @@
+// Patch Tag: LB-AI-FORECAST-20250915A
+(function () {
+    'use strict';
+
+    const AI_FORECAST_VERSION = 'LB-AI-FORECAST-20250915A';
+    const DEFAULT_LOOKBACK = 20;
+    const MIN_SEQUENCE_COUNT = 40;
+    const INITIAL_CAPITAL = 1_000_000;
+
+    const aiForecastState = {
+        initialized: false,
+        dataset: null,
+        datasetSignature: null,
+        busy: false,
+        stockName: null,
+        priceModeLabel: null,
+        lastResult: null,
+        model: null,
+        normalization: null,
+        tfReady: false,
+        tfPromise: null,
+        lookback: DEFAULT_LOOKBACK,
+    };
+
+    function getElement(id) {
+        return document.getElementById(id);
+    }
+
+    function setText(id, text) {
+        const el = getElement(id);
+        if (!el) return;
+        el.textContent = text;
+    }
+
+    function formatPercent(value, fractionDigits = 2) {
+        if (!Number.isFinite(value)) return '—';
+        const percentage = value * 100;
+        return `${percentage.toFixed(fractionDigits)}%`;
+    }
+
+    function formatNumber(value, fractionDigits = 0) {
+        if (!Number.isFinite(value)) return '—';
+        try {
+            return new Intl.NumberFormat('zh-TW', { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits }).format(value);
+        } catch (error) {
+            return value.toFixed(fractionDigits);
+        }
+    }
+
+    function formatCurrency(value) {
+        if (!Number.isFinite(value)) return '—';
+        try {
+            return new Intl.NumberFormat('zh-TW', { style: 'currency', currency: 'TWD', maximumFractionDigits: 0 }).format(value);
+        } catch (error) {
+            return `${value.toFixed(0)}`;
+        }
+    }
+
+    function parseNumber(value) {
+        const num = Number(value);
+        return Number.isFinite(num) ? num : null;
+    }
+
+    function ensureInitialized() {
+        if (aiForecastState.initialized) {
+            return;
+        }
+        aiForecastState.initialized = true;
+        const versionEl = getElement('ai-forecast-version');
+        if (versionEl) {
+            versionEl.textContent = AI_FORECAST_VERSION;
+        }
+        const runBtn = getElement('ai-forecast-run');
+        if (runBtn) {
+            runBtn.addEventListener('click', () => {
+                runAiForecastTraining().catch((error) => {
+                    console.error('[AI Forecast] Training failed:', error);
+                });
+            });
+        }
+        resetAiForecastMetrics();
+        updateRunButtonState({ disabled: true, label: '啟動 AI 訓練' });
+        setAiForecastStatus('尚未同步回測資料。', 'muted');
+    }
+
+    function resetAiForecastMetrics() {
+        setText('ai-forecast-train-accuracy', '—');
+        setText('ai-forecast-test-accuracy', '—');
+        setText('ai-forecast-next-decision', '—');
+        setText('ai-forecast-next-prob', '—');
+        setText('ai-forecast-total-return', '—');
+        setText('ai-forecast-average-return', '—');
+        setText('ai-forecast-trade-count', '—');
+        setText('ai-forecast-kelly-fraction', '—');
+    }
+
+    function setAiForecastStatus(message, tone = 'muted') {
+        const statusEl = getElement('ai-forecast-status');
+        if (!statusEl) return;
+        statusEl.textContent = message;
+        const toneColorMap = {
+            success: 'var(--primary)',
+            error: '#dc2626',
+            info: 'var(--foreground)',
+            muted: 'var(--muted-foreground)',
+        };
+        statusEl.style.color = toneColorMap[tone] || toneColorMap.muted;
+    }
+
+    function updateRunButtonState({ disabled, label }) {
+        const runBtn = getElement('ai-forecast-run');
+        if (!runBtn) return;
+        runBtn.disabled = Boolean(disabled);
+        if (label) {
+            runBtn.textContent = label;
+        }
+    }
+
+    function describePriceMode(priceMode) {
+        if (!priceMode) return '';
+        const normalized = priceMode.toString().toLowerCase();
+        if (normalized.includes('adj')) return '調整後價格';
+        if (normalized.includes('raw')) return '原始價格';
+        return priceMode;
+    }
+
+    function summariseDataset(dataset) {
+        const container = getElement('ai-forecast-dataset-summary');
+        if (!container) return;
+        if (!dataset || dataset.totalSamples === 0) {
+            container.innerHTML = `
+                <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                    <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">資料概況</p>
+                    <p class="text-sm mt-2" style="color: var(--foreground);">等待回測資料同步...</p>
+                </div>
+                <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                    <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">訓練狀態</p>
+                    <p class="text-sm mt-2" style="color: var(--muted-foreground);">尚未啟動訓練。</p>
+                </div>`;
+            return;
+        }
+        const priceModeLabel = aiForecastState.priceModeLabel ? `｜${aiForecastState.priceModeLabel}` : '';
+        const trainSize = dataset.trainSize;
+        const testSize = dataset.testSize;
+        const availability = dataset.totalSamples >= MIN_SEQUENCE_COUNT
+            ? '可啟動訓練'
+            : `至少需要 ${MIN_SEQUENCE_COUNT} 筆樣本`;
+        container.innerHTML = `
+            <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">資料概況</p>
+                <ul class="mt-2 space-y-1 text-sm" style="color: var(--foreground);">
+                    <li>標的：${aiForecastState.stockName || '—'}${priceModeLabel}</li>
+                    <li>樣本期間：${dataset.startDate || '—'} ~ ${dataset.lastDate || '—'}</li>
+                    <li>可用樣本：${formatNumber(dataset.totalSamples)} 筆（lookback = ${dataset.lookback}）</li>
+                    <li>拆分：訓練 ${formatNumber(trainSize)}｜測試 ${formatNumber(testSize)}</li>
+                </ul>
+            </div>
+            <div class="p-4 rounded-lg border" style="border-color: var(--border); background-color: var(--background);">
+                <p class="text-xs uppercase tracking-wide" style="color: var(--muted-foreground);">訓練狀態</p>
+                <p class="text-sm mt-2" style="color: var(--muted-foreground);">${availability}</p>
+            </div>`;
+    }
+
+    function resetAiForecastTab() {
+        ensureInitialized();
+        aiForecastState.dataset = null;
+        aiForecastState.datasetSignature = null;
+        aiForecastState.stockName = null;
+        aiForecastState.priceModeLabel = null;
+        aiForecastState.lastResult = null;
+        resetAiForecastMetrics();
+        summariseDataset(null);
+        setAiForecastStatus('尚未同步回測資料。', 'muted');
+        updateRunButtonState({ disabled: true, label: '啟動 AI 訓練' });
+    }
+
+    function toDatasetSignature(dataset) {
+        if (!dataset) return null;
+        const parts = [dataset.startDate, dataset.lastDate, dataset.totalSamples, dataset.lookback];
+        return parts.filter(Boolean).join('|');
+    }
+
+    function buildDatasetFromVisibleData(rawData, lookback) {
+        if (!Array.isArray(rawData) || rawData.length <= lookback) {
+            return {
+                sequences: [],
+                labels: [],
+                meta: [],
+                totalSamples: 0,
+                lookback,
+                startDate: rawData && rawData[0] ? (rawData[0].date || rawData[0].Date || null) : null,
+                lastDate: rawData && rawData.length > 0 ? (rawData[rawData.length - 1].date || rawData[rawData.length - 1].Date || null) : null,
+                lastClose: rawData && rawData.length > 0 ? parseNumber(rawData[rawData.length - 1].close ?? rawData[rawData.length - 1].Close) : null,
+                inferenceSequence: null,
+            };
+        }
+
+        const closes = rawData.map((row) => parseNumber(row.close ?? row.Close));
+        const dates = rawData.map((row) => row.date || row.Date || null);
+        const returns = new Array(rawData.length).fill(null);
+        for (let i = 1; i < rawData.length; i += 1) {
+            const prev = closes[i - 1];
+            const current = closes[i];
+            if (!Number.isFinite(prev) || !Number.isFinite(current) || prev === 0) {
+                returns[i] = null;
+            } else {
+                returns[i] = (current - prev) / prev;
+            }
+        }
+
+        const sequences = [];
+        const labels = [];
+        const meta = [];
+        let startDate = null;
+        let lastDate = null;
+
+        for (let index = lookback; index < rawData.length - 1; index += 1) {
+            const sequence = [];
+            let valid = true;
+            for (let j = index - lookback + 1; j <= index; j += 1) {
+                const value = returns[j];
+                if (!Number.isFinite(value)) {
+                    valid = false;
+                    break;
+                }
+                sequence.push(value);
+            }
+            if (!valid || sequence.length !== lookback) {
+                continue;
+            }
+            const currentClose = closes[index];
+            const nextClose = closes[index + 1];
+            if (!Number.isFinite(currentClose) || !Number.isFinite(nextClose)) {
+                continue;
+            }
+            const priceDiff = nextClose - currentClose;
+            const returnRatio = currentClose !== 0 ? priceDiff / currentClose : 0;
+            const label = priceDiff >= 2 ? 1 : 0;
+
+            sequences.push(sequence);
+            labels.push(label);
+            meta.push({
+                date: dates[index] || null,
+                nextDate: dates[index + 1] || null,
+                currentClose,
+                nextClose,
+                diff: priceDiff,
+                returnRatio,
+                label,
+            });
+            if (!startDate) {
+                startDate = dates[index - lookback + 1] || dates[index] || null;
+            }
+            lastDate = dates[index] || null;
+        }
+
+        let inferenceSequence = null;
+        if (rawData.length > lookback) {
+            const inferenceCandidate = [];
+            for (let i = rawData.length - lookback; i < rawData.length; i += 1) {
+                const value = returns[i];
+                if (!Number.isFinite(value)) {
+                    inferenceCandidate.length = 0;
+                    break;
+                }
+                inferenceCandidate.push(value);
+            }
+            if (inferenceCandidate.length === lookback) {
+                inferenceSequence = inferenceCandidate;
+            }
+        }
+
+        return {
+            sequences,
+            labels,
+            meta,
+            lookback,
+            totalSamples: sequences.length,
+            startDate,
+            lastDate,
+            lastClose: closes[closes.length - 1] ?? null,
+            lastDateForPrediction: dates[dates.length - 1] || null,
+            inferenceSequence,
+        };
+    }
+
+    function updateAiForecastTab(payload = {}) {
+        ensureInitialized();
+        const { result = null, stockName = null } = payload;
+        const visibleData = Array.isArray(window.visibleStockData) ? window.visibleStockData : [];
+        const lookback = aiForecastState.lookback;
+        const dataset = buildDatasetFromVisibleData(visibleData, lookback);
+        const totalSamples = dataset ? dataset.totalSamples : 0;
+        const baseTrainSize = Math.floor(totalSamples * (2 / 3));
+        const resolvedTrainSize = totalSamples > 0 ? Math.max(baseTrainSize, 1) : 0;
+        const resolvedTestSize = Math.max(totalSamples - resolvedTrainSize, 0);
+        dataset.trainSize = resolvedTrainSize;
+        dataset.testSize = resolvedTestSize;
+
+        aiForecastState.dataset = dataset;
+        aiForecastState.datasetSignature = toDatasetSignature(dataset);
+        aiForecastState.stockName = stockName || (result && result.stockName) || null;
+        aiForecastState.priceModeLabel = describePriceMode(result && result.priceMode);
+        aiForecastState.lastResult = null;
+        summariseDataset(dataset);
+        resetAiForecastMetrics();
+
+        if (!dataset || dataset.totalSamples < MIN_SEQUENCE_COUNT) {
+            setAiForecastStatus(`資料不足，至少需要 ${MIN_SEQUENCE_COUNT} 筆樣本才能訓練。`, 'muted');
+            updateRunButtonState({ disabled: true, label: '啟動 AI 訓練' });
+            return;
+        }
+
+        setAiForecastStatus('資料同步完成，可啟動訓練。', 'info');
+        updateRunButtonState({ disabled: false, label: '啟動 AI 訓練' });
+    }
+
+    function computeNormalization(trainSequences) {
+        if (!Array.isArray(trainSequences) || trainSequences.length === 0) {
+            return { mean: 0, std: 1 };
+        }
+        let sum = 0;
+        let count = 0;
+        trainSequences.forEach((sequence) => {
+            sequence.forEach((value) => {
+                sum += value;
+                count += 1;
+            });
+        });
+        const mean = count > 0 ? sum / count : 0;
+        let variance = 0;
+        trainSequences.forEach((sequence) => {
+            sequence.forEach((value) => {
+                variance += (value - mean) ** 2;
+            });
+        });
+        const std = count > 0 ? Math.sqrt(variance / count) : 1;
+        return { mean, std: std === 0 ? 1 : std };
+    }
+
+    function normaliseSequence(sequence, normalization) {
+        return sequence.map((value) => {
+            const normalised = (value - normalization.mean) / normalization.std;
+            return [normalised];
+        });
+    }
+
+    function ensureTensorFlowReady() {
+        if (aiForecastState.tfReady && typeof window.tf !== 'undefined') {
+            return Promise.resolve(window.tf);
+        }
+        if (typeof window.tf !== 'undefined') {
+            aiForecastState.tfReady = true;
+            return Promise.resolve(window.tf);
+        }
+        if (!aiForecastState.tfPromise) {
+            aiForecastState.tfPromise = new Promise((resolve, reject) => {
+                const existing = document.querySelector('script[data-ai-forecast-tf="true"]');
+                if (existing) {
+                    if (typeof window.tf !== 'undefined') {
+                        aiForecastState.tfReady = true;
+                        resolve(window.tf);
+                        return;
+                    }
+                    existing.addEventListener('load', () => {
+                        if (typeof window.tf !== 'undefined') {
+                            aiForecastState.tfReady = true;
+                            resolve(window.tf);
+                        } else {
+                            reject(new Error('TensorFlow.js 尚未就緒'));
+                        }
+                    });
+                    existing.addEventListener('error', () => {
+                        reject(new Error('TensorFlow.js 載入失敗'));
+                    });
+                    return;
+                }
+                const script = document.createElement('script');
+                script.src = 'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.12.0/dist/tf.min.js';
+                script.async = true;
+                script.dataset.aiForecastTf = 'true';
+                script.onload = () => {
+                    if (typeof window.tf !== 'undefined') {
+                        aiForecastState.tfReady = true;
+                        resolve(window.tf);
+                    } else {
+                        reject(new Error('TensorFlow.js 尚未就緒'));
+                    }
+                };
+                script.onerror = () => reject(new Error('TensorFlow.js 載入失敗'));
+                document.head.appendChild(script);
+            });
+        }
+        return aiForecastState.tfPromise;
+    }
+
+    function computeKellyFraction(probability, avgWin, avgLoss) {
+        if (!Number.isFinite(probability)) return 0;
+        const p = Math.min(Math.max(probability, 0), 1);
+        const q = 1 - p;
+        if (!Number.isFinite(avgWin) || !Number.isFinite(avgLoss)) {
+            return 0;
+        }
+        if (avgWin <= 0) {
+            return 0;
+        }
+        const lossMagnitude = Math.abs(avgLoss);
+        if (lossMagnitude === 0) {
+            return 0;
+        }
+        const numerator = (p * avgWin) - (q * lossMagnitude);
+        const denominator = avgWin * lossMagnitude;
+        if (denominator === 0) {
+            return 0;
+        }
+        const fraction = numerator / denominator;
+        if (!Number.isFinite(fraction)) {
+            return 0;
+        }
+        return Math.max(0, Math.min(fraction, 1));
+    }
+
+    function geometricMean(returns) {
+        if (!Array.isArray(returns) || returns.length === 0) {
+            return null;
+        }
+        let product = 1;
+        let count = 0;
+        for (let i = 0; i < returns.length; i += 1) {
+            const value = returns[i];
+            if (!Number.isFinite(value)) continue;
+            const growth = 1 + value;
+            if (growth <= 0) {
+                return null;
+            }
+            product *= growth;
+            count += 1;
+        }
+        if (count === 0) return null;
+        return product ** (1 / count) - 1;
+    }
+
+    async function runAiForecastTraining() {
+        ensureInitialized();
+        if (aiForecastState.busy) {
+            return;
+        }
+        const dataset = aiForecastState.dataset;
+        if (!dataset || dataset.totalSamples < MIN_SEQUENCE_COUNT) {
+            setAiForecastStatus(`資料不足，至少需要 ${MIN_SEQUENCE_COUNT} 筆樣本才能訓練。`, 'muted');
+            return;
+        }
+        aiForecastState.busy = true;
+        aiForecastState.lastResult = null;
+        updateRunButtonState({ disabled: true, label: '訓練中...' });
+        setAiForecastStatus('正在訓練 LSTM 模型，請稍候...', 'info');
+
+        try {
+            const tf = await ensureTensorFlowReady();
+            const trainSize = dataset.trainSize ?? Math.floor(dataset.totalSamples * (2 / 3));
+            const testSize = dataset.totalSamples - trainSize;
+
+            const trainSequences = dataset.sequences.slice(0, trainSize);
+            const trainLabels = dataset.labels.slice(0, trainSize);
+            const trainMeta = dataset.meta.slice(0, trainSize);
+            const testSequences = dataset.sequences.slice(trainSize);
+            const testLabels = dataset.labels.slice(trainSize);
+            const testMeta = dataset.meta.slice(trainSize);
+
+            const normalization = computeNormalization(trainSequences);
+            const trainTensor = tf.tensor3d(trainSequences.map((seq) => normaliseSequence(seq, normalization)));
+            const trainLabelTensor = tf.tensor2d(trainLabels.map((label) => [label]));
+            const testTensor = testSize > 0 ? tf.tensor3d(testSequences.map((seq) => normaliseSequence(seq, normalization))) : null;
+            const testLabelTensor = testSize > 0 ? tf.tensor2d(testLabels.map((label) => [label])) : null;
+
+            if (aiForecastState.model) {
+                try {
+                    aiForecastState.model.dispose();
+                } catch (disposeError) {
+                    console.warn('[AI Forecast] Failed to dispose previous model:', disposeError);
+                }
+                aiForecastState.model = null;
+            }
+
+            const model = tf.sequential();
+            model.add(tf.layers.inputLayer({ inputShape: [dataset.lookback, 1] }));
+            model.add(tf.layers.lstm({ units: 32, activation: 'tanh', recurrentActivation: 'sigmoid', kernelRegularizer: tf.regularizers.l2({ l2: 0.0005 }) }));
+            model.add(tf.layers.dropout({ rate: 0.2 }));
+            model.add(tf.layers.dense({ units: 16, activation: 'relu', kernelRegularizer: tf.regularizers.l2({ l2: 0.0005 }) }));
+            model.add(tf.layers.dropout({ rate: 0.1 }));
+            model.add(tf.layers.dense({ units: 1, activation: 'sigmoid' }));
+            model.compile({ optimizer: tf.train.adam(0.001), loss: 'binaryCrossentropy', metrics: ['accuracy'] });
+
+            const epochs = Math.min(60, Math.max(25, Math.round(trainSize / 2)));
+            const batchSize = Math.min(64, Math.max(8, Math.round(trainSize / 6)));
+            let lastReportedEpoch = -1;
+
+            await model.fit(trainTensor, trainLabelTensor, {
+                epochs,
+                batchSize,
+                shuffle: true,
+                validationSplit: trainSize > 60 ? 0.2 : 0,
+                callbacks: {
+                    onEpochEnd: async (epoch, logs) => {
+                        if (epoch - lastReportedEpoch >= 5 || epoch === epochs - 1) {
+                            const loss = logs.loss != null ? logs.loss.toFixed(4) : '—';
+                            setAiForecastStatus(`訓練進度：第 ${epoch + 1}/${epochs} 回合，loss=${loss}`, 'info');
+                            lastReportedEpoch = epoch;
+                            await tf.nextFrame();
+                        }
+                    },
+                },
+            });
+
+            const [trainLossTensor, trainAccTensor] = model.evaluate(trainTensor, trainLabelTensor);
+            const trainAccuracy = trainAccTensor ? (await trainAccTensor.data())[0] : null;
+            if (trainLossTensor) trainLossTensor.dispose();
+            if (trainAccTensor) trainAccTensor.dispose();
+
+            let testAccuracy = null;
+            let predictions = [];
+            if (testTensor && testLabelTensor) {
+                const evalResult = model.evaluate(testTensor, testLabelTensor);
+                if (Array.isArray(evalResult) && evalResult.length > 1) {
+                    const accTensor = evalResult[1];
+                    testAccuracy = (await accTensor.data())[0];
+                    evalResult[0]?.dispose?.();
+                    accTensor?.dispose?.();
+                }
+                const predictionTensor = model.predict(testTensor);
+                predictions = Array.isArray(predictionTensor)
+                    ? await Promise.all(predictionTensor.map(async (tensor) => (await tensor.data())[0]))
+                    : Array.from(await predictionTensor.data());
+                predictionTensor.dispose();
+            }
+
+            const winReturns = [];
+            const lossReturns = [];
+            trainMeta.forEach((item, index) => {
+                const ret = item.returnRatio;
+                if (!Number.isFinite(ret)) return;
+                if (trainLabels[index] === 1) {
+                    winReturns.push(ret);
+                } else if (ret < 0) {
+                    lossReturns.push(ret);
+                }
+            });
+            const avgWin = winReturns.length > 0 ? (winReturns.reduce((sum, val) => sum + val, 0) / winReturns.length) : null;
+            const avgLoss = lossReturns.length > 0 ? (lossReturns.reduce((sum, val) => sum + val, 0) / lossReturns.length) : null;
+
+            const trades = [];
+            const tradeReturns = [];
+            let capital = INITIAL_CAPITAL;
+            let appliedKellySum = 0;
+            if (testMeta.length > 0) {
+                for (let i = 0; i < testMeta.length; i += 1) {
+                    const probability = Number.isFinite(predictions[i]) ? predictions[i] : null;
+                    const meta = testMeta[i];
+                    if (probability === null || probability < 0.5) continue;
+                    const kellyFraction = computeKellyFraction(probability, avgWin ?? 0, avgLoss ?? 0);
+                    if (kellyFraction <= 0) continue;
+                    const returnRatio = meta.returnRatio;
+                    if (!Number.isFinite(returnRatio)) continue;
+                    const positionSize = capital * kellyFraction;
+                    const profit = positionSize * returnRatio;
+                    capital += profit;
+                    appliedKellySum += kellyFraction;
+                    trades.push({
+                        date: meta.date,
+                        nextDate: meta.nextDate,
+                        probability,
+                        kellyFraction,
+                        returnRatio,
+                        diff: meta.diff,
+                        currentClose: meta.currentClose,
+                        nextClose: meta.nextClose,
+                        label: meta.label,
+                    });
+                    tradeReturns.push(returnRatio);
+                }
+            }
+
+            const totalReturn = capital / INITIAL_CAPITAL - 1;
+            const avgKellyFraction = trades.length > 0 ? appliedKellySum / trades.length : 0;
+            const averageTradeReturn = geometricMean(tradeReturns);
+
+            let nextPrediction = null;
+            if (Array.isArray(dataset.inferenceSequence) && dataset.inferenceSequence.length === dataset.lookback) {
+                const inputTensor = tf.tensor3d([normaliseSequence(dataset.inferenceSequence, normalization)]);
+                const predictionTensor = model.predict(inputTensor);
+                const probability = (await predictionTensor.data())[0];
+                inputTensor.dispose();
+                predictionTensor.dispose();
+                const kellyFraction = computeKellyFraction(probability, avgWin ?? 0, avgLoss ?? 0);
+                nextPrediction = {
+                    probability,
+                    decision: probability >= 0.5 && kellyFraction > 0 ? '建議買入' : '建議觀望',
+                    kellyFraction,
+                    basisDate: dataset.lastDateForPrediction || dataset.lastDate || null,
+                    basisClose: dataset.lastClose,
+                };
+            }
+
+            trainTensor.dispose();
+            trainLabelTensor.dispose();
+            testTensor?.dispose();
+            testLabelTensor?.dispose();
+
+            aiForecastState.model = model;
+            aiForecastState.normalization = normalization;
+            aiForecastState.lastResult = {
+                trainAccuracy,
+                testAccuracy,
+                totalReturn,
+                averageTradeReturn,
+                trades,
+                avgKellyFraction,
+                nextPrediction,
+            };
+
+            renderAiForecastResult(aiForecastState.lastResult);
+            setAiForecastStatus('訓練完成，已更新評估結果。', 'success');
+        } catch (error) {
+            console.error('[AI Forecast] Unexpected error:', error);
+            setAiForecastStatus(`訓練失敗：${error.message}`, 'error');
+        } finally {
+            aiForecastState.busy = false;
+            updateRunButtonState({ disabled: false, label: '重新訓練' });
+        }
+    }
+
+    function renderAiForecastResult(result) {
+        if (!result) {
+            resetAiForecastMetrics();
+            return;
+        }
+        setText('ai-forecast-train-accuracy', formatPercent(result.trainAccuracy ?? null, 1));
+        setText('ai-forecast-test-accuracy', formatPercent(result.testAccuracy ?? null, 1));
+        const nextDecisionLabel = result.nextPrediction ? result.nextPrediction.decision : '—';
+        const nextProbability = result.nextPrediction ? formatPercent(result.nextPrediction.probability ?? null, 1) : '—';
+        setText('ai-forecast-next-decision', nextDecisionLabel);
+        setText('ai-forecast-next-prob', nextProbability);
+
+        setText('ai-forecast-total-return', formatPercent(result.totalReturn ?? null, 2));
+        setText('ai-forecast-average-return', formatPercent(result.averageTradeReturn ?? null, 2));
+        setText('ai-forecast-trade-count', formatNumber(result.trades ? result.trades.length : 0));
+        const kellyDisplay = result.avgKellyFraction != null && result.avgKellyFraction > 0
+            ? formatPercent(result.avgKellyFraction, 1)
+            : '—';
+        setText('ai-forecast-kelly-fraction', kellyDisplay);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        ensureInitialized();
+    });
+
+    window.updateAiForecastTab = updateAiForecastTab;
+    window.resetAiForecastTab = resetAiForecastTab;
+})();

--- a/js/backtest.js
+++ b/js/backtest.js
@@ -5049,8 +5049,8 @@ function clearPreviousResults() {
     document.getElementById("optimization-results").innerHTML=`<p class="text-gray-500">請執行優化</p>`;
     document.getElementById("performance-table-container").innerHTML=`<p class="text-gray-500">請先執行回測以生成期間績效數據。</p>`;
     if(stockChart){
-        stockChart.destroy(); 
-        stockChart=null; 
+        stockChart.destroy();
+        stockChart=null;
         const chartContainer = document.getElementById('chart-container');
         if (chartContainer) {
             chartContainer.innerHTML = '<canvas id="chart" class="w-full h-full absolute inset-0"></canvas><div class="text-muted text-center" style="color: var(--muted-foreground);"><i data-lucide="bar-chart-3" class="lucide w-12 h-12 mx-auto mb-2 opacity-50"></i><p>執行回測後將顯示淨值曲線</p></div>';
@@ -5077,6 +5077,13 @@ function clearPreviousResults() {
     renderPricePipelineSteps();
     renderPriceInspectorDebug();
     refreshDataDiagnosticsPanel();
+    if (typeof window.resetAiForecastTab === 'function') {
+        try {
+            window.resetAiForecastTab();
+        } catch (error) {
+            console.warn('[AI Forecast] reset tab failed:', error);
+        }
+    }
 }
 
 const adjustmentReasonLabels = {
@@ -6188,6 +6195,13 @@ function handleBacktestResult(result, stockName, dataSource) {
         displayTradeResults(result);
         renderChart(result);
         updateChartTrendOverlay();
+        if (typeof window.updateAiForecastTab === 'function') {
+            try {
+                window.updateAiForecastTab({ result, stockName });
+            } catch (error) {
+                console.warn('[AI Forecast] 更新資料失敗:', error);
+            }
+        }
         activateTab('summary');
 
         setTimeout(() => {

--- a/log.md
+++ b/log.md
@@ -1,3 +1,11 @@
+## 2025-11-13 — Patch LB-AI-FORECAST-20250915A
+- **Scope**: 新增「AI 預測」分頁，整合 LSTM 模型與凱利公式資金管理，僅在預測隔日收盤價上漲 2 元以上時進場。
+- **Features**:
+  - 以 20 日報酬序列訓練 TensorFlow.js LSTM，採 2:1 訓練/測試切分並顯示訓練、測試勝率。
+  - 依訓練資料推估平均盈虧幅度，套用凱利公式計算每筆交易投入比例並模擬測試區間總報酬。
+  - 於主回測完成或重置時自動同步資料/清除狀態，UI 揭露研究依據與最新判讀結果。
+- **Testing**: `npm run lint`（N/A，維持既有 `node` 腳本語法檢查：`node - <<'NODE' const fs=require('fs');['js/backtest.js','js/main.js','js/worker.js','js/ai-forecast.js'].forEach((file)=>{new (require('vm').Script)(fs.readFileSync(file,'utf8'),{filename:file});});console.log('scripts compile');NODE`）
+
 ## 2025-11-12 — Patch LB-TRADE-ENTRY-20251112A
 - **Issue recap**: 分段進場在全部出場後，`buildAggregatedLongEntry` 仍以已被清零的 `longPositionCost*` 值計算，導致交易紀錄中的買入價格被顯示為 0。
 - **Fix**: 改用每段進場快照的 `originalCost`／`originalCostWithoutFee` 與 `originalShares` 彙總平均成本，確保整併後的買入價格維持原始交易成本。


### PR DESCRIPTION
## Summary
- add an AI預測 tab with TensorFlow.js LSTM training, Kelly sizing backtest metrics, and literature references
- synchronize AI tab state with main backtest lifecycle and expose a reusable forecast controller
- document the change in log.md with new patch entry

## Testing
- node - <<'NODE' const fs=require('fs');['js/backtest.js','js/main.js','js/worker.js','js/ai-forecast.js'].forEach((file)=>{new (require('vm').Script)(fs.readFileSync(file,'utf8'),{filename:file});});console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68db7e0f00c4832489ac968d3fb835e3