### PR TITLE
Enhance AI prediction threshold and seed management

### DIFF
--- a/index.html
+++ b/index.html
@@ -2123,12 +2123,40 @@
                                                 </button>
                                                 <div id="ai-status" class="text-xs" style="color: var(--muted-foreground);">尚未開始</div>
                                             </div>
+                                            <div class="grid gap-4 md:grid-cols-2">
+                                                <div class="flex flex-col gap-2 p-3 border rounded-lg" style="border-color: var(--border); background-color: color-mix(in srgb, var(--secondary) 6%, transparent);">
+                                                    <div class="flex items-center justify-between">
+                                                        <span class="text-xs font-medium" style="color: var(--foreground);">勝率門檻（%）</span>
+                                                        <button id="ai-optimize-threshold" type="button" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors border" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 8%, transparent); color: var(--primary);">
+                                                            <i data-lucide="gauge" class="lucide-xs"></i>一鍵最佳報酬
+                                                        </button>
+                                                    </div>
+                                                    <div class="flex items-center gap-2">
+                                                        <input id="ai-win-threshold" type="number" min="50" max="100" step="1" value="60" class="w-24 px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                        <span class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">預測上漲機率需高於門檻才會進場，可在不重新訓練的情況下即時重算收益。</span>
+                                                    </div>
+                                                </div>
+                                                <div class="flex flex-col gap-2 p-3 border rounded-lg" style="border-color: var(--border); background-color: color-mix(in srgb, var(--muted) 10%, transparent);">
+                                                    <span class="text-xs font-medium" style="color: var(--foreground);">種子管理</span>
+                                                    <input id="ai-seed-name" type="text" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" placeholder="訓練勝率XX.X%｜測試正確率YY.Y%" style="border-color: var(--border); background-color: var(--input);" />
+                                                    <div class="flex flex-wrap gap-2">
+                                                        <button id="ai-save-seed" type="button" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors" style="background-color: var(--secondary); color: var(--secondary-foreground);">
+                                                            <i data-lucide="save" class="lucide-xs"></i>儲存種子
+                                                        </button>
+                                                        <button id="ai-load-seed" type="button" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors border" style="border-color: var(--border); color: var(--foreground);">
+                                                            <i data-lucide="download" class="lucide-xs"></i>載入選取種子
+                                                        </button>
+                                                    </div>
+                                                    <select id="ai-saved-seeds" multiple size="5" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground text-xs focus:outline-none focus:ring-2 focus:ring-ring" style="border-color: var(--border); background-color: var(--input);"></select>
+                                                    <span class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">預設名稱依訓練勝率與測試正確率生成，可同時選擇多個種子載入，快速比對不同訓練結果。</span>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="card">
                                         <div class="card-header flex flex-col gap-2">
                                             <h3 class="card-title text-base">模型與交易成果</h3>
-                                            <p class="text-xs" style="color: var(--muted-foreground);">展示訓練與測試勝率、預測信心與採用凱利公式後的資金曲線摘要。</p>
+                                            <p class="text-xs" style="color: var(--muted-foreground);">展示訓練與測試勝率、勝率門檻調整後的交易統計，以及隔日預測的即時摘要。</p>
                                         </div>
                                         <div class="card-content space-y-4">
                                             <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4 text-xs" id="ai-metrics-overview" style="color: var(--foreground);">
@@ -2148,22 +2176,20 @@
                                                     <p id="ai-hit-rate" class="text-[11px]" style="color: var(--muted-foreground);">命中率：—</p>
                                                 </div>
                                                 <div class="p-3 border rounded-lg" style="border-color: var(--border);">
-                                                    <p class="font-medium text-[13px]" style="color: var(--muted-foreground);">AI 策略報酬</p>
+                                                    <p class="font-medium text-[13px]" style="color: var(--muted-foreground);">AI 策略報酬評估（交易報酬% 中位數）</p>
                                                     <p id="ai-total-return" class="text-lg font-semibold">—</p>
-                                                    <p id="ai-average-profit" class="text-[11px]" style="color: var(--muted-foreground);">平均每筆：—</p>
+                                                    <p id="ai-average-profit" class="text-[11px]" style="color: var(--muted-foreground);">平均報酬%・標準差</p>
                                                 </div>
                                             </div>
                                             <div class="overflow-x-auto">
                                                 <table class="min-w-full divide-y divide-border text-xs" style="border-color: var(--border);">
                                                     <thead class="bg-muted/40" style="background-color: color-mix(in srgb, var(--muted) 20%, transparent); color: var(--foreground);">
                                                         <tr>
-                                                            <th class="px-3 py-2 text-left font-semibold">買進日</th>
-                                                            <th class="px-3 py-2 text-left font-semibold">賣出日</th>
+                                                            <th class="px-3 py-2 text-left font-semibold">交易日</th>
                                                             <th class="px-3 py-2 text-right font-semibold">預測上漲機率</th>
                                                             <th class="px-3 py-2 text-right font-semibold">實際報酬%</th>
                                                             <th class="px-3 py-2 text-right font-semibold">投入比例</th>
-                                                            <th class="px-3 py-2 text-right font-semibold">交易盈虧</th>
-                                                            <th class="px-3 py-2 text-right font-semibold">累積資金</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">交易報酬%</th>
                                                         </tr>
                                                     </thead>
                                                     <tbody id="ai-trade-table-body" class="divide-y divide-border" style="border-color: var(--border);"></tbody>
@@ -2171,6 +2197,7 @@
                                             </div>
                                             <div class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">
                                                 <p id="ai-trade-summary">尚未生成交易結果。</p>
+                                                <p id="ai-next-day-forecast" class="mt-1">尚未計算隔日預測。</p>
                                             </div>
                                         </div>
                                     </div>

--- a/log.md
+++ b/log.md
@@ -1,3 +1,12 @@
+## 2025-09-22 — Patch LB-AI-LSTM-20250922A
+- **Scope**: AI 預測分頁資金控管、收益呈現與種子管理強化。
+- **Features**:
+  - 勝率門檻可獨立於訓練後重算交易結果並提供 50%~100% 自動掃描最佳化。
+  - 凱利公式與固定投入比例可即時切換，交易報酬統計改採中位數／平均報酬%／標準差，表格同步改為交易報酬%。
+  - 新增隔日預測摘要，表格保留最後一筆測試資料並附上隔日機率。
+  - 建立本地種子儲存／載入與多選支援，預設名稱依訓練勝率與測試正確率生成。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/ai-prediction.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
 ## 2025-09-15 — Patch LB-AI-LSTM-20250915A
 - **Scope**: 新增「AI 預測」分頁與 LSTM 深度學習模組，整合凱利公式資金管理與快取資料串接。
 - **Features**:

--- a/log.md
+++ b/log.md
@@ -781,6 +781,12 @@
 - **Diagnostics**: 於本地載入頁面確認初始 `<img>` 即為指定 GIF，並觀察 `dataset.lbMascotSource` 會在 Tenor API 成功後更新為 `tenor:https://media.tenor.com/...`，確保不再回退到 SVG。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/backtest.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
 
+## 2025-12-10 — Patch LB-AI-LSTM-20250929B
+- **Issue recap**: LSTM 模型仍在主執行緒訓練，啟動 AI 預測時頁面易凍結且進度無法掌握，亦缺乏背景錯誤通知機制。
+- **Fix**: 建立 `LB-AI-LSTM-20250929B` 管線，改以 `worker.js` 執行 TensorFlow.js 訓練並透過訊息回傳進度、結果與錯誤，前端僅負責資料切片與結果渲染。
+- **Diagnostics**: 確認 Web Worker 能接收資料集、回傳訓練指標與隔日預測，UI 端在勝率門檻、凱利開關與種子載入時可即時重算交易統計。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/ai-prediction.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
 ## 2025-12-09 — Patch LB-AI-LSTM-20250924A
 - **Issue recap**: AI 隔日預測在啟用凱利公式時未提供建議投入比例，且交易報酬統計未過濾缺少交易日的筆數，造成評估依據不完整。
 - **Fix**: 於凱利模式下依預測勝率計算隔日投入比例並同步顯示於預測區與表格，同時僅保留具備有效交易日的交易紀錄再計算中位數、平均與標準差。

--- a/log.md
+++ b/log.md
@@ -781,3 +781,9 @@
 - **Diagnostics**: 於本地載入頁面確認初始 `<img>` 即為指定 GIF，並觀察 `dataset.lbMascotSource` 會在 Tenor API 成功後更新為 `tenor:https://media.tenor.com/...`，確保不再回退到 SVG。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/backtest.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
 
+## 2025-12-09 — Patch LB-AI-LSTM-20250924A
+- **Issue recap**: AI 隔日預測在啟用凱利公式時未提供建議投入比例，且交易報酬統計未過濾缺少交易日的筆數，造成評估依據不完整。
+- **Fix**: 於凱利模式下依預測勝率計算隔日投入比例並同步顯示於預測區與表格，同時僅保留具備有效交易日的交易紀錄再計算中位數、平均與標準差。
+- **Diagnostics**: 本地載入 AI 分頁，套用凱利公式與勝率門檻調整後可看到隔日預測顯示投入比例，並確認交易表與統計僅涵蓋具日期的交易。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/ai-prediction.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+


### PR DESCRIPTION
## Summary
- allow recomputing AI trades with adjustable win-rate threshold and Kelly toggle without retraining
- refresh AI results presentation with trade return median metrics, updated table layout, and next-day forecast display
- add local seed save/load controls with default names and log the new patch entry

## Testing
- node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/ai-prediction.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68dc775689bc832493928200ce6e25d4