### PR TITLE
Add ANN model and multi-model AI configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2066,12 +2066,20 @@
                             </div>
                             <div class="tab-content hidden" id="ai-prediction-tab">
                                 <div class="space-y-6">
+                                    <!-- Patch Tag: LB-AI-ANNS-UI-20251121A -->
                                     <div class="card">
-                                        <div class="card-header flex flex-col gap-2">
-                                            <h3 class="card-title text-base">LSTM 深度學習預測設定</h3>
-                                            <p class="text-xs leading-relaxed" style="color: var(--muted-foreground);">
+                                        <div class="card-header flex flex-col gap-3">
+                                            <div class="flex flex-wrap items-center justify-between gap-3">
+                                                <h3 class="card-title text-base" id="ai-settings-title">AI 模型預測設定</h3>
+                                                <span id="ai-model-version" class="inline-flex items-center px-2 py-1 rounded text-[11px] font-medium" style="background-color: color-mix(in srgb, var(--primary) 16%, transparent); color: var(--primary);">LSTM 深度學習</span>
+                                            </div>
+                                            <div id="ai-model-switcher" class="inline-flex items-center overflow-hidden rounded-md border" style="border-color: var(--border);">
+                                                <button type="button" data-ai-model="lstm" class="ai-model-toggle px-3 py-1.5 text-xs font-medium focus:outline-none" style="background-color: var(--primary); color: var(--primary-foreground);">LSTM 深度學習</button>
+                                                <button type="button" data-ai-model="anns" class="ai-model-toggle px-3 py-1.5 text-xs font-medium focus:outline-none" style="background-color: transparent; color: var(--muted-foreground);">ANNS 技術指標</button>
+                                            </div>
+                                            <p id="ai-settings-description" class="text-xs leading-relaxed" style="color: var(--muted-foreground);">
                                                 依據 Fischer &amp; Krauss (2018)、Sirignano &amp; Cont (2019) 與 Chen et al. (2024) 對金融時間序列的研究設計，採用長短期記憶網路（LSTM）分析收盤價方向。
-                                                資料以 2:1 的比例劃分為訓練與測試集，僅根據當前收盤價之前的資訊進行預測。
+                                                資料以 80%：20% 的比例劃分為訓練與測試集，僅使用當前收盤價之前的資訊進行預測。
                                             </p>
                                         </div>
                                         <div class="card-content space-y-6">
@@ -2083,12 +2091,12 @@
                                                 </label>
                                                 <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
                                                     訓練輪數（epochs）
-                                                    <input id="ai-epochs" type="number" min="10" max="200" step="10" value="80" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                    <input id="ai-epochs" type="number" min="10" max="300" step="10" value="80" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
                                                     <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">增加輪數可提高擬合度，但須留意過擬合。</span>
                                                 </label>
                                                 <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
                                                     批次大小（batch size）
-                                                    <input id="ai-batch-size" type="number" min="8" max="256" step="8" value="64" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                    <input id="ai-batch-size" type="number" min="8" max="512" step="8" value="64" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
                                                     <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">批次需小於訓練樣本數，以保留梯度穩定性。</span>
                                                 </label>
                                                 <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
@@ -2096,12 +2104,36 @@
                                                     <input id="ai-learning-rate" type="number" min="0.0001" max="0.05" step="0.0001" value="0.005" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
                                                     <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">根據金融序列噪音，建議 0.001~0.01。</span>
                                                 </label>
+                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                    訓練 / 測試切分
+                                                    <select id="ai-train-ratio" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);">
+                                                        <option value="0.7">70% 訓練 / 30% 測試</option>
+                                                        <option value="0.75">75% 訓練 / 25% 測試</option>
+                                                        <option value="0.8" selected>80% 訓練 / 20% 測試</option>
+                                                        <option value="0.85">85% 訓練 / 15% 測試</option>
+                                                    </select>
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">可依資料長度調整測試樣本比例。</span>
+                                                </label>
+                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                    預測門檻（Prob. ≥ 門檻才開倉）
+                                                    <input id="ai-threshold" type="number" min="0.1" max="0.9" step="0.01" value="0.5" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">調整模型信心門檻，控管假突破。</span>
+                                                </label>
+                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                    隨機種子
+                                                    <div class="flex items-center gap-2">
+                                                        <input id="ai-random-seed" type="number" min="0" step="1" value="42" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                        <button id="ai-save-seed" type="button" class="px-2 py-1 text-[11px] border rounded" style="border-color: var(--border); color: var(--primary);">儲存</button>
+                                                        <button id="ai-randomize-seed" type="button" class="px-2 py-1 text-[11px] border rounded" style="border-color: var(--border); color: var(--foreground);">亂數</button>
+                                                    </div>
+                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">固定種子可重現結果；不同模型各自保存。</span>
+                                                </label>
                                                 <label class="flex flex-col gap-2 text-xs font-medium md:col-span-2 xl:col-span-2" style="color: var(--foreground);">
                                                     資金控管
                                                     <div class="flex flex-col gap-2 p-3 border rounded-lg" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 4%, transparent);">
                                                         <label class="inline-flex items-center gap-2 text-xs">
                                                             <input id="ai-enable-kelly" type="checkbox" class="rounded border-border text-primary focus:ring-primary" />
-                                                            <span>啟用凱利公式估算投入比例（預設根據訓練期勝率與平均盈虧比）</span>
+                                                            <span>啟用凱利公式估算投入比例（依訓練期勝率與平均盈虧比）</span>
                                                         </label>
                                                         <label class="flex items-center gap-2 text-xs">
                                                             <span class="min-w-[120px]">固定投入比例</span>
@@ -2114,7 +2146,8 @@
                                             <div class="p-3 border rounded-lg bg-background" style="border-color: var(--border);">
                                                 <div class="flex flex-wrap items-center gap-3 text-xs" style="color: var(--muted-foreground);">
                                                     <span id="ai-dataset-summary">尚未取得資料，請先完成一次主回測。</span>
-                                                    <span class="px-2 py-1 rounded" style="background-color: color-mix(in srgb, var(--secondary) 16%, transparent); color: var(--secondary-foreground);">訓練：測試 = 2 : 1</span>
+                                                    <span id="ai-train-ratio-badge" class="px-2 py-1 rounded" style="background-color: color-mix(in srgb, var(--secondary) 16%, transparent); color: var(--secondary-foreground);">訓練：測試 = 80 : 20</span>
+                                                    <span id="ai-threshold-badge" class="px-2 py-1 rounded" style="background-color: color-mix(in srgb, var(--muted) 24%, transparent); color: var(--foreground);">預測門檻 50%</span>
                                                 </div>
                                             </div>
                                             <div class="flex flex-wrap items-center gap-3">
@@ -2127,7 +2160,10 @@
                                     </div>
                                     <div class="card">
                                         <div class="card-header flex flex-col gap-2">
-                                            <h3 class="card-title text-base">模型與交易成果</h3>
+                                            <div class="flex flex-wrap items-center justify-between gap-3">
+                                                <h3 class="card-title text-base">模型與交易成果</h3>
+                                                <span id="ai-result-model-label" class="text-xs font-semibold" style="color: var(--primary);">LSTM 深度學習</span>
+                                            </div>
                                             <p class="text-xs" style="color: var(--muted-foreground);">展示訓練與測試勝率、預測信心與採用凱利公式後的資金曲線摘要。</p>
                                         </div>
                                         <div class="card-content space-y-4">
@@ -2148,9 +2184,25 @@
                                                     <p id="ai-hit-rate" class="text-[11px]" style="color: var(--muted-foreground);">命中率：—</p>
                                                 </div>
                                                 <div class="p-3 border rounded-lg" style="border-color: var(--border);">
-                                                    <p class="font-medium text-[13px]" style="color: var(--muted-foreground);">AI 策略報酬</p>
+                                                    <p class="font-medium text-[13px]" style="color: var (--muted-foreground);">AI 策略報酬</p>
                                                     <p id="ai-total-return" class="text-lg font-semibold">—</p>
                                                     <p id="ai-average-profit" class="text-[11px]" style="color: var(--muted-foreground);">平均每筆：—</p>
+                                                </div>
+                                            </div>
+                                            <div id="ai-extra-metrics" class="grid gap-4 md:grid-cols-2 text-xs" style="color: var(--foreground);">
+                                                <div class="p-3 border rounded-lg" style="border-color: var(--border);">
+                                                    <p class="font-medium text-[13px]" style="color: var(--muted-foreground);">混淆矩陣</p>
+                                                    <dl class="grid grid-cols-2 gap-y-1 mt-2 text-[11px]" id="ai-confusion-matrix">
+                                                        <div class="flex items-center justify-between"><dt>TP（預測漲且漲）</dt><dd id="ai-confusion-tp">—</dd></div>
+                                                        <div class="flex items-center justify-between"><dt>TN（預測跌且跌）</dt><dd id="ai-confusion-tn">—</dd></div>
+                                                        <div class="flex items-center justify-between"><dt>FP（預測漲實際跌）</dt><dd id="ai-confusion-fp">—</dd></div>
+                                                        <div class="flex items-center justify-between"><dt>FN（預測跌實際漲）</dt><dd id="ai-confusion-fn">—</dd></div>
+                                                    </dl>
+                                                </div>
+                                                <div class="p-3 border rounded-lg" style="border-color: var(--border);">
+                                                    <p class="font-medium text-[13px]" style="color: var(--muted-foreground);">資金建議</p>
+                                                    <p id="ai-kelly-stats" class="text-[11px]" style="color: var(--muted-foreground);">尚未計算。</p>
+                                                    <p id="ai-training-odds" class="text-[11px] mt-1" style="color: var(--muted-foreground);">訓練期平均盈虧比：—</p>
                                                 </div>
                                             </div>
                                             <div class="overflow-x-auto">

--- a/js/ai-prediction.js
+++ b/js/ai-prediction.js
@@ -1,12 +1,54 @@
 /* global tf, document, window */
 
 // Patch Tag: LB-AI-LSTM-20250915A
+// Patch Tag: LB-AI-MULTIMODEL-20251120A
+// Patch Tag: LB-AI-ANNS-20251120A
+// Patch Tag: LB-AI-MULTIMODEL-20251121B
+// Patch Tag: LB-AI-ANNS-20251121B
+
 (function registerLazybacktestAIPrediction() {
-    const VERSION_TAG = 'LB-AI-LSTM-20250915A';
+    const MULTI_VERSION_TAG = 'LB-AI-MULTIMODEL-20251121B';
+    const LSTM_VERSION_TAG = 'LB-AI-LSTM-20250915A';
+    const ANN_VERSION_TAG = 'LB-AI-ANNS-20251121B';
+    const STORAGE_PREFIX = 'LB_AI_MODEL_SEED_';
+    const MAX_RENDER_TRADES = 200;
+
+    const MODEL_DEFINITIONS = {
+        lstm: {
+            id: 'lstm',
+            label: 'LSTM 深度學習',
+            versionTag: LSTM_VERSION_TAG,
+            description: '依據 Fischer & Krauss (2018)、Sirignano & Cont (2019) 與 Chen et al. (2024) 的研究設計，採用 LSTM 分析隔日收盤方向，僅使用歷史收盤序列與報酬。',
+        },
+        anns: {
+            id: 'anns',
+            label: 'ANNS 技術指標',
+            versionTag: ANN_VERSION_TAG,
+            description: '以技術指標為特徵的前饋式人工神經網路（ANN），於 Worker 端計算 SMA、EMA、KD、RSI、MACD、CCI 等指標並分割 80/20 訓練測試，回傳混淆矩陣與凱利建議。',
+        },
+    };
+
+    const colorMap = {
+        info: 'var(--muted-foreground)',
+        success: 'var(--primary)',
+        warning: 'var(--secondary)',
+        error: 'var(--destructive)',
+    };
+
     const state = {
         running: false,
-        lastSummary: null,
-        odds: 1,
+        activeModel: 'lstm',
+        seeds: {},
+        modelResults: {
+            lstm: null,
+            anns: null,
+        },
+        trainingOdds: {
+            lstm: null,
+            anns: null,
+        },
+        annWorker: null,
+        annWorkerReady: false,
     };
 
     const elements = {
@@ -29,13 +71,26 @@
         averageProfit: null,
         tradeTableBody: null,
         tradeSummary: null,
-    };
-
-    const colorMap = {
-        info: 'var(--muted-foreground)',
-        success: 'var(--primary)',
-        warning: 'var(--secondary)',
-        error: 'var(--destructive)',
+        modelVersion: null,
+        modelToggles: [],
+        settingsTitle: null,
+        settingsDescription: null,
+        trainRatio: null,
+        threshold: null,
+        thresholdBadge: null,
+        trainRatioBadge: null,
+        seedInput: null,
+        seedSave: null,
+        seedRandom: null,
+        resultModelLabel: null,
+        kellyStats: null,
+        trainingOddsLabel: null,
+        confusion: {
+            tp: null,
+            tn: null,
+            fp: null,
+            fn: null,
+        },
     };
 
     const ensureBridge = () => {
@@ -91,6 +146,27 @@
         return parseNumberInput(input, 100000, { min: 1000 });
     };
 
+    const getLookback = () => Math.round(parseNumberInput(elements.lookback, 20, { min: 5, max: 60 }));
+    const getEpochs = () => Math.round(parseNumberInput(elements.epochs, 80, { min: 10, max: 300 }));
+    const getBatchSize = () => Math.round(parseNumberInput(elements.batchSize, 64, { min: 8, max: 512 }));
+    const getLearningRate = () => parseNumberInput(elements.learningRate, 0.005, { min: 0.0001, max: 0.05 });
+
+    const getTrainRatio = () => {
+        if (!elements.trainRatio) return 0.8;
+        const value = Number(elements.trainRatio.value);
+        if (!Number.isFinite(value)) return 0.8;
+        return Math.min(Math.max(value, 0.6), 0.9);
+    };
+
+    const getThreshold = () => {
+        if (!elements.threshold) return 0.5;
+        return Math.min(Math.max(Number(elements.threshold.value) || 0.5, 0.1), 0.9);
+    };
+
+    const getFixedFraction = () => parseNumberInput(elements.fixedFraction, 0.2, { min: 0.01, max: 1 });
+
+    const isKellyEnabled = () => Boolean(elements.enableKelly?.checked);
+
     const getVisibleData = () => {
         const bridge = ensureBridge();
         if (bridge && typeof bridge.getVisibleStockData === 'function') {
@@ -119,6 +195,13 @@
             }
         }
         return null;
+    };
+
+    const getDatasetRows = () => {
+        if (typeof window !== 'undefined' && Array.isArray(window.cachedStockData) && window.cachedStockData.length > 0) {
+            return window.cachedStockData;
+        }
+        return getVisibleData();
     };
 
     const buildDataset = (rows, lookback) => {
@@ -197,26 +280,6 @@
         return sequences.map((seq) => seq.map((value) => (value - mean) / (std || 1)));
     };
 
-    const createModel = (lookback, learningRate) => {
-        const model = tf.sequential();
-        model.add(tf.layers.lstm({ units: 32, returnSequences: true, inputShape: [lookback, 1] }));
-        model.add(tf.layers.dropout({ rate: 0.2 }));
-        model.add(tf.layers.lstm({ units: 16 }));
-        model.add(tf.layers.dropout({ rate: 0.1 }));
-        model.add(tf.layers.dense({ units: 16, activation: 'relu' }));
-        model.add(tf.layers.dense({ units: 1, activation: 'sigmoid' }));
-        const optimizer = tf.train.adam(learningRate);
-        model.compile({ optimizer, loss: 'binaryCrossentropy', metrics: ['accuracy'] });
-        return model;
-    };
-
-    const computeKellyFraction = (probability, odds) => {
-        const sanitizedProb = Math.min(Math.max(probability, 0.001), 0.999);
-        const b = Math.max(odds, 1e-6);
-        const fraction = sanitizedProb - ((1 - sanitizedProb) / b);
-        return Math.max(0, Math.min(fraction, 1));
-    };
-
     const computeTrainingOdds = (returns, trainSize) => {
         if (!Array.isArray(returns) || returns.length === 0 || trainSize <= 0) {
             return 1;
@@ -232,23 +295,67 @@
         return Math.max(avgWin / avgLoss, 0.25);
     };
 
-    const updateDatasetSummary = (rows) => {
-        if (!elements.datasetSummary) return;
-        const data = Array.isArray(rows) ? rows : [];
-        if (data.length === 0) {
-            elements.datasetSummary.textContent = '尚未取得資料，請先完成一次主回測。';
-            return;
+    const computeKellyFraction = (probability, odds) => {
+        const sanitizedProb = Math.min(Math.max(probability, 0.001), 0.999);
+        const b = Math.max(odds, 1e-6);
+        const fraction = sanitizedProb - ((1 - sanitizedProb) / b);
+        return Math.max(0, Math.min(fraction, 1));
+    };
+
+    const computeConfusionMatrix = (labels, probabilities, threshold) => {
+        const confusion = { TP: 0, TN: 0, FP: 0, FN: 0 };
+        if (!Array.isArray(labels) || !Array.isArray(probabilities) || labels.length !== probabilities.length) {
+            return confusion;
         }
-        const sorted = [...data]
-            .filter((row) => row && typeof row.date === 'string')
-            .sort((a, b) => a.date.localeCompare(b.date));
-        if (sorted.length === 0) {
-            elements.datasetSummary.textContent = '資料缺少有效日期，請重新回測。';
-            return;
+        for (let i = 0; i < labels.length; i += 1) {
+            const actual = labels[i];
+            const predicted = probabilities[i] >= threshold ? 1 : 0;
+            if (actual === 1 && predicted === 1) confusion.TP += 1;
+            else if (actual === 0 && predicted === 0) confusion.TN += 1;
+            else if (actual === 0 && predicted === 1) confusion.FP += 1;
+            else if (actual === 1 && predicted === 0) confusion.FN += 1;
         }
-        const firstDate = sorted[0].date;
-        const lastDate = sorted[sorted.length - 1].date;
-        elements.datasetSummary.textContent = `可用資料 ${sorted.length} 筆，區間 ${firstDate} ~ ${lastDate}。`;
+        return confusion;
+    };
+
+    const estimateKellyFromTrades = (trades) => {
+        if (!Array.isArray(trades) || trades.length === 0) {
+            return { p: 0, b: 0, k: 0 };
+        }
+        const ups = [];
+        const dns = [];
+        trades.forEach((trade) => {
+            if (!trade || !Number.isFinite(trade.actualReturn)) return;
+            if (trade.actualReturn > 0) ups.push(trade.actualReturn);
+            else dns.push(Math.abs(trade.actualReturn));
+        });
+        const total = ups.length + dns.length;
+        const p = total > 0 ? ups.length / total : 0;
+        const avgUp = ups.length ? ups.reduce((a, b) => a + b, 0) / ups.length : 0;
+        const avgDn = dns.length ? dns.reduce((a, b) => a + b, 0) / dns.length : 0;
+        const b = avgDn > 0 ? (avgUp / avgDn) : 1;
+        const q = 1 - p;
+        const k = Math.max(0, (b * p - q) / (b || 1));
+        return { p, b, k };
+    };
+
+    const resetMetricsDisplay = () => {
+        if (elements.trainAccuracy) elements.trainAccuracy.textContent = '—';
+        if (elements.trainLoss) elements.trainLoss.textContent = 'Loss：—';
+        if (elements.testAccuracy) elements.testAccuracy.textContent = '—';
+        if (elements.testLoss) elements.testLoss.textContent = 'Loss：—';
+        if (elements.tradeCount) elements.tradeCount.textContent = '—';
+        if (elements.hitRate) elements.hitRate.textContent = '命中率：—';
+        if (elements.totalReturn) elements.totalReturn.textContent = '—';
+        if (elements.averageProfit) elements.averageProfit.textContent = '平均每筆：—';
+        if (elements.kellyStats) elements.kellyStats.textContent = '尚未計算。';
+        if (elements.trainingOddsLabel) elements.trainingOddsLabel.textContent = '訓練期平均盈虧比：—';
+        if (elements.confusion.tp) elements.confusion.tp.textContent = '—';
+        if (elements.confusion.tn) elements.confusion.tn.textContent = '—';
+        if (elements.confusion.fp) elements.confusion.fp.textContent = '—';
+        if (elements.confusion.fn) elements.confusion.fn.textContent = '—';
+        if (elements.tradeTableBody) elements.tradeTableBody.innerHTML = '';
+        if (elements.tradeSummary) elements.tradeSummary.textContent = '尚未生成交易結果。';
     };
 
     const renderTrades = (records) => {
@@ -258,7 +365,7 @@
             elements.tradeTableBody.innerHTML = '';
             return;
         }
-        const limited = rows.slice(0, 200);
+        const limited = rows.slice(0, MAX_RENDER_TRADES);
         const html = limited
             .map((trade) => {
                 const probabilityText = formatPercent(trade.probability, 1);
@@ -282,8 +389,11 @@
         elements.tradeTableBody.innerHTML = html;
     };
 
-    const updateSummaryMetrics = (summary) => {
-        if (!summary) return;
+    const updateMetricTexts = (summary) => {
+        if (!summary) {
+            resetMetricsDisplay();
+            return;
+        }
         if (elements.trainAccuracy) elements.trainAccuracy.textContent = formatPercent(summary.trainAccuracy, 2);
         if (elements.trainLoss) elements.trainLoss.textContent = `Loss：${formatNumber(summary.trainLoss, 4)}`;
         if (elements.testAccuracy) elements.testAccuracy.textContent = formatPercent(summary.testAccuracy, 2);
@@ -292,48 +402,264 @@
         if (elements.hitRate) elements.hitRate.textContent = `命中率：${formatPercent(summary.hitRate, 2)}`;
         if (elements.totalReturn) elements.totalReturn.textContent = `${formatPercent(summary.totalReturn, 2)}（${formatCurrency(summary.finalCapital)}）`;
         if (elements.averageProfit) elements.averageProfit.textContent = `平均每筆：${formatCurrency(summary.averageProfit)}`;
-        if (elements.tradeSummary) {
-            const strategyLabel = summary.usingKelly ? '已啟用凱利公式' : '採用固定比例';
-            elements.tradeSummary.textContent = `共評估 ${summary.totalPredictions} 筆測試樣本，執行 ${summary.executedTrades} 筆多單交易，${strategyLabel}。最終資金 ${formatCurrency(summary.finalCapital)}，總報酬 ${formatPercent(summary.totalReturn, 2)}。`;
+        if (elements.trainingOddsLabel) {
+            const odds = state.trainingOdds[state.activeModel];
+            elements.trainingOddsLabel.textContent = Number.isFinite(odds)
+                ? `訓練期平均盈虧比：${formatNumber(odds, 2)}`
+                : '訓練期平均盈虧比：—';
         }
     };
 
-    const runPrediction = async () => {
-        if (state.running) return;
+    const updateKellyInfo = (summary) => {
+        if (!elements.kellyStats) return;
+        if (!summary || !Number.isFinite(summary.kelly)) {
+            elements.kellyStats.textContent = '尚未計算。';
+            return;
+        }
+        const details = summary.kellyDetails || {};
+        elements.kellyStats.textContent = summary.kelly > 0
+            ? `建議最大投入比例約 ${formatPercent(summary.kelly, 1)}，測試集中勝率 ${formatPercent(details.p || 0, 1)}、盈虧比 ${formatNumber(details.b || 0, 2)}。`
+            : '測試集中優勢不足，建議降低部位或觀望。';
+    };
+
+    const updateConfusionDisplay = (confusion) => {
+        const target = confusion || { TP: null, TN: null, FP: null, FN: null };
+        if (elements.confusion.tp) elements.confusion.tp.textContent = Number.isFinite(target.TP) ? target.TP : '—';
+        if (elements.confusion.tn) elements.confusion.tn.textContent = Number.isFinite(target.TN) ? target.TN : '—';
+        if (elements.confusion.fp) elements.confusion.fp.textContent = Number.isFinite(target.FP) ? target.FP : '—';
+        if (elements.confusion.fn) elements.confusion.fn.textContent = Number.isFinite(target.FN) ? target.FN : '—';
+    };
+
+    const updateTradeSummary = (summary) => {
+        if (!elements.tradeSummary) return;
+        if (!summary) {
+            elements.tradeSummary.textContent = '尚未生成交易結果。';
+            return;
+        }
+        const strategyLabel = summary.usingKelly ? '已啟用凱利公式' : '採用固定比例';
+        const thresholdText = `預測門檻 ${formatPercent(summary.threshold, 0)}`;
+        const ratioText = `訓練/測試 = ${Math.round(summary.trainRatio * 100)} / ${Math.round((1 - summary.trainRatio) * 100)}`;
+        elements.tradeSummary.textContent = `共評估 ${summary.totalPredictions} 筆測試樣本，執行 ${summary.executedTrades} 筆多單交易，${strategyLabel}，${thresholdText}，${ratioText}。最終資金 ${formatCurrency(summary.finalCapital)}，總報酬 ${formatPercent(summary.totalReturn, 2)}。`;
+    };
+
+    const updateModelVersionLabel = () => {
+        if (!elements.modelVersion) return;
+        const definition = MODEL_DEFINITIONS[state.activeModel];
+        elements.modelVersion.textContent = definition ? definition.label : 'AI 模型';
+    };
+
+    const updateResultModelLabel = () => {
+        if (!elements.resultModelLabel) return;
+        const definition = MODEL_DEFINITIONS[state.activeModel];
+        elements.resultModelLabel.textContent = definition ? definition.label : 'AI 模型';
+    };
+
+    const renderModelResult = (modelId) => {
+        const result = state.modelResults[modelId] || null;
+        if (elements.resultModelLabel) {
+            const definition = MODEL_DEFINITIONS[modelId];
+            elements.resultModelLabel.textContent = definition ? definition.label : 'AI 模型';
+        }
+        if (!result) {
+            resetMetricsDisplay();
+            return;
+        }
+        updateMetricTexts(result.summary);
+        updateKellyInfo(result.summary);
+        updateConfusionDisplay(result.confusion);
+        renderTrades(result.trades);
+        updateTradeSummary(result.summary);
+    };
+
+    const updateDatasetSummary = (rows) => {
+        if (!elements.datasetSummary) return;
+        const data = Array.isArray(rows) ? rows : getDatasetRows();
+        if (!Array.isArray(data) || data.length === 0) {
+            elements.datasetSummary.textContent = '尚未取得資料，請先完成一次主回測。';
+            return;
+        }
+        const sorted = [...data]
+            .filter((row) => row && typeof row.date === 'string')
+            .sort((a, b) => a.date.localeCompare(b.date));
+        if (sorted.length === 0) {
+            elements.datasetSummary.textContent = '資料缺少有效日期，請重新回測。';
+            return;
+        }
+        const firstDate = sorted[0].date;
+        const lastDate = sorted[sorted.length - 1].date;
+        elements.datasetSummary.textContent = `可用資料 ${sorted.length} 筆，區間 ${firstDate} ~ ${lastDate}。`;
+    };
+
+    const updateRatioBadge = () => {
+        if (!elements.trainRatioBadge) return;
+        const ratio = getTrainRatio();
+        const trainPct = Math.round(ratio * 100);
+        const testPct = 100 - trainPct;
+        elements.trainRatioBadge.textContent = `訓練：測試 = ${trainPct} : ${testPct}`;
+    };
+
+    const updateThresholdBadge = () => {
+        if (!elements.thresholdBadge) return;
+        elements.thresholdBadge.textContent = `預測門檻 ${formatPercent(getThreshold(), 0)}`;
+    };
+
+    const applyModelSeed = (modelId) => {
+        const seed = state.seeds[modelId];
+        if (!Number.isFinite(seed)) return;
+        if (typeof tf !== 'undefined' && tf?.util?.setSeed) {
+            try {
+                tf.util.setSeed(seed);
+            } catch (error) {
+                console.warn('[AI Prediction] 設定隨機種子失敗:', error);
+            }
+        }
+    };
+
+    const ensureAnnWorker = () => {
+        if (state.annWorker) return state.annWorker;
+        const workerPath = (typeof window !== 'undefined' && typeof window.workerUrl === 'string')
+            ? window.workerUrl
+            : 'js/worker.js';
+        try {
+            const worker = new Worker(workerPath);
+            worker.addEventListener('message', (event) => {
+                const message = event.data || {};
+                if (message.type === 'AI_ANN_PROGRESS') {
+                    const progress = message.payload?.progress ?? 0;
+                    showStatus(`訓練中… ${Math.round(progress * 100)}%`, 'info');
+                } else if (message.type === 'AI_ANN_DONE') {
+                    toggleRunning(false);
+                    showStatus('ANN 訓練完成', 'success');
+                    const payload = message.payload || {};
+                    state.modelResults.anns = {
+                        summary: payload.summary || null,
+                        trades: payload.trades || [],
+                        confusion: payload.confusion || null,
+                    };
+                    state.trainingOdds.anns = payload.summary?.trainingOdds ?? null;
+                    if (state.activeModel === 'anns') {
+                        renderModelResult('anns');
+                    }
+                } else if (message.type === 'AI_ANN_ERROR') {
+                    toggleRunning(false);
+                    showStatus(`ANN 執行失敗：${message.payload?.message || '未知錯誤'}`, 'error');
+                }
+            });
+            state.annWorker = worker;
+            return worker;
+        } catch (error) {
+            console.error('[AI Prediction] 建立 ANN Worker 失敗:', error);
+            showStatus('無法建立 ANN 訓練引擎，請檢查瀏覽器支援度。', 'error');
+            return null;
+        }
+    };
+
+    const storeSeed = (modelId, value) => {
+        if (!Number.isFinite(value)) return;
+        state.seeds[modelId] = value;
+        if (typeof window !== 'undefined' && window.localStorage) {
+            try {
+                window.localStorage.setItem(`${STORAGE_PREFIX}${modelId}`, String(Math.round(value)));
+            } catch (error) {
+                console.warn('[AI Prediction] 無法儲存種子至 localStorage:', error);
+            }
+        }
+    };
+
+    const loadStoredSeeds = () => {
+        if (typeof window === 'undefined' || !window.localStorage) return;
+        Object.keys(MODEL_DEFINITIONS).forEach((modelId) => {
+            try {
+                const stored = window.localStorage.getItem(`${STORAGE_PREFIX}${modelId}`);
+                if (stored !== null) {
+                    const parsed = Number(stored);
+                    if (Number.isFinite(parsed)) {
+                        state.seeds[modelId] = parsed;
+                    }
+                }
+            } catch (error) {
+                console.warn('[AI Prediction] 載入種子失敗:', error);
+            }
+            if (!Number.isFinite(state.seeds[modelId])) {
+                state.seeds[modelId] = 42;
+            }
+        });
+    };
+
+    const updateSeedInput = () => {
+        if (!elements.seedInput) return;
+        const seed = state.seeds[state.activeModel];
+        elements.seedInput.value = Number.isFinite(seed) ? String(Math.round(seed)) : '42';
+    };
+
+    const generateRandomSeed = () => {
+        if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+            const buffer = new Uint32Array(1);
+            crypto.getRandomValues(buffer);
+            return buffer[0];
+        }
+        return Math.floor(Math.random() * 1e9);
+    };
+
+    const setActiveModel = (modelId) => {
+        if (!MODEL_DEFINITIONS[modelId]) return;
+        state.activeModel = modelId;
+        elements.modelToggles.forEach((btn) => {
+            const target = btn.dataset.aiModel;
+            const isActive = target === modelId;
+            btn.style.backgroundColor = isActive ? 'var(--primary)' : 'transparent';
+            btn.style.color = isActive ? 'var(--primary-foreground)' : 'var(--muted-foreground)';
+        });
+        const definition = MODEL_DEFINITIONS[modelId];
+        if (elements.settingsTitle) elements.settingsTitle.textContent = 'AI 模型預測設定';
+        if (elements.settingsDescription) elements.settingsDescription.textContent = definition?.description || '';
+        if (elements.modelVersion) elements.modelVersion.textContent = definition?.label || 'AI 模型';
+        updateResultModelLabel();
+        updateSeedInput();
+        updateRatioBadge();
+        updateThresholdBadge();
+        renderModelResult(modelId);
+    };
+
+    const runLstmModel = async () => {
         if (typeof tf === 'undefined' || typeof tf.tensor !== 'function') {
             showStatus('未載入 TensorFlow.js，請確認網路連線。', 'error');
             return;
         }
+
         toggleRunning(true);
+        showStatus('準備資料…', 'info');
 
         try {
-            const lookback = Math.round(parseNumberInput(elements.lookback, 20, { min: 5, max: 60 }));
-            const epochs = Math.round(parseNumberInput(elements.epochs, 80, { min: 10, max: 300 }));
-            const batchSize = Math.round(parseNumberInput(elements.batchSize, 64, { min: 8, max: 512 }));
-            const learningRate = parseNumberInput(elements.learningRate, 0.005, { min: 0.0001, max: 0.05 });
-            const fixedFraction = parseNumberInput(elements.fixedFraction, 0.2, { min: 0.01, max: 1 });
-            const useKelly = Boolean(elements.enableKelly?.checked);
-
-            const rows = getVisibleData();
+            const rows = getDatasetRows();
             if (!Array.isArray(rows) || rows.length === 0) {
                 showStatus('尚未取得回測資料，請先在主頁面執行回測。', 'warning');
                 toggleRunning(false);
                 return;
             }
 
+            const lookback = getLookback();
+            const epochs = getEpochs();
+            const batchSize = getBatchSize();
+            const learningRate = getLearningRate();
+            const fixedFraction = getFixedFraction();
+            const useKelly = isKellyEnabled();
+            const trainRatio = getTrainRatio();
+            const threshold = getThreshold();
+
             const dataset = buildDataset(rows, lookback);
-            if (dataset.sequences.length < 45) {
+            if (dataset.sequences.length < Math.max(45, lookback * 3)) {
                 showStatus(`資料樣本不足（需至少 ${Math.max(45, lookback * 3)} 筆有效樣本，目前 ${dataset.sequences.length} 筆），請延長回測期間。`, 'warning');
                 toggleRunning(false);
                 return;
             }
 
             const totalSamples = dataset.sequences.length;
-            const trainSize = Math.max(Math.floor(totalSamples * (2 / 3)), lookback);
-            const boundedTrainSize = Math.min(trainSize, totalSamples - 1);
+            const tentativeTrainSize = Math.max(Math.floor(totalSamples * trainRatio), lookback);
+            const boundedTrainSize = Math.min(tentativeTrainSize, totalSamples - 1);
             const testSize = totalSamples - boundedTrainSize;
             if (boundedTrainSize <= 0 || testSize <= 0) {
-                showStatus('無法按照 2:1 分割訓練與測試集，請延長資料範圍。', 'warning');
+                showStatus('無法依照設定切分訓練與測試集，請延長資料範圍。', 'warning');
                 toggleRunning(false);
                 return;
             }
@@ -353,9 +679,19 @@
                 showStatus(`批次大小 ${batchSize} 大於訓練樣本數 ${boundedTrainSize}，已自動調整為 ${boundedTrainSize}。`, 'warning');
             }
 
-            const model = createModel(lookback, learningRate);
-            showStatus(`訓練中（共 ${epochs} 輪）...`, 'info');
+            const model = tf.sequential();
+            model.add(tf.layers.lstm({ units: 32, returnSequences: true, inputShape: [lookback, 1] }));
+            model.add(tf.layers.dropout({ rate: 0.2 }));
+            model.add(tf.layers.lstm({ units: 16 }));
+            model.add(tf.layers.dropout({ rate: 0.1 }));
+            model.add(tf.layers.dense({ units: 16, activation: 'relu' }));
+            model.add(tf.layers.dense({ units: 1, activation: 'sigmoid' }));
+            const optimizer = tf.train.adam(learningRate);
+            model.compile({ optimizer, loss: 'binaryCrossentropy', metrics: ['accuracy'] });
 
+            applyModelSeed('lstm');
+
+            showStatus(`訓練中（共 ${epochs} 輪）...`, 'info');
             const history = await model.fit(xTrain, yTrain, {
                 epochs,
                 batchSize: Math.min(batchSize, boundedTrainSize),
@@ -385,7 +721,6 @@
                 })
             );
             const testLoss = evalValues[0] ?? NaN;
-            const testAccuracy = evalValues[1] ?? NaN;
 
             const predictionsTensor = model.predict(xTest);
             const predictionValues = Array.from(await predictionsTensor.data());
@@ -394,15 +729,15 @@
             const labels = dataset.labels.slice(boundedTrainSize);
             let correctPredictions = 0;
             predictionValues.forEach((value, index) => {
-                const predictedLabel = value >= 0.5 ? 1 : 0;
+                const predictedLabel = value >= threshold ? 1 : 0;
                 if (predictedLabel === labels[index]) {
                     correctPredictions += 1;
                 }
             });
-            const manualAccuracy = correctPredictions / predictionValues.length;
+            const manualAccuracy = predictionValues.length > 0 ? (correctPredictions / predictionValues.length) : NaN;
 
             const trainingOdds = computeTrainingOdds(dataset.returns, boundedTrainSize);
-            state.odds = trainingOdds;
+            state.trainingOdds.lstm = trainingOdds;
 
             const initialCapital = resolveInitialCapital();
             let capital = initialCapital;
@@ -415,7 +750,7 @@
 
             for (let i = 0; i < predictionValues.length; i += 1) {
                 const probability = predictionValues[i];
-                const predictedUp = probability >= 0.5;
+                const predictedUp = probability >= threshold;
                 const actualReturn = testReturns[i];
                 const meta = testMeta[i];
                 if (!predictedUp || !meta) {
@@ -448,11 +783,14 @@
             const totalReturn = (capital - initialCapital) / initialCapital;
             const averageProfit = executed > 0 ? cumulativeProfit / executed : 0;
 
+            const kellyInfo = estimateKellyFromTrades(executedTrades);
+            const confusion = computeConfusionMatrix(labels, predictionValues, threshold);
+
             const summary = {
-                version: VERSION_TAG,
+                version: LSTM_VERSION_TAG,
                 trainAccuracy: finalTrainAccuracy,
                 trainLoss: finalTrainLoss,
-                testAccuracy: Number.isFinite(testAccuracy) ? testAccuracy : manualAccuracy,
+                testAccuracy: Number.isFinite(manualAccuracy) ? manualAccuracy : evalValues[1] ?? NaN,
                 testLoss,
                 totalPredictions,
                 executedTrades: executed,
@@ -461,24 +799,131 @@
                 averageProfit,
                 finalCapital: capital,
                 usingKelly: useKelly,
+                threshold,
+                trainRatio,
+                kelly: kellyInfo.k,
+                kellyDetails: kellyInfo,
+                trainingOdds,
             };
-            state.lastSummary = summary;
 
-            updateSummaryMetrics(summary);
-            renderTrades(executedTrades);
+            state.modelResults.lstm = {
+                summary,
+                trades: executedTrades,
+                confusion,
+            };
+
+            if (state.activeModel === 'lstm') {
+                updateMetricTexts(summary);
+                updateKellyInfo(summary);
+                updateConfusionDisplay(confusion);
+                renderTrades(executedTrades);
+                updateTradeSummary(summary);
+            }
+
             showStatus(`完成：訓練勝率 ${formatPercent(finalTrainAccuracy, 2)}，測試正確率 ${formatPercent(summary.testAccuracy, 2)}。`, 'success');
 
             tf.dispose([xAll, yAll, xTrain, yTrain, xTest, yTest]);
             model.dispose();
         } catch (error) {
-            console.error('[AI Prediction] 執行失敗:', error);
+            console.error('[AI Prediction] 執行 LSTM 失敗:', error);
             showStatus(`AI 預測執行失敗：${error.message}`, 'error');
         } finally {
             toggleRunning(false);
         }
     };
 
-    const init = () => {
+    const runAnnModel = () => {
+        const worker = ensureAnnWorker();
+        if (!worker) return;
+
+        const rows = getDatasetRows();
+        if (!Array.isArray(rows) || rows.length < 60) {
+            showStatus('資料不足（至少 60 根 K 線），請先延長回測期間。', 'warning');
+            return;
+        }
+
+        const payload = {
+            rows,
+            options: {
+                trainRatio: getTrainRatio(),
+                epochs: getEpochs(),
+                batchSize: getBatchSize(),
+                learningRate: getLearningRate(),
+                useKelly: isKellyEnabled(),
+                fixedFraction: getFixedFraction(),
+                threshold: getThreshold(),
+                seed: state.seeds.anns,
+                initialCapital: resolveInitialCapital(),
+            },
+        };
+
+        try {
+            toggleRunning(true);
+            showStatus('已送出至 Worker，開始訓練 ANN…', 'info');
+            worker.postMessage({ type: 'AI_ANN_RUN', payload });
+        } catch (error) {
+            console.error('[AI Prediction] 送交 ANN Worker 失敗:', error);
+            toggleRunning(false);
+            showStatus(`送交 ANN Worker 失敗：${error.message}`, 'error');
+        }
+    };
+
+    const runActiveModel = () => {
+        if (state.running) return;
+        if (state.activeModel === 'anns') {
+            runAnnModel();
+        } else {
+            runLstmModel();
+        }
+    };
+
+    const bindEvents = () => {
+        if (elements.runButton) {
+            elements.runButton.addEventListener('click', runActiveModel);
+        }
+
+        if (elements.trainRatio) {
+            elements.trainRatio.addEventListener('change', () => {
+                updateRatioBadge();
+                const rows = getDatasetRows();
+                updateDatasetSummary(rows);
+            });
+        }
+
+        if (elements.threshold) {
+            elements.threshold.addEventListener('input', () => {
+                updateThresholdBadge();
+            });
+        }
+
+        if (elements.seedSave) {
+            elements.seedSave.addEventListener('click', () => {
+                const seedValue = Number(elements.seedInput?.value);
+                if (!Number.isFinite(seedValue)) {
+                    showStatus('請輸入有效的整數種子。', 'warning');
+                    return;
+                }
+                storeSeed(state.activeModel, Math.round(seedValue));
+                showStatus(`已儲存 ${MODEL_DEFINITIONS[state.activeModel].label} 的隨機種子。`, 'success');
+            });
+        }
+
+        if (elements.seedRandom) {
+            elements.seedRandom.addEventListener('click', () => {
+                const randomSeed = generateRandomSeed();
+                if (elements.seedInput) elements.seedInput.value = String(randomSeed);
+            });
+        }
+
+        elements.modelToggles.forEach((btn) => {
+            btn.addEventListener('click', () => {
+                const modelId = btn.dataset.aiModel;
+                setActiveModel(modelId);
+            });
+        });
+    };
+
+    const initElements = () => {
         elements.datasetSummary = document.getElementById('ai-dataset-summary');
         elements.status = document.getElementById('ai-status');
         elements.runButton = document.getElementById('ai-run-button');
@@ -498,37 +943,62 @@
         elements.averageProfit = document.getElementById('ai-average-profit');
         elements.tradeTableBody = document.getElementById('ai-trade-table-body');
         elements.tradeSummary = document.getElementById('ai-trade-summary');
+        elements.modelVersion = document.getElementById('ai-model-version');
+        elements.settingsTitle = document.getElementById('ai-settings-title');
+        elements.settingsDescription = document.getElementById('ai-settings-description');
+        elements.trainRatio = document.getElementById('ai-train-ratio');
+        elements.threshold = document.getElementById('ai-threshold');
+        elements.thresholdBadge = document.getElementById('ai-threshold-badge');
+        elements.trainRatioBadge = document.getElementById('ai-train-ratio-badge');
+        elements.seedInput = document.getElementById('ai-random-seed');
+        elements.seedSave = document.getElementById('ai-save-seed');
+        elements.seedRandom = document.getElementById('ai-randomize-seed');
+        elements.resultModelLabel = document.getElementById('ai-result-model-label');
+        elements.kellyStats = document.getElementById('ai-kelly-stats');
+        elements.trainingOddsLabel = document.getElementById('ai-training-odds');
+        elements.confusion.tp = document.getElementById('ai-confusion-tp');
+        elements.confusion.tn = document.getElementById('ai-confusion-tn');
+        elements.confusion.fp = document.getElementById('ai-confusion-fp');
+        elements.confusion.fn = document.getElementById('ai-confusion-fn');
 
-        if (elements.runButton) {
-            elements.runButton.addEventListener('click', () => {
-                runPrediction();
-            });
+        const switcher = document.getElementById('ai-model-switcher');
+        if (switcher) {
+            elements.modelToggles = Array.from(switcher.querySelectorAll('[data-ai-model]'));
         }
+    };
 
-        updateDatasetSummary(getVisibleData());
-
+    const registerBridge = () => {
         const bridge = ensureBridge();
-        if (bridge) {
-            const previousHandler = typeof bridge.handleVisibleDataUpdate === 'function'
-                ? bridge.handleVisibleDataUpdate
-                : null;
-            bridge.handleVisibleDataUpdate = (data) => {
-                if (typeof previousHandler === 'function') {
-                    try {
-                        previousHandler(data);
-                    } catch (error) {
-                        console.warn('[AI Prediction] 前一個資料更新處理失敗:', error);
-                    }
+        if (!bridge) return;
+        const previousHandler = typeof bridge.handleVisibleDataUpdate === 'function'
+            ? bridge.handleVisibleDataUpdate
+            : null;
+        bridge.handleVisibleDataUpdate = (data) => {
+            if (typeof previousHandler === 'function') {
+                try {
+                    previousHandler(data);
+                } catch (error) {
+                    console.warn('[AI Prediction] 前一個資料更新處理失敗:', error);
                 }
-                updateDatasetSummary(data);
-            };
-            bridge.versionTag = VERSION_TAG;
-        }
-
-        window.addEventListener('lazybacktest:visible-data-changed', (event) => {
-            if (event && typeof event.detail === 'object') {
-                updateDatasetSummary(getVisibleData());
             }
+            updateDatasetSummary(data);
+        };
+        bridge.versionTag = MULTI_VERSION_TAG;
+    };
+
+    const init = () => {
+        initElements();
+        loadStoredSeeds();
+        setActiveModel('lstm');
+        updateRatioBadge();
+        updateThresholdBadge();
+        updateSeedInput();
+        updateDatasetSummary(getDatasetRows());
+        bindEvents();
+        registerBridge();
+
+        window.addEventListener('lazybacktest:visible-data-changed', () => {
+            updateDatasetSummary(getDatasetRows());
         });
     };
 

--- a/js/main.js
+++ b/js/main.js
@@ -16,6 +16,21 @@ let backtestWorker = null;
 let optimizationWorker = null;
 let workerUrl = null; // Loader 會賦值
 let cachedStockData = null;
+
+if (typeof window !== 'undefined') {
+    const existingDescriptor = Object.getOwnPropertyDescriptor(window, 'cachedStockData');
+    if (!existingDescriptor || existingDescriptor.configurable) {
+        Object.defineProperty(window, 'cachedStockData', {
+            configurable: true,
+            get() {
+                return cachedStockData;
+            },
+            set(value) {
+                cachedStockData = Array.isArray(value) ? value : null;
+            },
+        });
+    }
+}
 const cachedDataStore = new Map(); // Map<market|stockNo|priceMode, CacheEntry>
 const progressAnimator = createProgressAnimator();
 

--- a/log.md
+++ b/log.md
@@ -1,3 +1,35 @@
+## 2025-11-21 — Patch LB-AI-ANNS-20251121B
+- **Scope**: 將 ANN 模型版本號更新至 20251121B，補齊 Worker 端版本常數並在 TensorFlow.js 未載入時回傳明確錯誤。
+- **Details**:
+  - 前端 `ai-prediction.js` 與 Worker `worker.js` 對齊最新版本代碼，方便日後追蹤部署批次。
+  - 新增 UI Patch Tag，方便辨識 AI 模型卡片的改版節點。
+  - Worker 在未載入 tfjs 時即回傳錯誤，避免 `ReferenceError` 導致 Worker 終止並讓使用者無法得知原因。
+- **Testing**: `node - <<'NODE'
+const fs=require('fs');
+const vm=require('vm');
+['js/backtest.js','js/main.js','js/worker.js','js/ai-prediction.js'].forEach((file)=>{
+  const code=fs.readFileSync(file,'utf8');
+  new vm.Script(code,{filename:file});
+});
+console.log('scripts compile');
+NODE`
+
+## 2025-11-20 — Patch LB-AI-MULTIMODEL-20251120A
+- **Scope**: AI 分頁升級為多模型架構，新增 ANNS 技術指標模型、資料切分控制與種子管理。
+- **Features**:
+  - 重新設計 AI 設定卡，加入 LSTM／ANNS 切換、訓練比例下拉、預測門檻、隨機種子儲存與亂數產生，並更新結果卡顯示混淆矩陣與凱利建議。
+  - LSTM 模型支援自訂訓練／測試比例與預測門檻，執行後會回傳混淆矩陣、凱利推估與交易紀錄摘要。
+  - Worker 端導入 ANN 管線（技術指標特徵、標準化、Dense 模型訓練、凱利估算），以 `AI_ANN_*` 訊息回傳進度與完整績效指標。
+- **Testing**: `node - <<'NODE'
+const fs=require('fs');
+const vm=require('vm');
+['js/backtest.js','js/main.js','js/worker.js','js/ai-prediction.js'].forEach((file)=>{
+  const code=fs.readFileSync(file,'utf8');
+  new vm.Script(code,{filename:file});
+});
+console.log('scripts compile');
+NODE`
+
 ## 2025-09-15 — Patch LB-AI-LSTM-20250915A
 - **Scope**: 新增「AI 預測」分頁與 LSTM 深度學習模組，整合凱利公式資金管理與快取資料串接。
 - **Features**:


### PR DESCRIPTION
## Summary
- redesign the AI prediction tab to support LSTM/ANNS switching, training ratio control, threshold and seed management, and enhanced result metrics
- implement a TensorFlow.js ANN pipeline inside the worker to generate predictions, confusion matrix, Kelly guidance and trade breakdowns
- expose cached stock data globally for reuse and document the new release in log.md

## Testing
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
['js/backtest.js','js/main.js','js/worker.js','js/ai-prediction.js'].forEach((file)=>{
  const code=fs.readFileSync(file,'utf8');
  new vm.Script(code,{filename:file});
});
console.log('scripts compile');
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68dc928f76b08324af051f8e9cd1fef1