### PR TITLE
Add ANN worker-based prediction pipeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -2123,6 +2123,26 @@
                                                 </button>
                                                 <div id="ai-status" class="text-xs" style="color: var(--muted-foreground);">尚未開始</div>
                                             </div>
+                                            <div class="mt-2 flex items-center gap-2">
+                                                <button id="run-ann" class="px-3 py-2 bg-indigo-600 text-white rounded">ANNS 預測明日漲跌（Worker）</button>
+                                                <span id="ann-status" class="text-sm text-gray-500"></span>
+                                            </div>
+
+                                            <div id="ann-result" class="mt-3 hidden p-3 border rounded bg-white">
+                                                <div class="font-semibold">ANNS（技術指標）預測結果</div>
+                                                <div class="mt-1 text-sm" id="ann-acc"></div>
+                                                <div class="mt-1 text-sm" id="ann-kelly"></div>
+                                                <div class="mt-2 grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
+                                                    <div class="p-2 border rounded">
+                                                        <div class="font-medium mb-1">混淆矩陣</div>
+                                                        <div id="ann-cm"></div>
+                                                    </div>
+                                                    <div class="p-2 border rounded">
+                                                        <div class="font-medium mb-1">投資建議</div>
+                                                        <div id="ann-adv"></div>
+                                                    </div>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="card">

--- a/log.md
+++ b/log.md
@@ -772,3 +772,9 @@
 - **Diagnostics**: 於本地載入頁面確認初始 `<img>` 即為指定 GIF，並觀察 `dataset.lbMascotSource` 會在 Tenor API 成功後更新為 `tenor:https://media.tenor.com/...`，確保不再回退到 SVG。
 - **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/backtest.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
 
+## 2025-12-10 — Patch LB-ANN-TECH-20250712A
+- **Feature**: 在 AI 預測分頁新增「ANNS 預測明日漲跌（Worker）」按鈕與結果卡，沿用現有 UI 風格呈現準確率、凱利比例與混淆矩陣，並透過 Web Worker 執行 ANN 訓練以維持主執行緒流暢度。
+- **Worker**: 於 `worker.js` 匯入 TensorFlow.js、實作技術指標特徵工程、標準化與 ANN 訓練流程，並新增 `ANN_RUN` 訊息處理，回傳進度、結果與凱利估算，同時加入版本碼 `LB-ANN-TECH-20250712A` 以便追蹤。
+- **Main Thread**: 在 `main.js` 建立共用 Worker 實例、綁定訊息監聽與按鈕事件，並導出版本資訊至 `window.lazybacktestAnnVersion` 供診斷使用。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+


### PR DESCRIPTION
## Summary
- add an ANNS prediction button and result card to the AI tab
- introduce main-thread bindings to manage a shared worker for ANN training and status updates
- extend the worker with TensorFlow-based indicator features, ANN training, and Kelly estimation plus update log with LB-ANN-TECH-20250712A

## Testing
- node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68dc895bb84083248903b310fe7f068f