### PR TITLE
feat: default Taiwan price proxies to Fugle

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,7 +606,7 @@
                                     </div>
                                     <div class="card-content space-y-4">
                                         <div>
-                                            <label for="stockNo" class="block text-xs font-medium text-foreground mb-1" style="color: var(--foreground);">台灣/美國股票代碼 (目前無提供指數)</label>
+                                            <label for="stockNo" class="block text-xs font-medium text-foreground mb-1" style="color: var(--foreground);">台灣/美國股票或指數代碼</label>
                                             <div class="flex flex-wrap items-center gap-2">
                                                 <div class="flex-1 min-w-[160px] sm:min-w-[200px]">
                                                     <input

--- a/js/main.js
+++ b/js/main.js
@@ -876,12 +876,14 @@ function getTesterSourceConfigs(market, adjusted, splitEnabled) {
     }
     if (market === 'TPEX') {
         return [
-            { id: 'finmind', label: 'FinMind 主來源', description: '預設資料來源' },
+            { id: 'fugle', label: 'Fugle 主來源', description: '預設資料來源' },
+            { id: 'finmind', label: 'FinMind 備援', description: 'Fugle 失效時啟用' },
             { id: 'yahoo', label: 'Yahoo 備援', description: 'FinMind 失效時啟用' },
         ];
     }
     return [
-        { id: 'twse', label: 'TWSE 主來源', description: '預設資料來源' },
+        { id: 'fugle', label: 'Fugle 主來源', description: '預設資料來源' },
+        { id: 'twse', label: 'TWSE 備援', description: 'Fugle 失效時啟用' },
         { id: 'finmind', label: 'FinMind 備援', description: 'TWSE 失效時啟用' },
     ];
 }
@@ -1489,9 +1491,9 @@ function refreshDataSourceTester() {
     } else if (market === 'US') {
         messageLines.push('FinMind 為主來源，Yahoo Finance 為備援來源。建議兩者都測試一次並確認 FINMIND_TOKEN 設定。');
     } else if (market === 'TPEX') {
-        messageLines.push('FinMind 為主來源，上櫃備援由 Yahoo 提供。建議主備來源都測試一次。');
+        messageLines.push('Fugle 為主來源，上櫃市場會先落回 FinMind，再視需要啟用 Yahoo 備援。請確認 FUGLE_API_TOKEN 與備援來源都可正常取得資料。');
     } else {
-        messageLines.push('TWSE 為主來源，FinMind 為備援來源。建議主備來源都測試一次。');
+        messageLines.push('Fugle 為主來源，必要時會依序落回 TWSE 與 FinMind。建議依序測試各來源並確認 Token 設定。');
     }
 
     if (!missingInputs && (market === 'TWSE' || market === 'TPEX')) {

--- a/js/worker.js
+++ b/js/worker.js
@@ -2241,11 +2241,9 @@ function summariseDataSourceFlags(flags, defaultLabel, options = {}) {
     options.fallbackRemote ||
     (options.adjusted
       ? 'Yahoo Finance (還原)'
-      : options.market === 'TPEX'
+      : options.market === 'US'
         ? 'FinMind (主來源)'
-        : options.market === 'US'
-          ? 'FinMind (主來源)'
-          : defaultLabel || 'TWSE (主來源)');
+        : defaultLabel || 'Fugle (主來源)');
 
   const fallbackDescriptor = parseSourceLabelDescriptor(fallbackLabel);
   const combined = parsed.slice();
@@ -2364,8 +2362,7 @@ function tryResolveRangeFromYearSuperset({
   const dataSourceFlags = new Set([
     "Netlify 年度快取 (Worker Superset)",
   ]);
-  const defaultRemoteLabel =
-    marketKey === "TPEX" ? "FinMind (主來源)" : "TWSE (主來源)";
+  const defaultRemoteLabel = "Fugle (主來源)";
   const dataSourceLabel = summariseDataSourceFlags(
     dataSourceFlags,
     defaultRemoteLabel,
@@ -2910,8 +2907,7 @@ async function tryFetchRangeFromBlob({
     : "Netlify 年度快取 (Blob 補抓)";
   dataSourceFlags.add(blobSourceLabel);
 
-  const defaultRemoteLabel =
-    marketKey === "TPEX" ? "FinMind (主來源)" : "TWSE (主來源)";
+  const defaultRemoteLabel = "Fugle (主來源)";
 
   const dataSourceLabel = summariseDataSourceFlags(dataSourceFlags, defaultRemoteLabel, {
     market: marketKey,
@@ -3826,14 +3822,14 @@ async function fetchStockData(
   const defaultRemoteLabel = isTpex
     ? adjusted
       ? "Yahoo Finance (還原)"
-      : "FinMind (主來源)"
+      : "Fugle (主來源)"
     : isUs
       ? adjusted
         ? "Yahoo Finance (還原)"
         : "FinMind (主來源)"
       : adjusted
         ? "Yahoo Finance (還原)"
-        : "TWSE (主來源)";
+        : "Fugle (主來源)";
   const dataSourceLabel = summariseDataSourceFlags(
     sourceFlags,
     defaultRemoteLabel,

--- a/log.md
+++ b/log.md
@@ -1,3 +1,11 @@
+## 2025-09-23 — Patch LB-FUGLE-SOURCE-20250923A
+- **Scope**: Fugle 台股主來源導入與官方清單支援指數。
+- **Features**:
+  - TWSE/TPEX Proxy 以 Fugle 為預設來源，失敗時依序落回 TWSE/FinMind（含 Yahoo 還原），並調整快取標籤與來源摘要。
+  - 前端資料來源測試器新增 Fugle 按鈕與提示文案，更新預設來源說明為「Fugle → TWSE/FinMind」。
+  - 台股官方清單整合 FinMind TaiwanIndexInfo，輸出上市/上櫃主要指數並升級版本碼 `LB-TW-DIRECTORY-20250923A`。
+- **Testing**: `node - <<'NODE' const fs = require('fs'); const vm = require('vm'); ['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{ const code = fs.readFileSync(file,'utf8'); new vm.Script(code,{filename:file}); }); console.log('scripts compile'); NODE`
+
 ## 2025-09-22 — Patch LB-AI-LSTM-20250922A
 - **Scope**: AI 預測分頁資金控管、收益呈現與種子管理強化。
 - **Features**:

--- a/netlify/functions/twse-proxy.js
+++ b/netlify/functions/twse-proxy.js
@@ -1,8 +1,9 @@
-// netlify/functions/twse-proxy.js (v10.6 - TWSE primary with FinMind adaptive retries + request logs)
+// netlify/functions/twse-proxy.js (v11.0 - Fugle primary with TWSE/FinMind/Yahoo fallbacks + adaptive retries)
 // Patch Tag: LB-DATASOURCE-20241007A
 // Patch Tag: LB-FINMIND-RETRY-20241012A
 // Patch Tag: LB-BLOBS-LOCAL-20241007B
 // Patch Tag: LB-TWSE-PROXY-20250320A
+// Patch Tag: LB-FUGLE-SOURCE-20250923A
 import { getStore } from '@netlify/blobs';
 import fetch from 'node-fetch';
 
@@ -11,6 +12,11 @@ const inMemoryCache = new Map(); // Map<cacheKey, { timestamp, data }>
 const inMemoryBlobStores = new Map(); // Map<storeName, MemoryStore>
 const DAY_SECONDS = 24 * 60 * 60;
 const FINMIND_LEVEL_PATTERN = /your level is register/i;
+const FUGLE_DEFAULT_BASE_URL = 'https://api.fugle.tw/marketdata/v1.0/stock/daily/ohlcv';
+const FUGLE_PRIMARY_LABEL = 'Fugle (主來源)';
+const FUGLE_FORCED_LABEL = 'Fugle (強制)';
+const FUGLE_CACHE_LABEL = 'Fugle (快取)';
+const FUGLE_MEMORY_CACHE_LABEL = 'Fugle (記憶體快取)';
 
 function isQuotaError(error) {
     return error?.status === 402 || error?.status === 429;
@@ -208,6 +214,144 @@ function parseTWSEPayload(raw, stockNo) {
         ];
     });
     return { stockName, aaData };
+}
+
+function hasFugleToken() {
+    return typeof process.env.FUGLE_API_TOKEN === 'string' && process.env.FUGLE_API_TOKEN.trim() !== '';
+}
+
+function resolveFugleBaseUrl() {
+    const base = (process.env.FUGLE_API_BASE_URL || FUGLE_DEFAULT_BASE_URL || '').trim();
+    if (!base) return FUGLE_DEFAULT_BASE_URL;
+    return base.endsWith('/') ? base.slice(0, -1) : base;
+}
+
+function normaliseFugleDataset(payload) {
+    if (!payload) return { rows: [], stockName: '' };
+    if (Array.isArray(payload.data)) {
+        return { rows: payload.data, stockName: payload.info?.nameZhTw || payload.info?.name || payload.data?.[0]?.stockName || '' };
+    }
+    const series = payload.data || {};
+    const dates = Array.isArray(series.date) ? series.date : [];
+    const length = dates.length;
+    const rows = [];
+    for (let i = 0; i < length; i += 1) {
+        rows.push({
+            date: series.date?.[i],
+            open: series.open?.[i],
+            high: series.high?.[i],
+            low: series.low?.[i],
+            close: series.close?.[i],
+            volume: series.volume?.[i],
+            change: series.change?.[i],
+            stockName: series.stockName?.[i] || series.name?.[i] || series.symbolName?.[i],
+        });
+    }
+    return { rows, stockName: payload.info?.nameZhTw || payload.info?.name || '' };
+}
+
+function normaliseFugleNumber(value) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+}
+
+async function fetchFugleDaily(stockNo, startISO, endISO) {
+    if (!hasFugleToken()) {
+        throw new Error('未設定 FUGLE_API_TOKEN');
+    }
+    const baseUrl = resolveFugleBaseUrl();
+    const url = new URL(`${baseUrl}/${encodeURIComponent(stockNo)}`);
+    if (startISO) url.searchParams.set('from', startISO);
+    if (endISO) url.searchParams.set('to', endISO);
+    url.searchParams.set('apiToken', process.env.FUGLE_API_TOKEN.trim());
+
+    console.log(`[TWSE Proxy v11.0] 呼叫 Fugle: ${url.toString()}`);
+    const response = await fetch(url.toString(), { headers: { Accept: 'application/json' }, timeout: 15000 });
+    const rawText = await response.text();
+    let payload = null;
+    try {
+        payload = rawText ? JSON.parse(rawText) : null;
+    } catch (error) {
+        console.warn('[TWSE Proxy v11.0] Fugle 回傳非 JSON 內容，保留原始訊息以供除錯。', error);
+    }
+
+    if (!response.ok) {
+        const message = payload?.error || payload?.message || payload?.msg || `Fugle HTTP ${response.status}`;
+        throw new Error(message);
+    }
+
+    const { rows, stockName } = normaliseFugleDataset(payload);
+    if (!Array.isArray(rows) || rows.length === 0) {
+        throw new Error('Fugle 無回傳任何日線資料');
+    }
+    return { rows, stockName };
+}
+
+async function persistFugleEntries(store, stockNo, startISO, endISO, options = {}) {
+    const { rows, stockName } = await fetchFugleDaily(stockNo, startISO, endISO);
+    const monthlyBuckets = new Map();
+    let previousClose = null;
+    const resolvedName = (stockName || '').trim();
+
+    for (const item of rows) {
+        const isoDate = (item?.date || '').toString().slice(0, 10);
+        if (!isoDate) continue;
+        if (startISO && isoDate < startISO) continue;
+        if (endISO && isoDate > endISO) continue;
+        const rocDate = isoToRoc(isoDate);
+        if (!rocDate) continue;
+        const open = normaliseFugleNumber(item?.open);
+        const high = normaliseFugleNumber(item?.high);
+        const low = normaliseFugleNumber(item?.low);
+        const closeValue = normaliseFugleNumber(item?.close);
+        const volumeValue = normaliseFugleNumber(item?.volume);
+        const changeValue = normaliseFugleNumber(item?.change);
+        const finalClose = closeValue ?? open ?? high ?? low ?? previousClose;
+        if (!Number.isFinite(finalClose)) {
+            continue;
+        }
+        const finalOpen = safeRound(open ?? finalClose);
+        const finalHigh = safeRound(high ?? Math.max(finalOpen ?? finalClose, finalClose));
+        const finalLow = safeRound(low ?? Math.min(finalOpen ?? finalClose, finalClose));
+        const finalCloseRounded = safeRound(finalClose);
+        const finalChange = Number.isFinite(changeValue)
+            ? safeRound(changeValue)
+            : previousClose !== null && Number.isFinite(previousClose)
+                ? safeRound(finalClose - previousClose)
+                : 0;
+        previousClose = Number.isFinite(finalClose) ? finalClose : previousClose;
+        const volume = Number.isFinite(volumeValue) ? Math.round(volumeValue) : 0;
+        const monthKey = isoDate.slice(0, 7).replace('-', '');
+        if (!monthlyBuckets.has(monthKey)) monthlyBuckets.set(monthKey, []);
+        monthlyBuckets.get(monthKey).push([
+            rocDate,
+            stockNo,
+            resolvedName || item?.stockName || stockNo,
+            finalOpen,
+            finalHigh,
+            finalLow,
+            finalCloseRounded,
+            finalChange ?? 0,
+            volume,
+        ]);
+    }
+
+    const label = options.forced ? FUGLE_FORCED_LABEL : FUGLE_PRIMARY_LABEL;
+    for (const [monthKey, entries] of monthlyBuckets.entries()) {
+        if (!Array.isArray(entries) || entries.length === 0) continue;
+        entries.sort((a, b) => new Date(rocToISO(a[0])) - new Date(rocToISO(b[0])));
+        await writeCache(store, buildMonthCacheKey(stockNo, monthKey, false), {
+            stockName: resolvedName || stockNo,
+            aaData: entries,
+            dataSource: label,
+        });
+    }
+
+    if (monthlyBuckets.size === 0) {
+        throw new Error('Fugle 無對應區間資料');
+    }
+
+    return label;
 }
 
 async function fetchTwseMonth(stockNo, monthKey) {
@@ -589,7 +733,7 @@ function summariseSources(flags) {
         const isProxy = item.type === 'Proxy 快取';
         return !isLocal && (!item.type || isProxy) && !isBlob;
     });
-    const fallbackDescriptor = parseSourceLabelDescriptor('TWSE (主來源)');
+    const fallbackDescriptor = parseSourceLabelDescriptor(FUGLE_PRIMARY_LABEL);
     const combined = parsed.slice();
     if (!hasRemote && fallbackDescriptor) {
         combined.push(fallbackDescriptor);
@@ -605,8 +749,8 @@ function validateForceSource(adjusted, forceSource) {
         if (normalized === 'yahoo') return normalized;
         throw new Error('還原模式目前僅支援 Yahoo Finance 測試來源');
     }
-    if (normalized === 'twse' || normalized === 'finmind') return normalized;
-    throw new Error('原始模式僅支援 TWSE 或 FinMind 測試來源');
+    if (normalized === 'twse' || normalized === 'finmind' || normalized === 'fugle') return normalized;
+    throw new Error('原始模式僅支援 Fugle、TWSE 或 FinMind 測試來源');
 }
 
 export default async (req) => {
@@ -651,12 +795,15 @@ export default async (req) => {
             return new Response(JSON.stringify({ error: '日期範圍無效' }), { status: 400 });
         }
 
+        const startISO = formatISODateFromDate(startDate);
+        const endISO = formatISODateFromDate(endDate);
+
         const months = ensureMonthList(startDate, endDate);
-        console.log('[TWSE Proxy v10.6] 月份分段', {
+        console.log('[TWSE Proxy v11.0] 月份分段', {
             stockNo,
             segmentCount: months.length,
-            startISO: formatISODateFromDate(startDate),
-            endISO: formatISODateFromDate(endDate),
+            startISO,
+            endISO,
         });
         if (months.length === 0) {
             return new Response(JSON.stringify({ stockName: stockNo, iTotalRecords: 0, aaData: [], dataSource: 'TWSE' }), {
@@ -679,6 +826,8 @@ export default async (req) => {
         let yahooLabel = '';
         let finmindHydrated = false;
         let finmindLabel = '';
+        let fugleHydrated = false;
+        let fugleLabel = '';
 
         for (const month of months) {
             const cacheKey = buildMonthCacheKey(stockNo, month, adjusted);
@@ -705,8 +854,8 @@ export default async (req) => {
                             store,
                             stockNo,
                             adjusted,
-                            startDate.toISOString().split('T')[0],
-                            endDate.toISOString().split('T')[0],
+                            startISO,
+                            endISO,
                         );
                         payload = await readCache(store, cacheKey);
                         if (payload) sourceFlags.add(finmindLabel);
@@ -714,6 +863,25 @@ export default async (req) => {
                     } catch (error) {
                         console.error('[TWSE Proxy v10.2] 強制 FinMind 失敗:', error);
                         return new Response(JSON.stringify({ error: `FinMind 來源取得失敗: ${error.message}` }), { status: 502 });
+                    }
+                } else if (forcedSource === 'fugle') {
+                    try {
+                        fugleLabel = await persistFugleEntries(
+                            store,
+                            stockNo,
+                            startISO,
+                            endISO,
+                            { forced: true },
+                        );
+                        payload = await readCache(store, cacheKey);
+                        if (payload) sourceFlags.add(fugleLabel);
+                        fugleHydrated = true;
+                    } catch (error) {
+                        console.error('[TWSE Proxy v11.0] 強制 Fugle 失敗:', error);
+                        return new Response(
+                            JSON.stringify({ error: `Fugle 來源取得失敗: ${error.message}` }),
+                            { status: 502 },
+                        );
                     }
                 } else if (forcedSource === 'yahoo') {
                     try {
@@ -758,43 +926,81 @@ export default async (req) => {
                             else if (yahooLabel) sourceFlags.add(yahooLabel);
                         }
                     } else {
-                        try {
-                            const fresh = await fetchTwseMonth(stockNo, month);
-                            await writeCache(store, cacheKey, { stockName: fresh.stockName, aaData: fresh.aaData, dataSource: 'TWSE' });
-                            payload = await readCache(store, cacheKey);
-                            sourceFlags.add('TWSE');
-                        } catch (error) {
-                            console.warn(`[TWSE Proxy v10.2] TWSE 主來源失敗 (${month}):`, error.message);
-                            if (!finmindHydrated) {
+                        if (!fugleHydrated) {
+                            if (hasFugleToken()) {
                                 try {
-                                    finmindLabel = await hydrateFinMindDaily(
+                                    fugleLabel = await persistFugleEntries(
                                         store,
                                         stockNo,
-                                        false,
-                                        startDate.toISOString().split('T')[0],
-                                        endDate.toISOString().split('T')[0],
+                                        startISO,
+                                        endISO,
                                     );
-                                } catch (finmindError) {
-                                    console.error('[TWSE Proxy v10.2] FinMind 備援失敗:', finmindError);
-                                    return new Response(
-                                        JSON.stringify({ error: `FinMind 備援來源取得失敗: ${finmindError.message}` }),
-                                        { status: 502 },
-                                    );
+                                } catch (error) {
+                                    console.warn(`[TWSE Proxy v11.0] Fugle 主來源失敗 (${month}):`, error.message || error);
+                                    fugleLabel = '';
                                 }
-                                finmindHydrated = true;
                             }
+                            fugleHydrated = true;
                             payload = await readCache(store, cacheKey);
-                            if (payload && finmindLabel) sourceFlags.add(finmindLabel);
+                            if (payload && fugleLabel) {
+                                sourceFlags.add(fugleLabel);
+                            }
+                        }
+                        if (!payload) {
+                            try {
+                                const fresh = await fetchTwseMonth(stockNo, month);
+                                await writeCache(store, cacheKey, { stockName: fresh.stockName, aaData: fresh.aaData, dataSource: 'TWSE' });
+                                payload = await readCache(store, cacheKey);
+                                sourceFlags.add('TWSE');
+                            } catch (error) {
+                                console.warn(`[TWSE Proxy v10.2] TWSE 主來源失敗 (${month}):`, error.message);
+                                if (!finmindHydrated) {
+                                    try {
+                                        finmindLabel = await hydrateFinMindDaily(
+                                            store,
+                                            stockNo,
+                                            false,
+                                            startISO,
+                                            endISO,
+                                        );
+                                    } catch (finmindError) {
+                                        console.error('[TWSE Proxy v10.2] FinMind 備援失敗:', finmindError);
+                                        return new Response(
+                                            JSON.stringify({ error: `FinMind 備援來源取得失敗: ${finmindError.message}` }),
+                                            { status: 502 },
+                                        );
+                                    }
+                                    finmindHydrated = true;
+                                }
+                                payload = await readCache(store, cacheKey);
+                                if (payload && finmindLabel) sourceFlags.add(finmindLabel);
+                            }
                         }
                     }
+                }
+            }
                 } else {
+                    const dataSourceLabel = typeof payload.dataSource === 'string' ? payload.dataSource : '';
+                    const lowerLabel = dataSourceLabel.toLowerCase();
                     if (payload.source === 'blob') {
-                        sourceFlags.add('TWSE (快取)');
+                        if (lowerLabel.includes('fugle')) {
+                            sourceFlags.add(FUGLE_CACHE_LABEL);
+                        } else if (lowerLabel.includes('finmind')) {
+                            sourceFlags.add('FinMind (快取)');
+                        } else {
+                            sourceFlags.add('TWSE (快取)');
+                        }
                     } else if (payload.source === 'memory') {
-                        sourceFlags.add('TWSE (記憶體快取)');
+                        if (lowerLabel.includes('fugle')) {
+                            sourceFlags.add(FUGLE_MEMORY_CACHE_LABEL);
+                        } else if (lowerLabel.includes('finmind')) {
+                            sourceFlags.add('FinMind (記憶體快取)');
+                        } else {
+                            sourceFlags.add('TWSE (記憶體快取)');
+                        }
                     }
-                    if (payload.dataSource) {
-                        sourceFlags.add(payload.dataSource);
+                    if (dataSourceLabel) {
+                        sourceFlags.add(dataSourceLabel);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- promote Fugle to the primary data source in the TWSE/TPEX Netlify functions and adjust fallback/cache labelling
- enrich the Taiwan directory function with FinMind index listings for index symbol lookups
- refresh the frontend data-source tester copy and controls to reflect the new Fugle default and index support

## Testing
- node - <<'NODE' const fs = require('fs'); const vm = require('vm'); ['js/backtest.js','js/main.js','js/worker.js'].forEach((file)=>{ const code = fs.readFileSync(file,'utf8'); new vm.Script(code,{filename:file}); }); console.log('scripts compile'); NODE

------
https://chatgpt.com/codex/tasks/task_e_68dc9d51db748324948dc8ae5f1883bc