### PR TITLE
Add ANN worker-based prediction model

### DIFF
--- a/index.html
+++ b/index.html
@@ -2123,6 +2123,27 @@
                                                 </button>
                                                 <div id="ai-status" class="text-xs" style="color: var(--muted-foreground);">尚未開始</div>
                                             </div>
+                                            <div class="mt-2 flex items-center gap-2">
+                                                <button id="run-ann" type="button" class="px-3 py-2 bg-indigo-600 text-white rounded text-xs font-semibold shadow-sm hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1 transition">
+                                                    ANNS 預測明日漲跌（Worker）
+                                                </button>
+                                                <span id="ann-status" class="text-xs" style="color: var(--muted-foreground);"></span>
+                                            </div>
+                                            <div id="ann-result" class="mt-3 hidden p-3 border rounded-lg" style="border-color: var(--border); background-color: var(--background);">
+                                                <div class="font-semibold text-sm" style="color: var(--foreground);">ANNS（技術指標）預測結果</div>
+                                                <div class="mt-1 text-xs" id="ann-acc" style="color: var(--foreground);"></div>
+                                                <div class="mt-1 text-xs" id="ann-kelly" style="color: var(--foreground);"></div>
+                                                <div class="mt-2 grid grid-cols-1 md:grid-cols-2 gap-2 text-xs" style="color: var(--foreground);">
+                                                    <div class="p-2 border rounded" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 6%, transparent);">
+                                                        <div class="font-medium mb-1">混淆矩陣</div>
+                                                        <div id="ann-cm" class="space-y-1"></div>
+                                                    </div>
+                                                    <div class="p-2 border rounded" style="border-color: var(--border); background-color: color-mix(in srgb, var(--secondary) 6%, transparent);">
+                                                        <div class="font-medium mb-1">投資建議</div>
+                                                        <div id="ann-adv"></div>
+                                                    </div>
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="card">
@@ -2251,7 +2272,6 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.15.0/dist/tf.min.js"></script>
     <script src="js/shared-lookback.js"></script>
     <script src="js/config.js"></script>
     <script src="js/main.js"></script>

--- a/log.md
+++ b/log.md
@@ -1,3 +1,11 @@
+## 2025-11-17 — Patch LB-AI-ANNS-20251117A
+- **Scope**: 在 AI 預測分頁新增可切換的 ANNS 模型，將訓練流程移入 Web Worker 以避免阻塞主執行緒。
+- **Features**:
+  - index.html 追加 ANNS 執行按鈕與結果卡片，顯示訓練進度、準確率、混淆矩陣與凱利比率建議，並移除主執行緒的 tfjs 載入。
+  - main.js 建立共用 `lbWorker` 實例並綁定事件，負責將快取的股價資料交由 Worker 處理並同步更新 UI。
+  - worker.js 載入 TensorFlow.js、實作技術指標特徵工程、標準化與 ANN 訓練／評估流程，並回傳進度與結果訊息。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/worker.js','js/ai-prediction.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile (with ai)');NODE`
+
 ## 2025-09-15 — Patch LB-AI-LSTM-20250915A
 - **Scope**: 新增「AI 預測」分頁與 LSTM 深度學習模組，整合凱利公式資金管理與快取資料串接。
 - **Features**:


### PR DESCRIPTION
## Summary
- add an ANNS prediction trigger and result card to the AI 預測 panel and remove eager TFJS loading from the main document
- wire up a shared ANN worker controller in main.js to stream progress/results and reuse cached OHLC data
- implement ANN feature engineering, training, evaluation, and Kelly estimation directly inside worker.js and record the release in log.md; lazily load TFJS for the existing LSTM flow

## Testing
- `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/main.js','js/worker.js','js/ai-prediction.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile (with ai)');NODE`


------
https://chatgpt.com/codex/tasks/task_e_68dc895bb84083248903b310fe7f068f