### PR TITLE
feat: switch taiwan sources to fugle and add index lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,7 +606,7 @@
                                     </div>
                                     <div class="card-content space-y-4">
                                         <div>
-                                            <label for="stockNo" class="block text-xs font-medium text-foreground mb-1" style="color: var(--foreground);">台灣/美國股票代碼 (目前無提供指數)</label>
+                                            <label for="stockNo" class="block text-xs font-medium text-foreground mb-1" style="color: var(--foreground);">台灣/美國股票或指數代碼</label>
                                             <div class="flex flex-wrap items-center gap-2">
                                                 <div class="flex-1 min-w-[160px] sm:min-w-[200px]">
                                                     <input
@@ -627,6 +627,7 @@
                                                     >
                                                         <option value="TWSE">上市</option>
                                                         <option value="TPEX">上櫃</option>
+                                                        <option value="INDEX">指數</option>
                                                         <option value="US">美股</option>
                                                     </select>
                                                 </div>

--- a/js/main.js
+++ b/js/main.js
@@ -778,6 +778,7 @@ function getCurrentMarketFromUI() {
 function getMarketLabel(market) {
     if (market === 'TPEX') return '上櫃 (TPEX)';
     if (market === 'US') return '美股 (US)';
+    if (market === 'INDEX') return '台股指數';
     return '上市 (TWSE)';
 }
 
@@ -876,13 +877,15 @@ function getTesterSourceConfigs(market, adjusted, splitEnabled) {
     }
     if (market === 'TPEX') {
         return [
-            { id: 'finmind', label: 'FinMind 主來源', description: '預設資料來源' },
+            { id: 'fugle', label: 'Fugle 主來源', description: '預設資料來源' },
+            { id: 'finmind', label: 'FinMind 備援', description: 'Fugle 失效時啟用' },
             { id: 'yahoo', label: 'Yahoo 備援', description: 'FinMind 失效時啟用' },
         ];
     }
     return [
-        { id: 'twse', label: 'TWSE 主來源', description: '預設資料來源' },
-        { id: 'finmind', label: 'FinMind 備援', description: 'TWSE 失效時啟用' },
+        { id: 'fugle', label: 'Fugle 主來源', description: '預設資料來源' },
+        { id: 'twse', label: 'TWSE 官網', description: 'Fugle 失效時啟用' },
+        { id: 'finmind', label: 'FinMind 備援', description: '官網失效時啟用' },
     ];
 }
 
@@ -1489,9 +1492,9 @@ function refreshDataSourceTester() {
     } else if (market === 'US') {
         messageLines.push('FinMind 為主來源，Yahoo Finance 為備援來源。建議兩者都測試一次並確認 FINMIND_TOKEN 設定。');
     } else if (market === 'TPEX') {
-        messageLines.push('FinMind 為主來源，上櫃備援由 Yahoo 提供。建議主備來源都測試一次。');
+        messageLines.push('Fugle 為主來源，上櫃備援依序為 FinMind 與 Yahoo。建議主備來源都測試一次。');
     } else {
-        messageLines.push('TWSE 為主來源，FinMind 為備援來源。建議主備來源都測試一次。');
+        messageLines.push('Fugle 為主來源，TWSE 官網與 FinMind 為備援來源。建議主備來源都測試一次。');
     }
 
     if (!missingInputs && (market === 'TWSE' || market === 'TPEX')) {

--- a/js/worker.js
+++ b/js/worker.js
@@ -299,15 +299,17 @@ function getPrimaryForceSource(marketKey, adjusted) {
     if (marketKey === "US") return null;
     return "yahoo";
   }
-  if (marketKey === "TPEX" || marketKey === "US") return "finmind";
-  if (marketKey === "TWSE") return "twse";
+  if (marketKey === "US") return "finmind";
+  if (marketKey === "TPEX") return "fugle";
+  if (marketKey === "TWSE" || marketKey === "INDEX") return "fugle";
   return null;
 }
 
 function getFallbackForceSource(marketKey, adjusted) {
   if (adjusted) return null;
-  if (marketKey === "TPEX" || marketKey === "US") return null;
-  return "finmind";
+  if (marketKey === "US") return null;
+  if (marketKey === "TPEX" || marketKey === "TWSE" || marketKey === "INDEX") return "finmind";
+  return null;
 }
 
 function getMarketKey(marketType) {

--- a/log.md
+++ b/log.md
@@ -1,3 +1,12 @@
+## 2025-07-05 — Patch LB-FUGLE-PRIMARY-20250705A
+- **Scope**: 將台股上市、上櫃資料管線改以 Fugle 為主來源並支援指數代碼查詢。
+- **Highlights**:
+  - TWSE/TPEX Netlify 函式新增 Fugle API 解析，保留 TWSE/FinMind/Yahoo 備援並更新資料來源摘要。
+  - Worker 強制來源順序改為優先 Fugle，前端資料來源測試器新增 Fugle 按鈕與說明。
+  - 台股清單快取併入 FinMind 指數資訊，名稱查詢支援台股指數並於 UI 加入指數市場選項。
+  - README 更新 Netlify 環境變數指引，新增 `FUGLE_API_TOKEN` 與指數查詢行為說明。
+- **Testing**: 待瀏覽器回測驗證（本地無前端環境）。
+
 ## 2025-09-22 — Patch LB-AI-LSTM-20250922A
 - **Scope**: AI 預測分頁資金控管、收益呈現與種子管理強化。
 - **Features**:

--- a/netlify/functions/shared/fugle-client.js
+++ b/netlify/functions/shared/fugle-client.js
@@ -1,0 +1,138 @@
+// shared Fugle client (LB-FUGLE-PRIMARY-20250705A)
+import fetch from 'node-fetch';
+
+const FUGLE_CANDLES_ENDPOINT = 'https://api.fugle.tw/marketdata/v1.0/stock/candles';
+
+function resolveFugleToken() {
+    return (
+        process.env.FUGLE_API_TOKEN ||
+        process.env.FUGLE_APIKEY ||
+        process.env.FUGLE_API_KEY ||
+        process.env.FUGLE_TOKEN ||
+        null
+    );
+}
+
+function normaliseDateInput(value) {
+    if (!value) return null;
+    const trimmed = value.trim();
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed;
+    if (/^\d{8}$/.test(trimmed)) {
+        return `${trimmed.slice(0, 4)}-${trimmed.slice(4, 6)}-${trimmed.slice(6)}`;
+    }
+    return null;
+}
+
+export async function requestFugleDailyCandles(stockNo, options = {}) {
+    if (!stockNo) {
+        throw new Error('缺少 Fugle 查詢代號');
+    }
+    const token = resolveFugleToken();
+    if (!token) {
+        throw new Error('未設定 Fugle API Token');
+    }
+
+    const startISO = normaliseDateInput(options.startDate || options.startISO || options.from);
+    const endISO = normaliseDateInput(options.endDate || options.endISO || options.to);
+
+    const url = new URL(FUGLE_CANDLES_ENDPOINT);
+    url.searchParams.set('symbolId', stockNo);
+    url.searchParams.set('apiToken', token);
+    url.searchParams.set('klineType', 'day');
+    if (startISO) url.searchParams.set('from', startISO);
+    if (endISO) url.searchParams.set('to', endISO);
+
+    const requestInit = {
+        headers: { Accept: 'application/json' },
+        timeout: options.timeoutMs || 15000,
+    };
+
+    const response = await fetch(url.toString(), requestInit);
+    const rawText = await response.text();
+    let payload = null;
+    try {
+        payload = rawText ? JSON.parse(rawText) : null;
+    } catch (error) {
+        throw new Error('Fugle 回傳非 JSON 內容');
+    }
+
+    if (!response.ok || payload?.error) {
+        const message =
+            payload?.error || payload?.message || payload?.msg || `Fugle HTTP ${response.status}`;
+        const error = new Error(message);
+        error.status = response.status;
+        throw error;
+    }
+
+    const dataBlock = payload?.data && typeof payload.data === 'object' ? payload.data : {};
+    const candles = Array.isArray(dataBlock?.candles)
+        ? dataBlock.candles
+        : Array.isArray(payload?.data)
+            ? payload.data
+            : [];
+    const infoBlock = dataBlock?.info || dataBlock?.meta || dataBlock || {};
+    const stockName =
+        infoBlock?.name ||
+        infoBlock?.symbolName ||
+        infoBlock?.symbolNameZh ||
+        infoBlock?.symbolNameEn ||
+        infoBlock?.securityName ||
+        payload?.data?.stockName ||
+        stockNo;
+
+    return {
+        stockName,
+        candles,
+        raw: payload,
+    };
+}
+
+export function extractFugleCandleDate(candle) {
+    if (!candle || typeof candle !== 'object') return null;
+    const dateField =
+        candle.date ||
+        candle.Date ||
+        candle.time ||
+        candle.timestamp ||
+        candle.tradeDate ||
+        null;
+    if (!dateField) return null;
+    if (typeof dateField === 'number' && Number.isFinite(dateField)) {
+        const date = new Date(dateField * (dateField > 1e12 ? 1 : 1000));
+        if (Number.isNaN(date.getTime())) return null;
+        return date.toISOString().split('T')[0];
+    }
+    const text = String(dateField).trim();
+    if (/^\d{4}-\d{2}-\d{2}$/.test(text)) return text;
+    if (/^\d{8}$/.test(text)) {
+        return `${text.slice(0, 4)}-${text.slice(4, 6)}-${text.slice(6)}`;
+    }
+    if (/^\d{4}\/\d{2}\/\d{2}$/.test(text)) {
+        return text.replace(/\//g, '-');
+    }
+    return null;
+}
+
+export function normaliseFugleCandle(candle) {
+    if (!candle || typeof candle !== 'object') return null;
+    const open = Number(candle.open ?? candle.Open ?? candle.openPrice ?? candle.open_price);
+    const high = Number(candle.high ?? candle.High ?? candle.highPrice ?? candle.high_price);
+    const low = Number(candle.low ?? candle.Low ?? candle.lowPrice ?? candle.low_price);
+    const close = Number(candle.close ?? candle.Close ?? candle.closePrice ?? candle.close_price);
+    const volume = Number(
+        candle.volume ??
+        candle.Volume ??
+        candle.tradeVolume ??
+        candle.TradeVolume ??
+        candle.volumeK ??
+        candle.accTradeVolume ??
+        0,
+    );
+    return {
+        open: Number.isFinite(open) ? open : null,
+        high: Number.isFinite(high) ? high : null,
+        low: Number.isFinite(low) ? low : null,
+        close: Number.isFinite(close) ? close : null,
+        volume: Number.isFinite(volume) ? volume : 0,
+    };
+}


### PR DESCRIPTION
## Summary
- integrate a shared Fugle client and promote it as the primary data source for TWSE/TPEX proxies with updated worker source ordering
- extend the Taiwan directory Netlify function and front-end lookup cache to include FinMind index data and index-specific fetchers
- refresh the UI tester, market selector, and copy to surface Fugle/Yahoo fallback options and support index tickers

## Testing
- not run (requires browser backtest environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc9d51db748324948dc8ae5f1883bc