### PR TITLE
Add AI buy rule selector and price columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -2125,8 +2125,16 @@
                                                         </label>
                                                         <label class="flex items-center gap-2 text-xs">
                                                             <span class="min-w-[120px]">固定投入比例</span>
-                                                            <input id="ai-fixed-fraction" type="number" min="0.01" max="1" step="0.01" value="0.2" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
-                                                            <span class="text-[11px]" style="color: var(--muted-foreground);">停用凱利時使用，表示投入現金比例。</span>
+                                                            <input id="ai-fixed-fraction" type="number" min="1" max="100" step="1" value="100" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                            <span class="text-[11px]" style="color: var(--muted-foreground);">停用凱利時使用，百分比表示投入現金比例。</span>
+                                                        </label>
+                                                        <label class="flex items-center gap-2 text-xs">
+                                                            <span class="min-w-[120px]">買入規則</span>
+                                                            <select id="ai-buy-rule" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);">
+                                                                <option value="close-limit">收盤價掛單（預設）</option>
+                                                                <option value="open-market">開盤價買入</option>
+                                                            </select>
+                                                            <span class="text-[11px]" style="color: var(--muted-foreground);">切換後即時重算交易結果。</span>
                                                         </label>
                                                     </div>
                                                 </label>
@@ -2207,6 +2215,8 @@
                                                         <tr>
                                                             <th class="px-3 py-2 text-left font-semibold">交易日</th>
                                                             <th class="px-3 py-2 text-right font-semibold">預測上漲機率</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">買入價格</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">賣出價格</th>
                                                             <th class="px-3 py-2 text-right font-semibold">實際報酬%</th>
                                                             <th class="px-3 py-2 text-right font-semibold">投入比例</th>
                                                             <th class="px-3 py-2 text-right font-semibold">交易報酬%</th>
@@ -2216,6 +2226,7 @@
                                                 </table>
                                             </div>
                                             <div class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">
+                                                <p id="ai-buy-rule-description">收盤價掛單：隔日預測上漲且隔日最低價低於今日收盤，若開盤價低於今日收盤則以開盤價成交，否則以今日收盤價掛單，賣出價為隔日收盤。</p>
                                                 <p id="ai-trade-summary">尚未生成交易結果。</p>
                                                 <p id="ai-next-day-forecast" class="mt-1">尚未計算隔日預測。</p>
                                             </div>

--- a/js/worker.js
+++ b/js/worker.js
@@ -334,6 +334,21 @@ function annResolveClose(row) {
   return NaN;
 }
 
+function annResolveOpen(row, fallback) {
+  const candidates = [
+    row?.open,
+    row?.adjustedOpen,
+    row?.rawOpen,
+    row?.baseOpen,
+    row?.referenceOpen,
+  ];
+  for (let i = 0; i < candidates.length; i += 1) {
+    const value = Number(candidates[i]);
+    if (Number.isFinite(value) && value > 0) return value;
+  }
+  return Number.isFinite(fallback) && fallback > 0 ? fallback : NaN;
+}
+
 function annResolveHigh(row, fallback) {
   const value = Number(row?.high);
   if (Number.isFinite(value) && value > 0) return value;
@@ -559,9 +574,11 @@ function annPrepareDataset(rows) {
         .filter((row) => row && typeof row.date === 'string')
         .map((row) => {
           const close = annResolveClose(row);
+          const open = annResolveOpen(row, close);
           return {
             date: row.date,
             close,
+            open,
             high: annResolveHigh(row, close),
             low: annResolveLow(row, close),
           };
@@ -571,6 +588,7 @@ function annPrepareDataset(rows) {
     : [];
 
   const close = parsed.map((row) => row.close);
+  const open = parsed.map((row) => row.open);
   const high = parsed.map((row) => row.high);
   const low = parsed.map((row) => row.low);
 
@@ -627,6 +645,10 @@ function annPrepareDataset(rows) {
       tradeDate: next.date,
       buyClose: current.close,
       sellClose: next.close,
+      nextOpen: next.open,
+      nextLow: next.low,
+      nextClose: next.close,
+      nextHigh: next.high,
     });
     returns.push(change);
   }

--- a/log.md
+++ b/log.md
@@ -1,3 +1,11 @@
+## 2025-09-24 — Patch LB-AI-ENTRY-20250924A
+- **Scope**: AI 預測頁面買入規則、資金控管與交易表格調整。
+- **Features**:
+  - 新增「收盤價掛單」與「開盤價買入」兩種買入規則，可即時切換並於表格下方顯示完整邏輯說明。
+  - 交易表格補上買入價格／賣出價格欄位，並依選定規則重算實際報酬與交易報酬%。
+  - 固定投入比例改以百分比顯示並預設 100%，凱利開關與買入規則切換時會同步重算交易摘要與隔日預測。
+- **Testing**: `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/ai-prediction.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`
+
 ## 2025-09-22 — Patch LB-AI-LSTM-20250922A
 - **Scope**: AI 預測分頁資金控管、收益呈現與種子管理強化。
 - **Features**:


### PR DESCRIPTION
## Summary
- add a buy rule selector with inline description and expand the AI trade table to show entry/exit prices
- default fixed allocation to 100% with percent inputs and recompute trades under the selected buy rule
- extend ANN metadata with next-day open/low prices to support the new execution logic and record the patch in log.md

## Testing
- node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/ai-prediction.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68dd3101c1cc8324b0b88b8498fbb6db