### PR TITLE
feat: prioritize Fugle data and index lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,7 +606,7 @@
                                     </div>
                                     <div class="card-content space-y-4">
                                         <div>
-                                            <label for="stockNo" class="block text-xs font-medium text-foreground mb-1" style="color: var(--foreground);">台灣/美國股票代碼 (目前無提供指數)</label>
+                                            <label for="stockNo" class="block text-xs font-medium text-foreground mb-1" style="color: var(--foreground);">台灣/美國股票或指數代碼</label>
                                             <div class="flex flex-wrap items-center gap-2">
                                                 <div class="flex-1 min-w-[160px] sm:min-w-[200px]">
                                                     <input

--- a/js/main.js
+++ b/js/main.js
@@ -857,8 +857,8 @@ function getDateRangeFromUI() {
 function getTesterSourceConfigs(market, adjusted, splitEnabled) {
     if (adjusted) {
         const netlifyDescription = splitEnabled
-            ? 'TWSE/FinMind 原始 + FinMind 配息 + 股票拆分'
-            : 'TWSE/FinMind 原始 + FinMind 配息';
+            ? 'Fugle/TWSE 原始 + FinMind 配息 + 股票拆分'
+            : 'Fugle/TWSE 原始 + FinMind 配息';
         return [
             { id: 'yahoo', label: 'Yahoo 還原價', description: '主來源 (還原股價)' },
             {
@@ -876,13 +876,15 @@ function getTesterSourceConfigs(market, adjusted, splitEnabled) {
     }
     if (market === 'TPEX') {
         return [
-            { id: 'finmind', label: 'FinMind 主來源', description: '預設資料來源' },
-            { id: 'yahoo', label: 'Yahoo 備援', description: 'FinMind 失效時啟用' },
+            { id: 'fugle', label: 'Fugle 主來源', description: '預設資料來源' },
+            { id: 'finmind', label: 'FinMind 備援', description: 'Fugle 失效時啟用' },
+            { id: 'yahoo', label: 'Yahoo 備援', description: 'FinMind 亦失效時測試' },
         ];
     }
     return [
-        { id: 'twse', label: 'TWSE 主來源', description: '預設資料來源' },
-        { id: 'finmind', label: 'FinMind 備援', description: 'TWSE 失效時啟用' },
+        { id: 'fugle', label: 'Fugle 主來源', description: '預設資料來源' },
+        { id: 'twse', label: 'TWSE 備援', description: 'Fugle 失效時啟用' },
+        { id: 'finmind', label: 'FinMind 備援', description: 'TWSE 亦失效時測試' },
     ];
 }
 
@@ -1483,15 +1485,15 @@ function refreshDataSourceTester() {
     } else if (adjusted) {
         messageLines.push(
             splitEnabled
-                ? '還原股價以 Yahoo Finance 為主來源，Netlify 會結合 TWSE/FinMind 原始行情、FinMind 配息與股票拆分資訊。'
-                : '還原股價以 Yahoo Finance 為主來源，Netlify 會結合 TWSE/FinMind 原始行情與 FinMind 配息做備援。',
+                ? '還原股價以 Yahoo Finance 為主來源，Netlify 會結合 Fugle/TWSE 原始行情、FinMind 配息與股票拆分資訊。'
+                : '還原股價以 Yahoo Finance 為主來源，Netlify 會結合 Fugle/TWSE 原始行情與 FinMind 配息做備援。',
         );
     } else if (market === 'US') {
         messageLines.push('FinMind 為主來源，Yahoo Finance 為備援來源。建議兩者都測試一次並確認 FINMIND_TOKEN 設定。');
     } else if (market === 'TPEX') {
-        messageLines.push('FinMind 為主來源，上櫃備援由 Yahoo 提供。建議主備來源都測試一次。');
+        messageLines.push('Fugle 為主來源，上櫃備援依序為 FinMind 與 Yahoo。建議主備來源都測試一次。');
     } else {
-        messageLines.push('TWSE 為主來源，FinMind 為備援來源。建議主備來源都測試一次。');
+        messageLines.push('Fugle 為主來源，TWSE 為備援來源。建議主備來源都測試一次。');
     }
 
     if (!missingInputs && (market === 'TWSE' || market === 'TPEX')) {

--- a/js/worker.js
+++ b/js/worker.js
@@ -843,15 +843,16 @@ function getPrimaryForceSource(marketKey, adjusted) {
     if (marketKey === "US") return null;
     return "yahoo";
   }
-  if (marketKey === "TPEX" || marketKey === "US") return "finmind";
-  if (marketKey === "TWSE") return "twse";
+  if (marketKey === "US") return "finmind";
+  if (marketKey === "TWSE" || marketKey === "TPEX") return "fugle";
   return null;
 }
 
 function getFallbackForceSource(marketKey, adjusted) {
   if (adjusted) return null;
-  if (marketKey === "TPEX" || marketKey === "US") return null;
-  return "finmind";
+  if (marketKey === "TWSE") return "twse";
+  if (marketKey === "TPEX") return "finmind";
+  return null;
 }
 
 function getMarketKey(marketType) {
@@ -2785,11 +2786,9 @@ function summariseDataSourceFlags(flags, defaultLabel, options = {}) {
     options.fallbackRemote ||
     (options.adjusted
       ? 'Yahoo Finance (還原)'
-      : options.market === 'TPEX'
+      : options.market === 'US'
         ? 'FinMind (主來源)'
-        : options.market === 'US'
-          ? 'FinMind (主來源)'
-          : defaultLabel || 'TWSE (主來源)');
+        : defaultLabel || 'Fugle (主來源)');
 
   const fallbackDescriptor = parseSourceLabelDescriptor(fallbackLabel);
   const combined = parsed.slice();
@@ -2909,7 +2908,7 @@ function tryResolveRangeFromYearSuperset({
     "Netlify 年度快取 (Worker Superset)",
   ]);
   const defaultRemoteLabel =
-    marketKey === "TPEX" ? "FinMind (主來源)" : "TWSE (主來源)";
+    marketKey === "US" ? "FinMind (主來源)" : "Fugle (主來源)";
   const dataSourceLabel = summariseDataSourceFlags(
     dataSourceFlags,
     defaultRemoteLabel,
@@ -3455,7 +3454,7 @@ async function tryFetchRangeFromBlob({
   dataSourceFlags.add(blobSourceLabel);
 
   const defaultRemoteLabel =
-    marketKey === "TPEX" ? "FinMind (主來源)" : "TWSE (主來源)";
+    marketKey === "US" ? "FinMind (主來源)" : "Fugle (主來源)";
 
   const dataSourceLabel = summariseDataSourceFlags(dataSourceFlags, defaultRemoteLabel, {
     market: marketKey,
@@ -4367,17 +4366,11 @@ async function fetchStockData(
 
   self.postMessage({ type: "progress", progress: 55, message: "整理數據..." });
   const deduped = dedupeAndSortData(normalizedRows);
-  const defaultRemoteLabel = isTpex
-    ? adjusted
-      ? "Yahoo Finance (還原)"
-      : "FinMind (主來源)"
+  const defaultRemoteLabel = adjusted
+    ? "Yahoo Finance (還原)"
     : isUs
-      ? adjusted
-        ? "Yahoo Finance (還原)"
-        : "FinMind (主來源)"
-      : adjusted
-        ? "Yahoo Finance (還原)"
-        : "TWSE (主來源)";
+      ? "FinMind (主來源)"
+      : "Fugle (主來源)";
   const dataSourceLabel = summariseDataSourceFlags(
     sourceFlags,
     defaultRemoteLabel,

--- a/log.md
+++ b/log.md
@@ -1,3 +1,11 @@
+## 2025-09-30 — Patch LB-DATAPIPE-FUGLE-20250930A / LB-INDEX-SEARCH-20250930A
+- **Scope**: 台股行情來源升級、指數代碼支援。
+- **Features**:
+  - 將上市/上櫃主來源改為 Fugle API，背景代理、年區間快取與 Worker 皆先嘗試 Fugle，再視情況回退 TWSE 或 FinMind。
+  - 資料來源測試、診斷訊息、提示文案同步改為展示 Fugle 主來源與新的備援順序。
+  - 台股清單新增 FinMind 指數資訊，前端查詢可取得台股主要指數名稱並標註 `INDEX` 類型，表單標籤更新為「股票或指數」。
+- **Testing**: 待 Netlify 實機確認 Fugle/FinMind Token 設定後再行驗證。
+
 ## 2025-09-22 — Patch LB-AI-LSTM-20250922A
 - **Scope**: AI 預測分頁資金控管、收益呈現與種子管理強化。
 - **Features**:


### PR DESCRIPTION
## Summary
- add Fugle candle integration as the primary price source across TWSE/TPEX proxies, range cache, and worker fallbacks while preserving TWSE/FinMind/Yahoo backups
- expose forceSource=fugle tester option and update UI copy to reflect the new data source order
- ingest FinMind TaiwanIndexInfo records into the Taiwan directory so index symbols can be searched alongside equities

## Testing
- not run (requires Fugle/FinMind tokens in Netlify to exercise the new data path)


------
https://chatgpt.com/codex/tasks/task_e_68dca99d1c188324a7f50142e6324da2