### PR TITLE
feat: add ANN model option to AI prediction

### DIFF
--- a/index.html
+++ b/index.html
@@ -2068,14 +2068,31 @@
                                 <div class="space-y-6">
                                     <div class="card">
                                         <div class="card-header flex flex-col gap-2">
-                                            <h3 class="card-title text-base">LSTM 深度學習預測設定</h3>
+                                            <h3 class="card-title text-base">AI 模型預測設定</h3>
                                             <p class="text-xs leading-relaxed" style="color: var(--muted-foreground);">
-                                                依據 Fischer &amp; Krauss (2018)、Sirignano &amp; Cont (2019) 與 Chen et al. (2024) 對金融時間序列的研究設計，採用長短期記憶網路（LSTM）分析收盤價方向。
-                                                資料以 2:1 的比例劃分為訓練與測試集，僅根據當前收盤價之前的資訊進行預測。
+                                                依據 Fischer &amp; Krauss (2018)、Sirignano &amp; Cont (2019) 與 Chen et al. (2024) 的時間序列研究，提供 LSTM 與 ANNS 兩種模型以分析收盤價方向。
+                                                兩者皆支援自訂訓練／測試比例、預測門檻與隨機種子，維持同一張設定卡即可切換模型並保留未來擴充彈性。
                                             </p>
                                         </div>
                                         <div class="card-content space-y-6">
                                             <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                    預測模型
+                                                    <select id="ai-model-select" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);">
+                                                        <option value="lstm">LSTM 深度學習</option>
+                                                        <option value="anns">ANNS 指標神經網路</option>
+                                                    </select>
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">切換後仍沿用同一組參數，方便比較模型表現。</span>
+                                                </label>
+                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                    訓練／測試比例
+                                                    <select id="ai-train-ratio" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);">
+                                                        <option value="0.8">80% 訓練 / 20% 測試</option>
+                                                        <option value="0.75">75% 訓練 / 25% 測試</option>
+                                                        <option value="0.7">70% 訓練 / 30% 測試</option>
+                                                    </select>
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">預設 80/20，符合近期回溯研究的訓練資料規模。</span>
+                                                </label>
                                                 <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
                                                     時間視窗（lookback，日）
                                                     <input id="ai-lookback" type="number" min="5" max="60" step="1" value="20" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
@@ -2096,6 +2113,19 @@
                                                     <input id="ai-learning-rate" type="number" min="0.0001" max="0.05" step="0.0001" value="0.005" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
                                                     <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">根據金融序列噪音，建議 0.001~0.01。</span>
                                                 </label>
+                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                    隨機種子
+                                                    <div class="flex items-center gap-2">
+                                                        <input id="ai-random-seed" type="number" step="1" value="20250930" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                        <button id="ai-save-seed" type="button" class="px-3 py-2 text-xs font-semibold rounded border transition-colors" style="border-color: var(--primary); color: var(--primary);">儲存種子</button>
+                                                    </div>
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">為不同模型保留同一種子，可重現資料切分與初始化結果。</span>
+                                                </label>
+                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                    預測門檻
+                                                    <input id="ai-threshold" type="number" min="0.1" max="0.9" step="0.01" value="0.5" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">預設 0.5，可視交易風格調整進出門檻。</span>
+                                                </label>
                                                 <label class="flex flex-col gap-2 text-xs font-medium md:col-span-2 xl:col-span-2" style="color: var(--foreground);">
                                                     資金控管
                                                     <div class="flex flex-col gap-2 p-3 border rounded-lg" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 4%, transparent);">
@@ -2114,12 +2144,12 @@
                                             <div class="p-3 border rounded-lg bg-background" style="border-color: var(--border);">
                                                 <div class="flex flex-wrap items-center gap-3 text-xs" style="color: var(--muted-foreground);">
                                                     <span id="ai-dataset-summary">尚未取得資料，請先完成一次主回測。</span>
-                                                    <span class="px-2 py-1 rounded" style="background-color: color-mix(in srgb, var(--secondary) 16%, transparent); color: var(--secondary-foreground);">訓練：測試 = 2 : 1</span>
+                                                    <span id="ai-ratio-chip" class="px-2 py-1 rounded" style="background-color: color-mix(in srgb, var(--secondary) 16%, transparent); color: var(--secondary-foreground);">訓練：測試 = 80% : 20%</span>
                                                 </div>
                                             </div>
                                             <div class="flex flex-wrap items-center gap-3">
                                                 <button id="ai-run-button" type="button" class="inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm font-semibold transition-colors" style="background-color: var(--primary); color: var(--primary-foreground);">
-                                                    <i data-lucide="cpu" class="lucide-sm"></i>啟動 AI 預測
+                                                    <i data-lucide="cpu" class="lucide-sm"></i><span id="ai-run-label">啟動 AI 預測</span>
                                                 </button>
                                                 <div id="ai-status" class="text-xs" style="color: var(--muted-foreground);">尚未開始</div>
                                             </div>

--- a/log.md
+++ b/log.md
@@ -1,3 +1,11 @@
+## 2025-09-30 — Patch LB-AI-HYBRID-20250930A
+- **Scope**: AI 預測雙模型化與資料切分控制。
+- **Features**:
+  - 在 AI 預測設定卡片加入模型選擇、訓練比例下拉、隨機種子儲存與預測門檻調整，並同步更新狀態顯示與按鈕標籤。
+  - 重構 `ai-prediction.js` 建立 LSTM/ANNS 共用流程、Kelly 及交易摘要計算，並以 Worker 執行 ANNS 訓練。
+  - 擴充 `worker.js` 導入技術指標特徵工程、標準化與 ANN 訓練回傳，提供訓練/測試評估與機率序列。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/ai-prediction.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
 ## 2025-09-15 — Patch LB-AI-LSTM-20250915A
 - **Scope**: 新增「AI 預測」分頁與 LSTM 深度學習模組，整合凱利公式資金管理與快取資料串接。
 - **Features**:


### PR DESCRIPTION
## Summary
- add AI model selector, train/test split dropdown, and seed/threshold controls to the prediction settings UI
- refactor `js/ai-prediction.js` to support LSTM and ANN workflows with shared trade summaries and worker integration
- extend `js/worker.js` with the ANN feature engineering/training pipeline and record the change in `log.md`

## Testing
- `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/ai-prediction.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`

------
https://chatgpt.com/codex/tasks/task_e_68dc928f76b08324af051f8e9cd1fef1