### PR TITLE
fix: sync ANN class stats with volatility thresholds

### DIFF
--- a/index.html
+++ b/index.html
@@ -2095,42 +2095,33 @@
                                                     <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">兩種模型皆使用相同切分比例，並可於訓練時調整。</span>
                                                 </label>
                                             </div>
-                                            <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
-                                                    時間視窗（lookback，日）
-                                                    <input id="ai-lookback" type="number" min="5" max="60" step="1" value="20" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
-                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">建議 10~30 日，可捕捉月內趨勢。</span>
-                                                </label>
-                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
-                                                    訓練輪數（epochs）
-                                                    <input id="ai-epochs" type="number" min="10" max="200" step="10" value="80" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
-                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">增加輪數可提高擬合度，但須留意過擬合。</span>
-                                                </label>
-                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
-                                                    批次大小（batch size）
-                                                    <input id="ai-batch-size" type="number" min="8" max="256" step="8" value="64" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
-                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">批次需小於訓練樣本數，以保留梯度穩定性。</span>
-                                                </label>
-                                                <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
-                                                    學習率
-                                                    <input id="ai-learning-rate" type="number" min="0.0001" max="0.05" step="0.0001" value="0.005" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
-                                                    <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">根據金融序列噪音，建議 0.001~0.01。</span>
-                                                </label>
-                                                <label class="flex flex-col gap-2 text-xs font-medium md:col-span-2 xl:col-span-2" style="color: var(--foreground);">
-                                                    資金控管
-                                                    <div class="flex flex-col gap-2 p-3 border rounded-lg" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 4%, transparent);">
-                                                        <label class="inline-flex items-center gap-2 text-xs">
-                                                            <input id="ai-enable-kelly" type="checkbox" class="rounded border-border text-primary focus:ring-primary" />
-                                                            <span>啟用凱利公式估算投入比例（預設根據訓練期勝率與平均盈虧比）</span>
+                                            <details id="ai-advanced-settings" class="rounded-lg border" style="border-color: var(--border);">
+                                                <summary class="px-3 py-2 text-xs font-semibold cursor-pointer" style="color: var(--foreground);">進階訓練參數（預設收合）</summary>
+                                                <div class="px-3 pb-3 pt-1 space-y-3">
+                                                    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                                                        <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                            時間視窗（lookback，日）
+                                                            <input id="ai-lookback" type="number" min="5" max="60" step="1" value="20" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                            <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">建議 10~30 日，可捕捉月內趨勢。</span>
                                                         </label>
-                                                        <label class="flex items-center gap-2 text-xs">
-                                                            <span class="min-w-[120px]">固定投入比例</span>
-                                                            <input id="ai-fixed-fraction" type="number" min="0.01" max="1" step="0.01" value="0.2" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
-                                                            <span class="text-[11px]" style="color: var(--muted-foreground);">停用凱利時使用，表示投入現金比例。</span>
+                                                        <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                            訓練輪數（epochs）
+                                                            <input id="ai-epochs" type="number" min="10" max="200" step="10" value="80" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                            <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">增加輪數可提高擬合度，但須留意過擬合。</span>
+                                                        </label>
+                                                        <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                            批次大小（batch size）
+                                                            <input id="ai-batch-size" type="number" min="8" max="256" step="8" value="64" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                            <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">批次需小於訓練樣本數，以保留梯度穩定性。</span>
+                                                        </label>
+                                                        <label class="flex flex-col gap-1 text-xs font-medium" style="color: var(--foreground);">
+                                                            學習率
+                                                            <input id="ai-learning-rate" type="number" min="0.0001" max="0.05" step="0.0001" value="0.005" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                            <span class="text-[11px] font-normal" style="color: var(--muted-foreground);">根據金融序列噪音，建議 0.001~0.01。</span>
                                                         </label>
                                                     </div>
-                                                </label>
-                                            </div>
+                                                </div>
+                                            </details>
                                             <div class="p-3 border rounded-lg bg-background" style="border-color: var(--border);">
                                                 <div class="flex flex-wrap items-center gap-3 text-xs" style="color: var(--muted-foreground);">
                                                     <span id="ai-dataset-summary">尚未取得資料，請先完成一次主回測。</span>
@@ -2141,34 +2132,110 @@
                                                 <button id="ai-run-button" type="button" class="inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm font-semibold transition-colors" style="background-color: var(--primary); color: var(--primary-foreground);">
                                                     <i data-lucide="cpu" class="lucide-sm"></i>啟動 AI 預測
                                                 </button>
+                                                <button id="ai-run-fresh-button" type="button" class="inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm font-semibold transition-colors border" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 8%, transparent); color: var(--primary);">
+                                                    <i data-lucide="refresh-cw" class="lucide-sm"></i>新的預測
+                                                </button>
+                                                <button id="ai-save-seed" type="button" class="inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm font-semibold transition-colors border" style="border-color: var(--border); background-color: color-mix(in srgb, var(--secondary) 12%, transparent); color: var(--secondary-foreground);">
+                                                    <i data-lucide="save" class="lucide-sm"></i>儲存此次結果
+                                                </button>
+                                                <button id="ai-ann-diagnostics" type="button" class="inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm font-semibold transition-colors border opacity-60 cursor-not-allowed" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 8%, transparent); color: var(--primary);" aria-label="尚未產生 ANNS 功能測試報告" disabled>
+                                                    <i data-lucide="clipboard-list" class="lucide-sm"></i>ANNS 測試報告
+                                                </button>
                                                 <div id="ai-status" class="text-xs" style="color: var(--muted-foreground);">尚未開始</div>
                                             </div>
                                             <div class="grid gap-4 md:grid-cols-2">
-                                                <div class="flex flex-col gap-2 p-3 border rounded-lg" style="border-color: var(--border); background-color: color-mix(in srgb, var(--secondary) 6%, transparent);">
-                                                    <div class="flex items-center justify-between">
-                                                        <span class="text-xs font-medium" style="color: var(--foreground);">勝率門檻（%）</span>
-                                                        <button id="ai-optimize-threshold" type="button" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors border" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 8%, transparent); color: var(--primary);">
-                                                            <i data-lucide="gauge" class="lucide-xs"></i>一鍵最佳報酬
-                                                        </button>
+                                                <div class="flex flex-col gap-4">
+                                                    <div class="flex flex-col gap-3 p-3 border rounded-lg" style="border-color: var(--border); background-color: color-mix(in srgb, var(--secondary) 6%, transparent);">
+                                                        <div class="flex flex-col gap-2">
+                                                            <div class="flex items-center justify-between flex-wrap gap-2">
+                                                                <span class="text-xs font-medium" style="color: var(--foreground);">勝率門檻（%）</span>
+                                                                <div class="flex flex-wrap items-center gap-2">
+                                                                    <label class="flex items-center gap-2 text-[11px]" style="color: var(--muted-foreground);">
+                                                                        <span>最佳化目標</span>
+                                                                        <select id="ai-optimize-target" class="px-2 py-1 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-1 focus:ring-ring text-[11px]" style="border-color: var(--border); background-color: var(--input);">
+                                                                            <option value="median">交易報酬中位數</option>
+                                                                            <option value="single">單次平均報酬</option>
+                                                                            <option value="monthly">月平均報酬</option>
+                                                                            <option value="yearly">年平均報酬</option>
+                                                                        </select>
+                                                                    </label>
+                                                                    <label class="flex items-center gap-2 text-[11px]" style="color: var(--muted-foreground);">
+                                                                        <span>最小交易總次數</span>
+                                                                        <input id="ai-optimize-min-trades" type="number" min="0" step="1" value="1" class="w-20 px-2 py-1 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-1 focus:ring-ring text-[11px]" style="border-color: var(--border); background-color: var(--input);" />
+                                                                    </label>
+                                                                    <button id="ai-optimize-threshold" type="button" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors border" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 8%, transparent); color: var(--primary);">
+                                                                        <i data-lucide="gauge" class="lucide-xs"></i>執行門檻最佳化
+                                                                    </button>
+                                                                </div>
+                                                            </div>
+                                                            <div class="flex items-center gap-2">
+                                                                <input id="ai-win-threshold" type="number" min="0" max="100" step="1" value="0" class="w-24 px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                                <span class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">預測上漲機率需高於門檻才會進場，可在不重新訓練的情況下即時重算收益。</span>
+                                                            </div>
+                                                        </div>
                                                     </div>
-                                                    <div class="flex items-center gap-2">
-                                                        <input id="ai-win-threshold" type="number" min="50" max="100" step="1" value="60" class="w-24 px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
-                                                        <span class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">預測上漲機率需高於門檻才會進場，可在不重新訓練的情況下即時重算收益。</span>
+                                                    <div class="flex flex-col gap-2 p-3 border rounded-lg" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 4%, transparent);">
+                                                        <span class="text-xs font-medium" style="color: var(--foreground);">資金控管</span>
+                                                        <label class="inline-flex items-center gap-2 text-xs">
+                                                            <input id="ai-enable-kelly" type="checkbox" class="rounded border-border text-primary focus:ring-primary" />
+                                                            <span>啟用凱利公式估算投入比例（預設根據訓練期勝率與平均盈虧比）</span>
+                                                        </label>
+                                                        <label class="flex items-center gap-2 text-xs">
+                                                            <span class="min-w-[120px]">固定投入比例（%）</span>
+                                                            <input id="ai-fixed-fraction" type="number" min="1" max="100" step="1" value="100" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);" />
+                                                            <span class="text-[11px]" style="color: var(--muted-foreground);">停用凱利時使用，表示投入現金比例。</span>
+                                                        </label>
+                                                        <label class="flex flex-col gap-1 text-xs">
+                                                            <span class="font-medium" style="color: var(--foreground);">預測分類模式</span>
+                                                            <select id="ai-classification-mode" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);">
+                                                                <option value="binary">二分類（漲跌）</option>
+                                                                <option value="multiclass">三分類（波動分級）</option>
+                                                            </select>
+                                                        <span class="text-[11px]" style="color: var(--muted-foreground);">二分類沿用漲跌預測；三分類會依訓練集上漲樣本前 25% 與下跌樣本前 25% 的四分位自動決定門檻，下方數值僅供檢視。</span>
+                                                        </label>
+                                                        <div class="flex flex-col gap-1 text-xs">
+                                                            <span class="font-medium" style="color: var(--foreground);">AI 買入規則</span>
+                                                            <select id="ai-trade-rule" class="px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" style="border-color: var(--border); background-color: var(--input);">
+                                                                <option value="close-trigger">收盤價掛單</option>
+                                                                <option value="close-entry">收盤價買入</option>
+                                                                <option value="open-entry">開盤價買入</option>
+                                                                <option value="volatility-tier">波動分級持有</option>
+                                                            </select>
+                                                            <span class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">切換買入條件後，交易表與統計會依相同預測結果重新計算。</span>
+                                                            <div class="grid gap-2 md:grid-cols-2 mt-2">
+                                                                <label class="flex flex-col gap-1 opacity-60">
+                                                                    <span style="color: var(--muted-foreground);">大漲定義（%｜訓練集上漲樣本前 25%）</span>
+                                                                    <input id="ai-volatility-surge" type="number" min="0.1" max="50" step="0.1" value="3.00" disabled class="px-3 py-2 border border-border rounded-md bg-input text-foreground text-sm cursor-not-allowed" style="border-color: var(--border); background-color: var(--input); cursor: not-allowed;" />
+                                                                    <span class="text-[11px]" style="color: var(--muted-foreground);">固定依訓練集上漲樣本的前 25% 四分位漲幅推導。</span>
+                                                                </label>
+                                                                <label class="flex flex-col gap-1 opacity-60">
+                                                                    <span style="color: var(--muted-foreground);">大跌定義（%｜訓練集中跌幅前 25%｜負值）</span>
+                                                                    <input id="ai-volatility-drop" type="number" min="-50" max="0" step="0.1" value="-3.00" disabled class="px-3 py-2 border border-border rounded-md bg-input text-foreground text-sm cursor-not-allowed" style="border-color: var(--border); background-color: var(--input); cursor: not-allowed;" />
+                                                                    <span class="text-[11px]" style="color: var(--muted-foreground);">固定依訓練集中跌幅的前 25% 四分位跌幅推導，保持負號顯示。</span>
+                                                                </label>
+                                                            </div>
+                                                            <div id="ai-volatility-diagnostics" class="flex flex-col gap-1 mt-2 p-3 border rounded-md text-[11px]" style="border-color: color-mix(in srgb, var(--primary) 35%, transparent); background-color: color-mix(in srgb, var(--primary) 6%, transparent); color: var(--muted-foreground);">
+                                                                <span class="text-xs font-medium" style="color: var(--foreground);">訓練集波動統計</span>
+                                                                <span id="ai-volatility-sample-summary">尚未計算，請完成一次 AI 預測。</span>
+                                                                <span id="ai-volatility-surge-summary"></span>
+                                                                <span id="ai-volatility-drop-summary"></span>
+                                                            </div>
+                                                        </div>
                                                     </div>
                                                 </div>
                                                 <div class="flex flex-col gap-2 p-3 border rounded-lg" style="border-color: var(--border); background-color: color-mix(in srgb, var(--muted) 10%, transparent);">
                                                     <span class="text-xs font-medium" style="color: var(--foreground);">種子管理</span>
-                                                    <input id="ai-seed-name" type="text" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" placeholder="訓練勝率XX.X%｜測試正確率YY.Y%" style="border-color: var(--border); background-color: var(--input);" />
+                                                    <input id="ai-seed-name" type="text" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground focus:outline-none focus:ring-2 focus:ring-ring text-sm" placeholder="【ANNS】測試勝率50.0%｜交易報酬中位數5.0%｜單次平均報酬2.5%｜月平均報酬4.0%｜年平均報酬48.0%｜交易次數12" style="border-color: var(--border); background-color: var(--input);" />
                                                     <div class="flex flex-wrap gap-2">
-                                                        <button id="ai-save-seed" type="button" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors" style="background-color: var(--secondary); color: var(--secondary-foreground);">
-                                                            <i data-lucide="save" class="lucide-xs"></i>儲存種子
-                                                        </button>
                                                         <button id="ai-load-seed" type="button" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors border" style="border-color: var(--border); color: var(--foreground);">
                                                             <i data-lucide="download" class="lucide-xs"></i>載入選取種子
                                                         </button>
+                                                        <button id="ai-delete-seed" type="button" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors border" style="border-color: color-mix(in srgb, var(--destructive) 40%, transparent); color: var(--destructive);">
+                                                            <i data-lucide="trash-2" class="lucide-xs"></i>刪除選取種子
+                                                        </button>
                                                     </div>
                                                     <select id="ai-saved-seeds" multiple size="5" class="w-full px-3 py-2 border border-border rounded-md bg-input text-foreground text-xs focus:outline-none focus:ring-2 focus:ring-ring" style="border-color: var(--border); background-color: var(--input);"></select>
-                                                    <span class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">預設名稱依訓練勝率與測試正確率生成，可同時選擇多個種子載入，快速比對不同訓練結果。</span>
+                                                    <span class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">預設名稱會自動帶入模型別（【LSTM】或【ANNS】）、測試勝率、交易報酬中位數、單次／月／年平均報酬與交易次數；可同時選擇多筆種子進行載入或刪除，儲存請於上方點選「儲存此次結果」。</span>
                                                 </div>
                                             </div>
                                         </div>
@@ -2186,7 +2253,7 @@
                                                     <p id="ai-train-loss" class="text-[11px]" style="color: var(--muted-foreground);">Loss：—</p>
                                                 </div>
                                                 <div class="p-3 border rounded-lg" style="border-color: var(--border);">
-                                                    <p class="font-medium text-[13px]" style="color: var(--muted-foreground);">測試期預測正確率</p>
+                                                    <p id="ai-test-accuracy-label" class="font-medium text-[13px]" style="color: var(--muted-foreground);">測試期預測正確率</p>
                                                     <p id="ai-test-accuracy" class="text-lg font-semibold">—</p>
                                                     <p id="ai-test-loss" class="text-[11px]" style="color: var(--muted-foreground);">Loss：—</p>
                                                 </div>
@@ -2196,17 +2263,23 @@
                                                     <p id="ai-hit-rate" class="text-[11px]" style="color: var(--muted-foreground);">命中率：—</p>
                                                 </div>
                                                 <div class="p-3 border rounded-lg" style="border-color: var(--border);">
-                                                    <p class="font-medium text-[13px]" style="color: var(--muted-foreground);">AI 策略報酬評估（交易報酬% 中位數）</p>
+                                                    <p class="font-medium text-[13px]" style="color: var(--muted-foreground);">AI 策略報酬評估（中位數與平均指標）</p>
                                                     <p id="ai-total-return" class="text-lg font-semibold">—</p>
-                                                    <p id="ai-average-profit" class="text-[11px]" style="color: var(--muted-foreground);">平均報酬%・標準差</p>
+                                                    <p id="ai-average-profit" class="text-[11px]" style="color: var(--muted-foreground);">AI勝率・單次／月／年平均報酬%・買入持有年化報酬%・標準差</p>
                                                 </div>
                                             </div>
                                             <div class="overflow-x-auto">
                                                 <table class="min-w-full divide-y divide-border text-xs" style="border-color: var(--border);">
                                                     <thead class="bg-muted/40" style="background-color: color-mix(in srgb, var(--muted) 20%, transparent); color: var(--foreground);">
                                                         <tr>
-                                                            <th class="px-3 py-2 text-left font-semibold">交易日</th>
-                                                            <th class="px-3 py-2 text-right font-semibold">預測上漲機率</th>
+                                                            <th class="px-3 py-2 text-left font-semibold">買入日</th>
+                                                            <th class="px-3 py-2 text-left font-semibold">賣出日</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">預測機率／分類</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">預測漲跌幅%</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">大漲門檻%</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">大跌門檻%</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">買入價格</th>
+                                                            <th class="px-3 py-2 text-right font-semibold">賣出價格</th>
                                                             <th class="px-3 py-2 text-right font-semibold">實際報酬%</th>
                                                             <th class="px-3 py-2 text-right font-semibold">投入比例</th>
                                                             <th class="px-3 py-2 text-right font-semibold">交易報酬%</th>
@@ -2215,9 +2288,15 @@
                                                     <tbody id="ai-trade-table-body" class="divide-y divide-border" style="border-color: var(--border);"></tbody>
                                                 </table>
                                             </div>
+                                            <div class="flex justify-end mt-2">
+                                                <button id="ai-toggle-all-trades" type="button" class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-medium transition-colors border opacity-60 cursor-not-allowed" style="border-color: var(--border); background-color: color-mix(in srgb, var(--primary) 8%, transparent); color: var(--primary);" aria-pressed="false" disabled>
+                                                    顯示全部預測紀錄
+                                                </button>
+                                            </div>
                                             <div class="text-[11px] leading-relaxed" style="color: var(--muted-foreground);">
                                                 <p id="ai-trade-summary">尚未生成交易結果。</p>
                                                 <p id="ai-next-day-forecast" class="mt-1">尚未計算隔日預測。</p>
+                                                <p id="ai-trade-rules" class="mt-1">買入邏輯：隔日預測上漲且隔日最低價跌破當日收盤價時，若隔日開盤價低於當日收盤價則以開盤價成交，否則以當日收盤價成交，並於隔日收盤價出場。</p>
                                             </div>
                                         </div>
                                     </div>

--- a/js/ai-prediction.js
+++ b/js/ai-prediction.js
@@ -1,8 +1,19 @@
 /* global document, window, workerUrl */
 
-// Patch Tag: LB-AI-HYBRID-20251212A
+// Patch Tag: LB-AI-TRADE-RULE-20251229A — Triple entry rules & deterministic evaluation.
+// Patch Tag: LB-AI-TRADE-VOLATILITY-20251230A — Volatility-tier strategy & multi-class forecasts.
+// Patch Tag: LB-AI-CLASS-MODE-20251230B — Classification mode toggle & binary-compatible pipelines.
+// Patch Tag: LB-AI-VOL-QUARTILE-20251231A — Train-set quartile thresholds for volatility tiers.
+// Patch Tag: LB-AI-VOL-QUARTILE-20260102A — Lock volatility UI to quartile-derived thresholds & fix ANN seed override.
+// Patch Tag: LB-AI-VOL-QUARTILE-20260105A — Positive/negative quartile tiers & full prediction table toggle.
+// Patch Tag: LB-AI-VOL-QUARTILE-20260108A — Sign-corrected quartile display & segregated gain/loss thresholds.
+// Patch Tag: LB-AI-VOL-QUARTILE-20260110A — Train-set quartile diagnostics & UI disclosure.
+// Patch Tag: LB-AI-HYBRID-20260122A — Multiclass threshold defaults & trade gating fixes.
+// Patch Tag: LB-AI-THRESHOLD-20260124A — Binary default win threshold tuned to 50%.
+// Patch Tag: LB-AI-VOL-QUARTILE-20260128A — 三分類預測幅度欄位與 quartile 門檻同步顯示。
 (function registerLazybacktestAIPrediction() {
-    const VERSION_TAG = 'LB-AI-HYBRID-20251212A';
+    const VERSION_TAG = 'LB-AI-VOL-QUARTILE-20260128A';
+    const DEFAULT_FIXED_FRACTION = 1;
     const SEED_STORAGE_KEY = 'lazybacktest-ai-seeds-v1';
     const MODEL_TYPES = {
         LSTM: 'lstm',
@@ -13,27 +24,89 @@
         [MODEL_TYPES.ANNS]: 'ANNS 技術指標感知器',
     };
     const formatModelLabel = (modelType) => MODEL_LABELS[modelType] || 'AI 模型';
+    const CLASSIFICATION_MODES = {
+        BINARY: 'binary',
+        MULTICLASS: 'multiclass',
+    };
+    const normalizeClassificationMode = (mode) => (mode === CLASSIFICATION_MODES.BINARY
+        ? CLASSIFICATION_MODES.BINARY
+        : CLASSIFICATION_MODES.MULTICLASS);
+    const getDefaultWinThresholdForMode = (mode) => (normalizeClassificationMode(mode) === CLASSIFICATION_MODES.MULTICLASS
+        ? 0
+        : 0.5);
+    const resolveWinThreshold = (state) => {
+        if (!state) {
+            return getDefaultWinThresholdForMode();
+        }
+        const classificationMode = normalizeClassificationMode(state.classification);
+        return Number.isFinite(state.winThreshold)
+            ? state.winThreshold
+            : getDefaultWinThresholdForMode(classificationMode);
+    };
+    const DEFAULT_VOLATILITY_THRESHOLDS = { surge: 0.03, drop: 0.03 };
+    const VOLATILITY_CLASS_LABELS = ['大跌', '小幅波動', '大漲'];
+
+    const TRADE_RULE_OPTIONS = [
+        {
+            value: 'close-trigger',
+            label: '收盤價掛單',
+            description: '買入邏輯：隔日預測上漲且隔日最低價跌破當日收盤價時，若隔日開盤價低於當日收盤價則以開盤價成交，否則以當日收盤價成交，並於隔日收盤價出場。',
+        },
+        {
+            value: 'close-entry',
+            label: '收盤價買入',
+            description: '買入邏輯：預測上漲時即以當日收盤價買入，並於隔日收盤價出場。',
+        },
+        {
+            value: 'open-entry',
+            label: '開盤價買入',
+            description: '買入邏輯：隔日預測上漲時即以隔日開盤價買入，並於隔日收盤價出場。',
+        },
+        {
+            value: 'volatility-tier',
+            label: '波動分級持有',
+            description: '買賣邏輯：模型依「大漲／小幅波動／大跌」三類判斷；當預測落在大漲區間且機率達門檻時於當日收盤價進場，之後小幅波動僅持有，遇到預測大跌且機率達門檻時於當日收盤前出場（門檻固定為訓練集上漲樣本前 25% 與下跌樣本前 25% 的四分位漲跌幅）。',
+        },
+    ];
+    const DEFAULT_TRADE_RULE = TRADE_RULE_OPTIONS[0].value;
+    const TRADE_RULE_MAP = TRADE_RULE_OPTIONS.reduce((acc, option) => {
+        acc[option.value] = option;
+        return acc;
+    }, {});
+    const ANN_META_MESSAGE = 'ANN_META';
+    const ANN_META_STORAGE_KEY = 'LB_ANN_META';
+    const LSTM_META_MESSAGE = 'LSTM_META';
+    const LSTM_META_STORAGE_KEY = 'LB_LSTM_META';
     const createModelState = () => ({
         lastSummary: null,
         odds: 1,
         predictionsPayload: null,
         trainingMetrics: null,
         currentTrades: [],
+        allPredictionRows: [],
         lastSeedDefault: '',
-        winThreshold: 0.5,
+        winThreshold: 0,
         kellyEnabled: false,
-        fixedFraction: 0.2,
+        fixedFraction: DEFAULT_FIXED_FRACTION,
+        lastRunMeta: null,
+        volatilityDiagnostics: null,
+        annDiagnostics: null,
         hyperparameters: {
             lookback: 20,
             epochs: 80,
             batchSize: 64,
             learningRate: 0.005,
             trainRatio: 0.8,
+            seed: null,
         },
+        tradeRule: DEFAULT_TRADE_RULE,
+        classification: CLASSIFICATION_MODES.MULTICLASS,
+        volatilityThresholds: { ...DEFAULT_VOLATILITY_THRESHOLDS },
     });
     const globalState = {
         running: false,
-        activeModel: MODEL_TYPES.LSTM,
+        activeModel: MODEL_TYPES.ANNS,
+        showAllPredictions: false,
         models: {
             [MODEL_TYPES.LSTM]: createModelState(),
             [MODEL_TYPES.ANNS]: createModelState(),
@@ -41,11 +114,15 @@
     };
     const getModelState = (model) => {
         if (!model || !globalState.models[model]) {
-            return globalState.models[MODEL_TYPES.LSTM];
+            return globalState.models[MODEL_TYPES.ANNS];
         }
         return globalState.models[model];
     };
     const getActiveModelState = () => getModelState(globalState.activeModel);
+    const getTradeRuleForModel = (model = globalState.activeModel) => {
+        const state = getModelState(model);
+        return normalizeTradeRule(state?.tradeRule);
+    };
 
     let aiWorker = null;
     let aiWorkerSequence = 0;
@@ -55,7 +132,9 @@
         datasetSummary: null,
         status: null,
         runButton: null,
+        freshRunButton: null,
         modelType: null,
+        classificationMode: null,
         trainRatio: null,
         lookback: null,
         epochs: null,
@@ -65,6 +144,8 @@
         fixedFraction: null,
         winThreshold: null,
         optimizeThreshold: null,
+        optimizeTarget: null,
+        optimizeMinTrades: null,
         trainRatioBadge: null,
         trainAccuracy: null,
         trainLoss: null,
@@ -77,10 +158,22 @@
         tradeTableBody: null,
         tradeSummary: null,
         nextDayForecast: null,
+        toggleAllTrades: null,
         seedName: null,
         saveSeedButton: null,
         savedSeedList: null,
         loadSeedButton: null,
+        deleteSeedButton: null,
+        tradeRuleSelect: null,
+        tradeRules: null,
+        volatilitySurge: null,
+        volatilityDrop: null,
+        volatilityDiagnostics: null,
+        volatilitySampleSummary: null,
+        volatilitySurgeSummary: null,
+        volatilityDropSummary: null,
+        annDiagnosticsButton: null,
+        testAccuracyLabel: null,
     };
 
     const colorMap = {
@@ -88,6 +181,140 @@
         success: 'var(--primary)',
         warning: 'var(--secondary)',
         error: 'var(--destructive)',
+    };
+    const FRACTION_MIN_PERCENT = 1;
+    const FRACTION_MAX_PERCENT = 100;
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
+    const normalizeTradeRule = (rule) => (TRADE_RULE_MAP[rule] ? rule : DEFAULT_TRADE_RULE);
+    const getTradeRuleConfig = (rule) => TRADE_RULE_MAP[normalizeTradeRule(rule)];
+    const getTradeRuleDescription = (rule) => getTradeRuleConfig(rule).description;
+    const updateTradeRuleDescription = (rule) => {
+        if (!elements.tradeRules) return;
+        const normalized = normalizeTradeRule(rule);
+        let description = getTradeRuleDescription(normalized);
+        const state = getModelState(globalState.activeModel);
+        const classificationMode = state?.classification || CLASSIFICATION_MODES.MULTICLASS;
+        if (normalized === 'volatility-tier') {
+            if (classificationMode === CLASSIFICATION_MODES.BINARY) {
+                description = '買賣邏輯：模型採二分類判斷，當預測隔日上漲且機率達門檻時於當日收盤進場，之後持有至預測隔日下跌且機率達門檻時於當日收盤出場。';
+            } else {
+                const thresholds = sanitizeVolatilityThresholds(state?.volatilityThresholds);
+                description = `${description}（${formatVolatilityDescription(thresholds)}）`;
+            }
+        } else if (classificationMode === CLASSIFICATION_MODES.MULTICLASS) {
+            description = `${description}（需同時判定為「大漲」且機率達門檻才會進場。）`;
+        }
+        elements.tradeRules.textContent = description;
+    };
+
+    const updateClassificationUIState = (_mode = CLASSIFICATION_MODES.MULTICLASS) => {
+        const surgeLabel = elements.volatilitySurge ? elements.volatilitySurge.closest('label') : null;
+        const dropLabel = elements.volatilityDrop ? elements.volatilityDrop.closest('label') : null;
+        [elements.volatilitySurge, elements.volatilityDrop].forEach((input) => {
+            if (!input) return;
+            input.disabled = true;
+            input.setAttribute('aria-disabled', 'true');
+            input.setAttribute('title', '門檻由訓練集上漲樣本前 25% 與下跌樣本前 25% 的四分位自動決定');
+            input.classList.add('cursor-not-allowed');
+        });
+        [surgeLabel, dropLabel].forEach((label) => {
+            if (label && label.classList) {
+                label.classList.add('opacity-60');
+            }
+        });
+        updateTradeRuleDescription(getTradeRuleForModel());
+        const diagnostics = getModelState(globalState.activeModel)?.volatilityDiagnostics;
+        updateVolatilityDiagnosticsDisplay(diagnostics, _mode);
+        if (elements.winThreshold) {
+            const state = getModelState(globalState.activeModel);
+            if (state) {
+                const normalized = normalizeClassificationMode(_mode);
+                const defaultThreshold = getDefaultWinThresholdForMode(normalized);
+                if (!Number.isFinite(state.winThreshold)
+                    || (normalized === CLASSIFICATION_MODES.MULTICLASS && state.winThreshold > defaultThreshold)
+                    || (normalized === CLASSIFICATION_MODES.BINARY && state.winThreshold <= 0)) {
+                    state.winThreshold = defaultThreshold;
+                }
+                elements.winThreshold.value = String(Math.round(resolveWinThreshold(state) * 100));
+            }
+            parseWinThreshold();
+        }
+        if (elements.testAccuracyLabel) {
+            const normalized = normalizeClassificationMode(_mode);
+            elements.testAccuracyLabel.textContent = normalized === CLASSIFICATION_MODES.MULTICLASS
+                ? '大漲命中率'
+                : '測試期預測正確率';
+        }
+    };
+
+    const convertFractionToPercent = (fraction) => {
+        const sanitized = sanitizeFraction(Number.isFinite(fraction) ? fraction : DEFAULT_FIXED_FRACTION);
+        const percent = sanitized * 100;
+        if (!Number.isFinite(percent)) {
+            return FRACTION_MIN_PERCENT;
+        }
+        return Math.min(Math.max(percent, FRACTION_MIN_PERCENT), FRACTION_MAX_PERCENT);
+    };
+
+    const syncFractionInputDisplay = (fraction) => {
+        if (!elements.fixedFraction) return;
+        const percent = convertFractionToPercent(fraction);
+        const display = Number(percent.toFixed(2));
+        elements.fixedFraction.value = Number.isFinite(display)
+            ? String(display)
+            : String(convertFractionToPercent(DEFAULT_FIXED_FRACTION));
+    };
+
+    const readFractionFromInput = (fallbackFraction = DEFAULT_FIXED_FRACTION) => {
+        if (!elements.fixedFraction) return sanitizeFraction(fallbackFraction);
+        const fallbackPercent = convertFractionToPercent(fallbackFraction);
+        const percentValue = parseNumberInput(elements.fixedFraction, fallbackPercent, {
+            min: FRACTION_MIN_PERCENT,
+            max: FRACTION_MAX_PERCENT,
+        });
+        const normalized = sanitizeFraction(percentValue / 100);
+        const display = Number(percentValue.toFixed(2));
+        elements.fixedFraction.value = Number.isFinite(display)
+            ? String(display)
+            : String(fallbackPercent);
+        return normalized;
+    };
+
+    let seedSaveFeedbackTimer = null;
+
+    const formatPrice = (value, digits = 2) => {
+        if (!Number.isFinite(value)) return '—';
+        return value.toFixed(digits);
+    };
+
+    const computeNextTradingDate = (dateString) => {
+        if (typeof dateString !== 'string' || !dateString) return null;
+        const base = new Date(`${dateString}T00:00:00Z`);
+        if (Number.isNaN(base.getTime())) return null;
+        const candidate = new Date(base.getTime());
+        candidate.setUTCDate(candidate.getUTCDate() + 1);
+        let weekday = candidate.getUTCDay();
+        while (weekday === 0 || weekday === 6) {
+            candidate.setUTCDate(candidate.getUTCDate() + 1);
+            weekday = candidate.getUTCDay();
+        }
+        return candidate.toISOString().slice(0, 10);
+    };
+
+    const resolveOpenValue = (row, fallback) => {
+        const candidates = [row?.open, row?.adjustedOpen, row?.adjOpen, row?.rawOpen];
+        for (let i = 0; i < candidates.length; i += 1) {
+            const value = Number(candidates[i]);
+            if (Number.isFinite(value) && value > 0) return value;
+        }
+        return Number.isFinite(fallback) && fallback > 0 ? fallback : NaN;
+    };
+
+    const resolveLowValue = (row, fallback) => {
+        const value = Number(row?.low);
+        if (Number.isFinite(value)) return value;
+        return Number.isFinite(fallback) ? fallback : NaN;
     };
 
     const ensureBridge = () => {
@@ -128,6 +355,36 @@
         }
     };
 
+    const persistAnnMeta = (meta) => {
+        if (!meta || typeof meta !== 'object') return;
+        const modelState = globalState.models[MODEL_TYPES.ANNS];
+        if (modelState) {
+            modelState.lastRunMeta = { ...meta };
+        }
+        if (typeof window === 'undefined' || !window.localStorage) return;
+        try {
+            const payload = { ...meta, savedAt: new Date().toISOString() };
+            window.localStorage.setItem(ANN_META_STORAGE_KEY, JSON.stringify(payload));
+        } catch (error) {
+            console.warn('[AI Prediction] 無法儲存 ANN 執行資訊：', error);
+        }
+    };
+
+    const persistLstmMeta = (meta) => {
+        if (!meta || typeof meta !== 'object') return;
+        const modelState = globalState.models[MODEL_TYPES.LSTM];
+        if (modelState) {
+            modelState.lastRunMeta = { ...meta };
+        }
+        if (typeof window === 'undefined' || !window.localStorage) return;
+        try {
+            const payload = { ...meta, savedAt: new Date().toISOString() };
+            window.localStorage.setItem(LSTM_META_STORAGE_KEY, JSON.stringify(payload));
+        } catch (error) {
+            console.warn('[AI Prediction] 無法儲存 LSTM 執行資訊：', error);
+        }
+    };
+
     const escapeHTML = (value) => {
         if (typeof value !== 'string') return '';
         return value
@@ -143,9 +400,204 @@
         return `${(value * 100).toFixed(digits)}%`;
     };
 
-    const formatNumber = (value, digits = 2) => {
+    const formatNumber = (value, digits = 4) => {
         if (!Number.isFinite(value)) return '—';
-        return value.toFixed(digits);
+        return Number(value).toFixed(digits);
+    };
+
+    const formatClassDistribution = (distribution, mode = CLASSIFICATION_MODES.MULTICLASS) => {
+        if (!distribution || typeof distribution !== 'object') return '—';
+        const normalized = normalizeClassificationMode(mode);
+        if (normalized === CLASSIFICATION_MODES.BINARY) {
+            const up = Number(distribution.up) || 0;
+            const down = Number(distribution.down) || 0;
+            return `上漲：${up}｜下跌：${down}`;
+        }
+        const surge = Number(distribution.surge) || 0;
+        const flat = Number(distribution.flat) || 0;
+        const drop = Number(distribution.drop) || 0;
+        return `大漲：${surge}｜小幅波動：${flat}｜大跌：${drop}`;
+    };
+
+    const formatShape = (shape) => {
+        if (Array.isArray(shape)) {
+            return `[${shape.map((item) => (Number.isFinite(item) ? item : '∗')).join(', ')}]`;
+        }
+        if (typeof shape === 'string') return shape;
+        if (shape && typeof shape === 'object') {
+            try {
+                return JSON.stringify(shape);
+            } catch (error) {
+                return '—';
+            }
+        }
+        return '—';
+    };
+
+    const updateAnnDiagnosticsButtonState = () => {
+        if (!elements.annDiagnosticsButton) return;
+        const annState = getModelState(MODEL_TYPES.ANNS);
+        const diagnostics = annState?.annDiagnostics;
+        const hasDiagnostics = Boolean(diagnostics && Array.isArray(diagnostics.layerDiagnostics) && diagnostics.layerDiagnostics.length > 0);
+        const isAnnActive = globalState.activeModel === MODEL_TYPES.ANNS;
+        const canOpen = isAnnActive && hasDiagnostics;
+        elements.annDiagnosticsButton.disabled = !canOpen;
+        elements.annDiagnosticsButton.classList.toggle('opacity-60', !canOpen);
+        elements.annDiagnosticsButton.classList.toggle('cursor-not-allowed', !canOpen);
+        if (!isAnnActive) {
+            const label = '僅在選取 ANNS 模型時可檢視功能測試報告';
+            elements.annDiagnosticsButton.setAttribute('aria-label', label);
+            elements.annDiagnosticsButton.setAttribute('title', label);
+        } else if (hasDiagnostics) {
+            const label = '開啟 ANNS 功能測試報告';
+            elements.annDiagnosticsButton.setAttribute('aria-label', label);
+            elements.annDiagnosticsButton.setAttribute('title', label);
+        } else {
+            const label = '尚未產生 ANNS 功能測試報告';
+            elements.annDiagnosticsButton.setAttribute('aria-label', label);
+            elements.annDiagnosticsButton.setAttribute('title', label);
+        }
+    };
+
+    const buildAnnDiagnosticsHtml = (diagnostics) => {
+        const dataset = diagnostics?.dataset || {};
+        const performance = diagnostics?.performance || {};
+        const indicatorDiagnostics = Array.isArray(diagnostics?.indicatorDiagnostics) ? diagnostics.indicatorDiagnostics : [];
+        const layerDiagnostics = Array.isArray(diagnostics?.layerDiagnostics) ? diagnostics.layerDiagnostics : [];
+        const accuracyLabel = performance.accuracyLabel || '測試正確率';
+        const timestamp = Number.isFinite(diagnostics?.timestamp)
+            ? new Date(diagnostics.timestamp).toISOString()
+            : new Date().toISOString();
+        const indicatorRows = indicatorDiagnostics.length > 0
+            ? indicatorDiagnostics.map((entry) => `
+                <tr>
+                    <td>${escapeHTML(entry.name || '')}</td>
+                    <td>${Number(entry.finiteSamples || 0)} / ${Number(entry.totalSamples || 0)}</td>
+                    <td>${formatPercent(entry.coverage ?? (entry.totalSamples > 0 ? (entry.finiteSamples / entry.totalSamples) : 0), 1)}</td>
+                    <td>${formatNumber(entry.min)}</td>
+                    <td>${formatNumber(entry.max)}</td>
+                </tr>
+            `).join('')
+            : '<tr><td colspan="5">尚未取得技術指標檢查結果。</td></tr>';
+        const layerRows = layerDiagnostics.length > 0
+            ? layerDiagnostics.map((layer) => {
+                const activation = layer.activation ? escapeHTML(layer.activation) : '—';
+                const units = Number.isFinite(layer.units) ? layer.units : '—';
+                const shapeText = formatShape(layer.outputShape);
+                const hasNaN = layer.hasNaN ? '⚠️ 發現 NaN' : '✅ 通過';
+                const weightSummaries = Array.isArray(layer.weightSummaries) && layer.weightSummaries.length > 0
+                    ? layer.weightSummaries.map((item) => {
+                        const label = `W${item.index ?? 0}`;
+                        const sizeText = `尺寸 ${Number(item.size || 0)}`;
+                        const finiteText = `有效 ${Number(item.finiteCount || 0)}`;
+                        const nanText = `NaN ${Number(item.nanCount || 0)}`;
+                        const rangeText = (Number.isFinite(item.min) && Number.isFinite(item.max))
+                            ? `範圍 [${formatNumber(item.min, 4)}, ${formatNumber(item.max, 4)}]`
+                            : '範圍 [—]';
+                        return `${label}：${sizeText}｜${finiteText}｜${nanText}｜${rangeText}`;
+                    }).join('<br/>')
+                    : '無可檢測權重';
+                const className = layer.className ? escapeHTML(layer.className) : '—';
+                const name = layer.name ? escapeHTML(layer.name) : `Layer ${layer.index}`;
+                return `
+                    <tr>
+                        <td>${layer.index ?? 0}</td>
+                        <td>${name}</td>
+                        <td>${className}</td>
+                        <td>${activation}</td>
+                        <td>${units}</td>
+                        <td>${escapeHTML(shapeText)}</td>
+                        <td>${hasNaN}</td>
+                        <td>${weightSummaries}</td>
+                    </tr>
+                `;
+            }).join('')
+            : '<tr><td colspan="8">尚未產生層級診斷資訊。</td></tr>';
+
+        const positivePrecisionText = Number.isFinite(performance.positivePrecision) ? formatPercent(performance.positivePrecision, 2) : '—';
+        const positiveRecallText = Number.isFinite(performance.positiveRecall) ? formatPercent(performance.positiveRecall, 2) : '—';
+        const positiveF1Text = Number.isFinite(performance.positiveF1) ? formatPercent(performance.positiveF1, 2) : '—';
+        const positiveLabel = dataset.classificationMode === CLASSIFICATION_MODES.BINARY ? '上漲' : '大漲';
+        const html = `<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="utf-8" />
+    <title>ANNS 功能測試報告</title>
+    <style>
+        body { font-family: 'Inter', 'Noto Sans TC', sans-serif; margin: 16px; color: #1f2933; background-color: #f9fafb; }
+        h1 { font-size: 1.5rem; margin-bottom: 0.75rem; }
+        h2 { font-size: 1.125rem; margin: 1.5rem 0 0.75rem; }
+        table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.875rem; background-color: #ffffff; }
+        th, td { border: 1px solid #d1d5db; padding: 0.5rem 0.75rem; text-align: left; vertical-align: top; }
+        th { background-color: #f3f4f6; font-weight: 600; }
+        .summary { background-color: #ffffff; border: 1px solid #d1d5db; padding: 1rem; border-radius: 8px; font-size: 0.9rem; }
+        .meta { font-size: 0.8rem; color: #6b7280; margin-bottom: 1rem; }
+        .note { font-size: 0.75rem; color: #4b5563; margin: 0.25rem 0; }
+    </style>
+</head>
+<body>
+    <h1>ANNS 功能測試報告</h1>
+    <div class="meta">版本：${escapeHTML(diagnostics?.version || '—')}｜產出時間：${escapeHTML(timestamp)}</div>
+    <section class="summary">
+        <p>資料筆數：共 ${Number(dataset.usableSamples || 0)} 筆（原始 ${Number(dataset.totalParsedRows || 0)} 筆），訓練集 ${Number(dataset.trainSamples || 0)} 筆｜測試集 ${Number(dataset.testSamples || 0)} 筆。</p>
+        <p>分類模式：${dataset.classificationMode === CLASSIFICATION_MODES.BINARY ? '二分類（漲跌）' : '三分類（波動分級）'}｜樣本分佈：${formatClassDistribution(dataset.classDistribution, dataset.classificationMode)}。</p>
+        <p>${accuracyLabel}：${formatPercent(performance.testAccuracy, 2)}｜訓練期勝率：${formatPercent(performance.trainAccuracy, 2)}。</p>
+        <p>${positiveLabel} precision：${positivePrecisionText}｜${positiveLabel} recall：${positiveRecallText}｜${positiveLabel} F1：${positiveF1Text}｜正向預測次數：${Number(performance.positivePredictions || 0)}｜實際${positiveLabel}天數：${Number(performance.positiveActuals || 0)}。</p>
+        <p class="note">Precision（精確率） = TP ÷ (TP + FP) → 預測${positiveLabel}時，有多少是真的${positiveLabel}？</p>
+        <p class="note">Recall（召回率） = TP ÷ (TP + FN) → 所有真的${positiveLabel}，有多少被模型抓到？</p>
+        <p class="note">F1（調和平均） = 2 × Precision × Recall ÷ (Precision + Recall) → 精確率與召回率的綜合。</p>
+    </section>
+    <h2>技術指標覆蓋率</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>指標名稱</th>
+                <th>有效樣本 / 總樣本</th>
+                <th>覆蓋率</th>
+                <th>最小值</th>
+                <th>最大值</th>
+            </tr>
+        </thead>
+        <tbody>${indicatorRows}</tbody>
+    </table>
+    <h2>模型層級檢查</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>名稱</th>
+                <th>類型</th>
+                <th>Activation</th>
+                <th>單元數</th>
+                <th>輸出維度</th>
+                <th>NaN 檢查</th>
+                <th>權重摘要</th>
+            </tr>
+        </thead>
+        <tbody>${layerRows}</tbody>
+    </table>
+</body>
+</html>`;
+        return html;
+    };
+
+    const openAnnDiagnosticsWindow = () => {
+        const annState = getModelState(MODEL_TYPES.ANNS);
+        const diagnostics = annState?.annDiagnostics;
+        if (!diagnostics) {
+            showStatus('[ANNS 技術指標感知器] 尚未產生功能測試報告，請先完成一次訓練。', 'warning');
+            return;
+        }
+        const popup = window.open('', 'annsDiagnostics', 'width=720,height=640,scrollbars=yes,resizable=yes');
+        if (!popup) {
+            showStatus('[ANNS 技術指標感知器] 瀏覽器封鎖了彈出視窗，請允許後再試。', 'warning');
+            return;
+        }
+        const reportHtml = buildAnnDiagnosticsHtml(diagnostics);
+        popup.document.open();
+        popup.document.write(reportHtml);
+        popup.document.close();
+        popup.focus();
     };
 
     const computeMedian = (values) => {
@@ -174,8 +626,580 @@
 
     const sanitizeFraction = (value) => {
         const num = Number(value);
-        if (!Number.isFinite(num)) return 0.01;
+        if (!Number.isFinite(num)) return DEFAULT_FIXED_FRACTION;
         return Math.min(Math.max(num, 0.01), 1);
+    };
+
+    const computeQuantileValue = (values, percentile) => {
+        if (!Array.isArray(values) || values.length === 0) return NaN;
+        const sorted = [...values].sort((a, b) => a - b);
+        const clamped = Math.min(Math.max(percentile, 0), 1);
+        if (sorted.length === 1 || clamped === 0) return sorted[0];
+        if (clamped === 1) return sorted[sorted.length - 1];
+        const position = (sorted.length - 1) * clamped;
+        const lowerIndex = Math.floor(position);
+        const upperIndex = Math.min(lowerIndex + 1, sorted.length - 1);
+        const weight = position - lowerIndex;
+        const lowerValue = sorted[lowerIndex];
+        const upperValue = sorted[upperIndex];
+        if (!Number.isFinite(lowerValue)) return upperValue;
+        if (!Number.isFinite(upperValue)) return lowerValue;
+        return lowerValue + ((upperValue - lowerValue) * weight);
+    };
+
+    const sanitizeVolatilityThresholds = (input = {}) => {
+        const fallbackSurge = DEFAULT_VOLATILITY_THRESHOLDS.surge;
+        const fallbackDrop = DEFAULT_VOLATILITY_THRESHOLDS.drop;
+        const rawSurge = Number(input?.surge);
+        const rawDrop = Number(input?.drop);
+        const rawLower = Number(input?.lowerQuantile);
+        const rawUpper = Number(input?.upperQuantile);
+
+        let surge = Number.isFinite(rawSurge) && Math.abs(rawSurge) > 0 ? Math.abs(rawSurge) : NaN;
+        let drop = Number.isFinite(rawDrop) && Math.abs(rawDrop) > 0 ? Math.abs(rawDrop) : NaN;
+
+        if (!(surge > 0) && Number.isFinite(rawUpper) && Math.abs(rawUpper) > 0) {
+            surge = Math.abs(rawUpper);
+        }
+        if (!(drop > 0) && Number.isFinite(rawLower) && Math.abs(rawLower) > 0) {
+            drop = Math.abs(rawLower);
+        }
+
+        if (!(surge > 0)) {
+            surge = fallbackSurge;
+        }
+        if (!(drop > 0)) {
+            drop = fallbackDrop;
+        }
+
+        surge = Math.min(Math.max(surge, 0.0001), 0.5);
+        drop = Math.min(Math.max(drop, 0.0001), 0.5);
+
+        let lowerQuantile;
+        if (Number.isFinite(rawLower) && Math.abs(rawLower) > 0) {
+            lowerQuantile = rawLower > 0 ? -Math.abs(rawLower) : Math.max(rawLower, -0.5);
+        } else {
+            lowerQuantile = -drop;
+        }
+
+        let upperQuantile;
+        if (Number.isFinite(rawUpper) && Math.abs(rawUpper) > 0) {
+            upperQuantile = rawUpper < 0 ? Math.abs(rawUpper) : Math.min(rawUpper, 0.5);
+        } else {
+            upperQuantile = surge;
+        }
+
+        upperQuantile = Math.min(Math.max(upperQuantile, 0.0001), 0.5);
+        lowerQuantile = Math.max(Math.min(lowerQuantile, -0.0001), -0.5);
+
+        return {
+            surge,
+            drop,
+            lowerQuantile,
+            upperQuantile,
+        };
+    };
+
+    const deriveVolatilityThresholdsFromReturns = (values, fallback = DEFAULT_VOLATILITY_THRESHOLDS, diagnosticsRef = null) => {
+        const fallbackSanitized = sanitizeVolatilityThresholds(fallback);
+        if (!Array.isArray(values) || values.length === 0) {
+            return fallbackSanitized;
+        }
+        const filtered = values.filter((value) => Number.isFinite(value));
+        if (filtered.length === 0) {
+            return fallbackSanitized;
+        }
+
+        const sorted = filtered.slice().sort((a, b) => a - b);
+        const positives = sorted.filter((value) => value > 0);
+        const negatives = sorted.filter((value) => value < 0);
+        const zeroCount = filtered.length - positives.length - negatives.length;
+
+        const combinedUpperQuartile = computeQuantileValue(sorted, 0.75);
+        const combinedLowerQuartile = computeQuantileValue(sorted, 0.25);
+        const positiveOnlyQuartile = positives.length > 0 ? computeQuantileValue(positives, 0.75) : NaN;
+        const negativeOnlyQuartile = negatives.length > 0 ? computeQuantileValue(negatives, 0.25) : NaN;
+
+        let positiveSource = 'combined';
+        let negativeSource = 'combined';
+
+        let upperCandidate = Number.isFinite(combinedUpperQuartile) ? combinedUpperQuartile : NaN;
+        if (!(upperCandidate > 0)) {
+            if (Number.isFinite(positiveOnlyQuartile) && positiveOnlyQuartile > 0) {
+                upperCandidate = positiveOnlyQuartile;
+                positiveSource = 'positive-only';
+            } else {
+                const fallbackUpper = Number.isFinite(fallbackSanitized.upperQuantile) && fallbackSanitized.upperQuantile > 0
+                    ? fallbackSanitized.upperQuantile
+                    : (fallbackSanitized.surge > 0 ? fallbackSanitized.surge : NaN);
+                upperCandidate = Number.isFinite(fallbackUpper) ? fallbackUpper : NaN;
+                positiveSource = 'default';
+            }
+        }
+
+        let lowerCandidate = Number.isFinite(combinedLowerQuartile) ? combinedLowerQuartile : NaN;
+        if (!(lowerCandidate < 0)) {
+            if (Number.isFinite(negativeOnlyQuartile) && negativeOnlyQuartile < 0) {
+                lowerCandidate = negativeOnlyQuartile;
+                negativeSource = 'negative-only';
+            } else {
+                const fallbackLower = Number.isFinite(fallbackSanitized.lowerQuantile) && fallbackSanitized.lowerQuantile < 0
+                    ? fallbackSanitized.lowerQuantile
+                    : (fallbackSanitized.drop > 0 ? -fallbackSanitized.drop : NaN);
+                lowerCandidate = Number.isFinite(fallbackLower) ? fallbackLower : NaN;
+                negativeSource = 'default';
+            }
+        }
+
+        const sanitized = sanitizeVolatilityThresholds({
+            surge: upperCandidate,
+            drop: Math.abs(lowerCandidate),
+            lowerQuantile: lowerCandidate,
+            upperQuantile: upperCandidate,
+        });
+
+        if (diagnosticsRef && typeof diagnosticsRef === 'object') {
+            const positiveThreshold = Number.isFinite(sanitized.upperQuantile)
+                ? sanitized.upperQuantile
+                : (Number.isFinite(sanitized.surge) ? sanitized.surge : NaN);
+            const negativeThreshold = Number.isFinite(sanitized.lowerQuantile)
+                ? sanitized.lowerQuantile
+                : (Number.isFinite(sanitized.drop) ? -sanitized.drop : NaN);
+
+            let positiveExceedCount = 0;
+            let negativeExceedCount = 0;
+            if (Number.isFinite(positiveThreshold) || Number.isFinite(negativeThreshold)) {
+                for (let i = 0; i < filtered.length; i += 1) {
+                    const value = filtered[i];
+                    if (Number.isFinite(positiveThreshold) && value >= positiveThreshold) {
+                        positiveExceedCount += 1;
+                    } else if (Number.isFinite(negativeThreshold) && value <= negativeThreshold) {
+                        negativeExceedCount += 1;
+                    }
+                }
+            }
+
+            let midbandCount = filtered.length - positiveExceedCount - negativeExceedCount;
+            if (!Number.isFinite(midbandCount) || midbandCount < 0) {
+                midbandCount = Math.max(filtered.length - positiveExceedCount - negativeExceedCount, 0);
+            }
+            const positiveExceedShare = positives.length > 0 ? (positiveExceedCount / positives.length) : NaN;
+            const negativeExceedShare = negatives.length > 0 ? (negativeExceedCount / negatives.length) : NaN;
+            const totalPositiveShare = filtered.length > 0 ? (positiveExceedCount / filtered.length) : NaN;
+            const totalNegativeShare = filtered.length > 0 ? (negativeExceedCount / filtered.length) : NaN;
+            const zeroShare = filtered.length > 0 ? (zeroCount / filtered.length) : NaN;
+            const midbandShare = filtered.length > 0 ? (midbandCount / filtered.length) : NaN;
+            diagnosticsRef.totalSamples = filtered.length;
+            if (!Number.isFinite(diagnosticsRef.expectedTrainSamples)) {
+                diagnosticsRef.expectedTrainSamples = filtered.length;
+            }
+            diagnosticsRef.positiveSamples = positives.length;
+            diagnosticsRef.negativeSamples = negatives.length;
+            diagnosticsRef.zeroSamples = zeroCount;
+            diagnosticsRef.upperQuartile = Number.isFinite(combinedUpperQuartile) ? combinedUpperQuartile : null;
+            diagnosticsRef.lowerQuartile = Number.isFinite(combinedLowerQuartile) ? combinedLowerQuartile : null;
+            diagnosticsRef.combinedUpperQuartile = diagnosticsRef.upperQuartile;
+            diagnosticsRef.combinedLowerQuartile = diagnosticsRef.lowerQuartile;
+            diagnosticsRef.positiveQuartile = diagnosticsRef.upperQuartile;
+            diagnosticsRef.negativeQuartile = diagnosticsRef.lowerQuartile;
+            diagnosticsRef.positiveOnlyQuartile = Number.isFinite(positiveOnlyQuartile) ? positiveOnlyQuartile : null;
+            diagnosticsRef.negativeOnlyQuartile = Number.isFinite(negativeOnlyQuartile) ? negativeOnlyQuartile : null;
+            diagnosticsRef.positiveThreshold = Number.isFinite(positiveThreshold) ? positiveThreshold : null;
+            diagnosticsRef.negativeThreshold = Number.isFinite(negativeThreshold) ? negativeThreshold : null;
+            diagnosticsRef.positiveExceedCount = positiveExceedCount;
+            diagnosticsRef.negativeExceedCount = negativeExceedCount;
+            diagnosticsRef.positiveExceedShare = Number.isFinite(positiveExceedShare) ? positiveExceedShare : null;
+            diagnosticsRef.negativeExceedShare = Number.isFinite(negativeExceedShare) ? negativeExceedShare : null;
+            diagnosticsRef.totalPositiveShare = Number.isFinite(totalPositiveShare) ? totalPositiveShare : null;
+            diagnosticsRef.totalNegativeShare = Number.isFinite(totalNegativeShare) ? totalNegativeShare : null;
+            diagnosticsRef.zeroShare = Number.isFinite(zeroShare) ? zeroShare : null;
+            diagnosticsRef.midbandCount = midbandCount;
+            diagnosticsRef.midbandShare = Number.isFinite(midbandShare) ? midbandShare : null;
+            diagnosticsRef.usedPositiveFallback = positiveSource !== 'combined';
+            diagnosticsRef.usedNegativeFallback = negativeSource !== 'combined';
+            diagnosticsRef.positiveSource = positiveSource;
+            diagnosticsRef.negativeSource = negativeSource;
+            diagnosticsRef.fallbackUpperQuartile = null;
+            diagnosticsRef.fallbackLowerQuartile = null;
+        }
+
+        return sanitized;
+    };
+
+    const classifySwingReturn = (value, thresholds) => {
+        if (!Number.isFinite(value)) return 1;
+        const upper = Number.isFinite(thresholds?.upperQuantile) ? thresholds.upperQuantile : thresholds?.surge;
+        const lower = Number.isFinite(thresholds?.lowerQuantile)
+            ? thresholds.lowerQuantile
+            : (Number.isFinite(thresholds?.drop) ? -thresholds.drop : -DEFAULT_VOLATILITY_THRESHOLDS.drop);
+        if (Number.isFinite(upper) && value >= upper) {
+            return 2;
+        }
+        if (Number.isFinite(lower) && value <= lower) {
+            return 0;
+        }
+        const fallbackSurge = Number.isFinite(thresholds?.surge) ? thresholds.surge : DEFAULT_VOLATILITY_THRESHOLDS.surge;
+        const fallbackDrop = Number.isFinite(thresholds?.drop) ? thresholds.drop : DEFAULT_VOLATILITY_THRESHOLDS.drop;
+        if (Number.isFinite(fallbackSurge) && value >= fallbackSurge) {
+            return 2;
+        }
+        if (Number.isFinite(fallbackDrop) && value <= -fallbackDrop) {
+            return 0;
+        }
+        return 1;
+    };
+
+    const volatilityToPercent = (thresholds = DEFAULT_VOLATILITY_THRESHOLDS) => {
+        const upperSource = Number.isFinite(thresholds?.upperQuantile)
+            ? thresholds.upperQuantile
+            : (Number.isFinite(thresholds?.surge) ? thresholds.surge : DEFAULT_VOLATILITY_THRESHOLDS.surge);
+        const lowerSource = Number.isFinite(thresholds?.lowerQuantile)
+            ? thresholds.lowerQuantile
+            : (Number.isFinite(thresholds?.drop) ? -Math.abs(thresholds.drop) : -DEFAULT_VOLATILITY_THRESHOLDS.drop);
+        const clampedUpper = Math.min(Math.max(upperSource, 0), 0.5);
+        const clampedLower = Math.max(Math.min(lowerSource, 0), -0.5);
+        return {
+            surge: Number((clampedUpper * 100).toFixed(2)),
+            drop: Number((clampedLower * 100).toFixed(2)),
+            upper: Number((clampedUpper * 100).toFixed(2)),
+            lower: Number((clampedLower * 100).toFixed(2)),
+        };
+    };
+
+    const resolveVolatilityBounds = (thresholds = DEFAULT_VOLATILITY_THRESHOLDS) => {
+        const sanitized = sanitizeVolatilityThresholds(thresholds);
+        const upper = Number.isFinite(sanitized?.upperQuantile)
+            ? sanitized.upperQuantile
+            : (Number.isFinite(sanitized?.surge) ? sanitized.surge : NaN);
+        const lower = Number.isFinite(sanitized?.lowerQuantile)
+            ? sanitized.lowerQuantile
+            : (Number.isFinite(sanitized?.drop) ? -Math.abs(sanitized.drop) : NaN);
+        return {
+            upper: Number.isFinite(upper) ? upper : NaN,
+            lower: Number.isFinite(lower) ? lower : NaN,
+        };
+    };
+
+    const formatVolatilityDescription = (thresholds = DEFAULT_VOLATILITY_THRESHOLDS) => {
+        const percent = volatilityToPercent(thresholds);
+        return `大漲≧${percent.surge.toFixed(2)}%｜大跌≦${percent.drop.toFixed(2)}%`;
+    };
+
+    const updateVolatilityDiagnosticsDisplay = (diagnostics, classificationMode = CLASSIFICATION_MODES.MULTICLASS) => {
+        const container = elements.volatilityDiagnostics;
+        const sampleEl = elements.volatilitySampleSummary;
+        const surgeEl = elements.volatilitySurgeSummary;
+        const dropEl = elements.volatilityDropSummary;
+        if (!container || !sampleEl || !surgeEl || !dropEl) {
+            return;
+        }
+        const normalizedMode = normalizeClassificationMode(classificationMode);
+        const hasDiagnostics = diagnostics && typeof diagnostics === 'object';
+        if (!hasDiagnostics || normalizedMode !== CLASSIFICATION_MODES.MULTICLASS) {
+            container.classList.add('opacity-60');
+            sampleEl.textContent = normalizedMode === CLASSIFICATION_MODES.MULTICLASS
+                ? '尚未計算，請完成一次 AI 預測。'
+                : '目前為二分類模式，僅顯示勝率門檻。';
+            surgeEl.textContent = '';
+            dropEl.textContent = '';
+            return;
+        }
+
+        container.classList.remove('opacity-60');
+        const totalSamples = Number.isFinite(diagnostics.totalSamples) ? diagnostics.totalSamples : 0;
+        const expectedSamples = Number.isFinite(diagnostics.expectedTrainSamples)
+            ? diagnostics.expectedTrainSamples
+            : totalSamples;
+        const positiveSamples = Number.isFinite(diagnostics.positiveSamples) ? diagnostics.positiveSamples : 0;
+        const negativeSamples = Number.isFinite(diagnostics.negativeSamples) ? diagnostics.negativeSamples : 0;
+        const zeroSamples = Number.isFinite(diagnostics.zeroSamples)
+            ? diagnostics.zeroSamples
+            : Math.max(totalSamples - positiveSamples - negativeSamples, 0);
+        const positiveExceed = Number.isFinite(diagnostics.positiveExceedCount) ? diagnostics.positiveExceedCount : 0;
+        const negativeExceed = Number.isFinite(diagnostics.negativeExceedCount) ? diagnostics.negativeExceedCount : 0;
+        let midband = Number.isFinite(diagnostics.midbandCount)
+            ? diagnostics.midbandCount
+            : (totalSamples - positiveExceed - negativeExceed);
+        if (!Number.isFinite(midband) || midband < 0) {
+            midband = Math.max(totalSamples - positiveExceed - negativeExceed, 0);
+        }
+
+        const midbandShare = Number.isFinite(diagnostics.midbandShare)
+            ? diagnostics.midbandShare
+            : (totalSamples > 0 ? midband / totalSamples : NaN);
+        const zeroShare = Number.isFinite(diagnostics.zeroShare)
+            ? diagnostics.zeroShare
+            : (totalSamples > 0 ? zeroSamples / totalSamples : NaN);
+
+        const positiveShare = Number.isFinite(diagnostics.positiveExceedShare)
+            ? diagnostics.positiveExceedShare
+            : (positiveSamples > 0 ? positiveExceed / positiveSamples : NaN);
+        const negativeShare = Number.isFinite(diagnostics.negativeExceedShare)
+            ? diagnostics.negativeExceedShare
+            : (negativeSamples > 0 ? negativeExceed / negativeSamples : NaN);
+        const totalPositiveShare = Number.isFinite(diagnostics.totalPositiveShare)
+            ? diagnostics.totalPositiveShare
+            : (totalSamples > 0 ? positiveExceed / totalSamples : NaN);
+        const totalNegativeShare = Number.isFinite(diagnostics.totalNegativeShare)
+            ? diagnostics.totalNegativeShare
+            : (totalSamples > 0 ? negativeExceed / totalSamples : NaN);
+
+        const positiveThreshold = Number.isFinite(diagnostics.positiveThreshold) ? diagnostics.positiveThreshold : NaN;
+        const negativeThreshold = Number.isFinite(diagnostics.negativeThreshold) ? diagnostics.negativeThreshold : NaN;
+        const combinedUpperQuartile = Number.isFinite(diagnostics.combinedUpperQuartile)
+            ? diagnostics.combinedUpperQuartile
+            : (Number.isFinite(diagnostics.upperQuartile) ? diagnostics.upperQuartile : NaN);
+        const combinedLowerQuartile = Number.isFinite(diagnostics.combinedLowerQuartile)
+            ? diagnostics.combinedLowerQuartile
+            : (Number.isFinite(diagnostics.lowerQuartile) ? diagnostics.lowerQuartile : NaN);
+        const positiveOnlyQuartile = Number.isFinite(diagnostics.positiveOnlyQuartile)
+            ? diagnostics.positiveOnlyQuartile
+            : NaN;
+        const negativeOnlyQuartile = Number.isFinite(diagnostics.negativeOnlyQuartile)
+            ? diagnostics.negativeOnlyQuartile
+            : NaN;
+        const positiveSource = typeof diagnostics.positiveSource === 'string'
+            ? diagnostics.positiveSource
+            : (diagnostics.usedPositiveFallback ? 'default' : 'combined');
+        const negativeSource = typeof diagnostics.negativeSource === 'string'
+            ? diagnostics.negativeSource
+            : (diagnostics.usedNegativeFallback ? 'default' : 'combined');
+
+        const summaryParts = [`訓練集隔日收盤漲跌幅 ${expectedSamples} 天`];
+        if (expectedSamples !== totalSamples) {
+            summaryParts.push(`有效樣本 ${totalSamples} 天`);
+        }
+        const signComposition = [];
+        if (positiveSamples > 0) signComposition.push(`上漲 ${positiveSamples} 天`);
+        if (negativeSamples > 0) signComposition.push(`下跌 ${negativeSamples} 天`);
+        if (zeroSamples > 0) {
+            const zeroShareText = Number.isFinite(zeroShare) ? formatPercent(zeroShare, 1) : '—';
+            signComposition.push(`平盤 ${zeroSamples} 天（約 ${zeroShareText}）`);
+        }
+        const midbandText = Number.isFinite(midbandShare) ? formatPercent(midbandShare, 1) : '—';
+        const compositionText = signComposition.length > 0
+            ? `（${signComposition.join('｜')}）`
+            : '';
+        const smallBandText = midband > 0
+            ? `｜小波動門檻內 ${midband} 天（約 ${midbandText}）`
+            : '';
+        sampleEl.textContent = `${summaryParts.join('｜')}${compositionText}${smallBandText}`;
+
+        const positiveCountText = positiveSamples > 0 ? `${positiveExceed}/${positiveSamples}` : `${positiveExceed}/—`;
+        const positiveShareText = Number.isFinite(positiveShare) ? formatPercent(positiveShare, 1) : '—';
+        const positiveTotalShareText = Number.isFinite(totalPositiveShare) ? formatPercent(totalPositiveShare, 1) : '—';
+        let positiveSourceText = '';
+        if (positiveSource === 'combined') {
+            positiveSourceText = Number.isFinite(combinedUpperQuartile)
+                ? `｜訓練集上四分位 (Q3) ${formatPercent(combinedUpperQuartile, 2)}`
+                : '｜使用訓練集上四分位 (Q3)';
+        } else if (positiveSource === 'positive-only') {
+            positiveSourceText = Number.isFinite(positiveOnlyQuartile)
+                ? `｜正報酬上四分位 ${formatPercent(positiveOnlyQuartile, 2)}`
+                : '｜正報酬樣本上四分位';
+        } else {
+            positiveSourceText = Number.isFinite(positiveThreshold)
+                ? `｜樣本不足，改用預設門檻 ${formatPercent(positiveThreshold, 2)}`
+                : '｜樣本不足，改用預設門檻';
+        }
+        surgeEl.textContent = Number.isFinite(positiveThreshold)
+            ? `大漲門檻 ≈ ${formatPercent(positiveThreshold, 2)}（達門檻 ${positiveCountText} 天，約 ${positiveShareText}｜占訓練集 ${positiveTotalShareText}）${positiveSourceText}`
+            : '大漲門檻尚未計算，請重新訓練一次。';
+
+        const negativeCountText = negativeSamples > 0 ? `${negativeExceed}/${negativeSamples}` : `${negativeExceed}/—`;
+        const negativeShareText = Number.isFinite(negativeShare) ? formatPercent(negativeShare, 1) : '—';
+        const negativeTotalShareText = Number.isFinite(totalNegativeShare) ? formatPercent(totalNegativeShare, 1) : '—';
+        let negativeSourceText = '';
+        if (negativeSource === 'combined') {
+            negativeSourceText = Number.isFinite(combinedLowerQuartile)
+                ? `｜訓練集下四分位 (Q1) ${formatPercent(combinedLowerQuartile, 2)}`
+                : '｜使用訓練集下四分位 (Q1)';
+        } else if (negativeSource === 'negative-only') {
+            negativeSourceText = Number.isFinite(negativeOnlyQuartile)
+                ? `｜負報酬下四分位 ${formatPercent(negativeOnlyQuartile, 2)}`
+                : '｜負報酬樣本下四分位';
+        } else {
+            negativeSourceText = Number.isFinite(negativeThreshold)
+                ? `｜樣本不足，改用預設門檻 ${formatPercent(negativeThreshold, 2)}`
+                : '｜樣本不足，改用預設門檻';
+        }
+        dropEl.textContent = Number.isFinite(negativeThreshold)
+            ? `大跌門檻 ≈ ${formatPercent(negativeThreshold, 2)}（達門檻 ${negativeCountText} 天，約 ${negativeShareText}｜占訓練集 ${negativeTotalShareText}）${negativeSourceText}`
+            : '大跌門檻尚未計算，請重新訓練一次。';
+    };
+
+    const normalizeProbabilities = (values) => {
+        const probs = values.map((value) => {
+            const num = Number(value);
+            if (!Number.isFinite(num)) return 0;
+            if (num < 0) return 0;
+            if (num > 1) return 1;
+            return num;
+        });
+        const sum = probs.reduce((acc, value) => acc + value, 0);
+        if (sum <= 0) {
+            return [1 / 3, 1 / 3, 1 / 3];
+        }
+        return probs.map((value) => value / sum);
+    };
+
+    const parsePredictionEntry = (value, mode = CLASSIFICATION_MODES.MULTICLASS) => {
+        const classificationMode = normalizeClassificationMode(mode);
+        const clampProbability = (num, fallback = 0) => {
+            const parsed = Number(num);
+            if (!Number.isFinite(parsed)) return fallback;
+            if (parsed < 0) return 0;
+            if (parsed > 1) return 1;
+            return parsed;
+        };
+        if (Array.isArray(value)) {
+            let probabilities;
+            if (value.length >= 3) {
+                probabilities = normalizeProbabilities([value[0], value[1], value[2]]);
+            } else if (classificationMode === CLASSIFICATION_MODES.BINARY) {
+                const pUp = clampProbability(value[value.length - 1], 0.5);
+                const pDown = clampProbability(value[0], 1 - pUp);
+                probabilities = normalizeProbabilities([pDown, 0, pUp]);
+            } else if (value.length === 2) {
+                probabilities = normalizeProbabilities([value[0], value[1], 1 - (Number(value[0]) + Number(value[1]))]);
+            } else {
+                const base = clampProbability(value[0], 1 / 3);
+                probabilities = normalizeProbabilities([base, base, base]);
+            }
+            const classIndex = probabilities.indexOf(Math.max(...probabilities));
+            return {
+                probabilities,
+                pDown: probabilities[0],
+                pFlat: probabilities[1],
+                pUp: probabilities[2],
+                classIndex,
+            };
+        }
+        if (value && typeof value === 'object') {
+            if (Array.isArray(value.probabilities)) {
+                return parsePredictionEntry(value.probabilities, classificationMode);
+            }
+            if (Array.isArray(value.probs)) {
+                return parsePredictionEntry(value.probs, classificationMode);
+            }
+            if (typeof value.pUp === 'number' || typeof value.up === 'number') {
+                const upValue = Number(value.pUp ?? value.up);
+                const downValue = Number(value.pDown ?? value.down ?? (1 - upValue));
+                const flatValue = Number(value.pFlat ?? value.flat ?? (1 - upValue - downValue));
+                return parsePredictionEntry([downValue, flatValue, upValue], classificationMode);
+            }
+        }
+        const fallback = classificationMode === CLASSIFICATION_MODES.BINARY ? 0.5 : (1 / 3);
+        const probability = clampProbability(value, fallback);
+        if (classificationMode === CLASSIFICATION_MODES.BINARY) {
+            const pUp = probability;
+            const pDown = 1 - pUp;
+            const probabilities = normalizeProbabilities([pDown, 0, pUp]);
+            return {
+                probabilities,
+                pDown: probabilities[0],
+                pFlat: probabilities[1],
+                pUp: probabilities[2],
+                classIndex: probabilities[2] >= probabilities[0] ? 2 : 0,
+            };
+        }
+        return {
+            probabilities: [1 / 3, 1 / 3, 1 / 3],
+            pDown: 1 / 3,
+            pFlat: 1 / 3,
+            pUp: 1 / 3,
+            classIndex: 1,
+        };
+    };
+
+    const formatClassLabel = (index, mode = CLASSIFICATION_MODES.MULTICLASS) => {
+        const classificationMode = normalizeClassificationMode(mode);
+        if (classificationMode === CLASSIFICATION_MODES.BINARY) {
+            return index === 2 ? '預測上漲' : '預測下跌';
+        }
+        return VOLATILITY_CLASS_LABELS[index] || VOLATILITY_CLASS_LABELS[1];
+    };
+
+    const formatPredictedSwingText = (index, mode, bounds) => {
+        const classificationMode = normalizeClassificationMode(mode);
+        if (classificationMode !== CLASSIFICATION_MODES.MULTICLASS) {
+            return '—';
+        }
+        const upper = Number.isFinite(bounds?.upper) ? bounds.upper : NaN;
+        const lower = Number.isFinite(bounds?.lower) ? bounds.lower : NaN;
+        if (index === 2) {
+            return Number.isFinite(upper) ? `≥ ${formatPercent(upper, 2)}` : '≥ 門檻';
+        }
+        if (index === 0) {
+            return Number.isFinite(lower) ? `≤ ${formatPercent(lower, 2)}` : '≤ 門檻';
+        }
+        if (Number.isFinite(lower) && Number.isFinite(upper)) {
+            return `${formatPercent(lower, 2)} ~ ${formatPercent(upper, 2)}`;
+        }
+        if (Number.isFinite(upper)) {
+            return `＜ ${formatPercent(upper, 2)}`;
+        }
+        if (Number.isFinite(lower)) {
+            return `＞ ${formatPercent(lower, 2)}`;
+        }
+        return '—';
+    };
+
+    const readVolatilityThresholdsFromInputs = (fallback = DEFAULT_VOLATILITY_THRESHOLDS) => {
+        const sanitized = sanitizeVolatilityThresholds(fallback);
+        const percent = volatilityToPercent(sanitized);
+        if (elements.volatilitySurge) {
+            elements.volatilitySurge.value = percent.surge.toFixed(2);
+        }
+        if (elements.volatilityDrop) {
+            elements.volatilityDrop.value = percent.drop.toFixed(2);
+        }
+        return sanitized;
+    };
+
+    const annotateForecast = (forecast, payload) => {
+        if (!forecast || !Number.isFinite(forecast.probability)) return null;
+        const annotated = { ...forecast };
+        const referenceDate = typeof annotated.referenceDate === 'string'
+            ? annotated.referenceDate
+            : (typeof payload?.datasetLastDate === 'string' ? payload.datasetLastDate : null);
+        if (!annotated.tradeDate || typeof annotated.tradeDate !== 'string') {
+            const computedDate = computeNextTradingDate(referenceDate);
+            if (computedDate) {
+                annotated.tradeDate = computedDate;
+            }
+        }
+        if (!Number.isFinite(annotated.buyPrice) && Number.isFinite(payload?.lastClose)) {
+            annotated.buyPrice = payload.lastClose;
+        }
+        if (referenceDate && !annotated.referenceDate) {
+            annotated.referenceDate = referenceDate;
+        }
+        if (referenceDate && !annotated.buyDate) {
+            annotated.buyDate = referenceDate;
+        }
+        if (annotated.tradeDate && !annotated.sellDate) {
+            annotated.sellDate = annotated.tradeDate;
+        }
+        const resolvedBounds = resolveVolatilityBounds(payload?.volatilityThresholds || DEFAULT_VOLATILITY_THRESHOLDS);
+        annotated.volatilityUpper = resolvedBounds.upper;
+        annotated.volatilityLower = resolvedBounds.lower;
+        return annotated;
+    };
+
+    const generateRuntimeSeed = () => {
+        if (typeof window !== 'undefined' && window.crypto && typeof window.crypto.getRandomValues === 'function') {
+            const array = new Uint32Array(1);
+            window.crypto.getRandomValues(array);
+            const seeded = array[0] >>> 0;
+            if (seeded > 0) {
+                return seeded;
+            }
+        }
+        const timeComponent = Date.now() & 0x7fffffff;
+        const randomComponent = Math.floor((Math.random() * 0x7fffffff) % 0x7fffffff);
+        const combined = (timeComponent ^ randomComponent) & 0x7fffffff;
+        return combined > 0 ? combined : (timeComponent || 1);
     };
 
     const updateTrainRatioBadge = (ratio) => {
@@ -204,12 +1228,16 @@
     };
 
     const parseWinThreshold = () => {
-        if (!elements.winThreshold) return 0.5;
-        const percent = Math.round(parseNumberInput(elements.winThreshold, 60, { min: 50, max: 100 }));
+        const modelState = getActiveModelState();
+        const classificationMode = normalizeClassificationMode(modelState?.classification || elements.classificationMode?.value);
+        if (!elements.winThreshold) return getDefaultWinThresholdForMode(classificationMode);
+        const defaultPercent = Math.round(getDefaultWinThresholdForMode(classificationMode) * 100);
+        const percent = Math.round(parseNumberInput(elements.winThreshold, defaultPercent, { min: 0, max: 100 }));
         elements.winThreshold.value = String(percent);
         const threshold = percent / 100;
-        const modelState = getActiveModelState();
-        modelState.winThreshold = threshold;
+        if (modelState) {
+            modelState.winThreshold = threshold;
+        }
         return threshold;
     };
 
@@ -219,27 +1247,48 @@
         const activeModel = globalState.activeModel;
         const options = seeds
             .filter((seed) => (seed.modelType || MODEL_TYPES.LSTM) === activeModel)
+            .sort((a, b) => (Number(b?.createdAt || 0) - Number(a?.createdAt || 0)))
             .map((seed) => `<option value="${escapeHTML(seed.id)}">${escapeHTML(seed.name || '未命名種子')}</option>`)
             .join('');
         elements.savedSeedList.innerHTML = options;
     };
 
-    const buildSeedDefaultName = (summary) => {
-        if (!summary) return '';
-        const trainText = formatPercent(summary.trainAccuracy, 1);
+    const buildSeedDefaultName = (summary, modelType = globalState.activeModel) => {
+        const prefix = modelType === MODEL_TYPES.LSTM ? '【LSTM】' : '【ANNS】';
+        if (!summary) {
+            return `${prefix}尚未產生預設名稱`;
+        }
         const testText = formatPercent(summary.testAccuracy, 1);
-        return `訓練勝率${trainText}｜測試正確率${testText}`;
+        const medianText = formatPercent(summary.tradeReturnMedian, 2);
+        const singleAverage = Number.isFinite(summary.tradeReturnAverageSingle)
+            ? formatPercent(summary.tradeReturnAverageSingle, 2)
+            : formatPercent(summary.tradeReturnAverage, 2);
+        const monthlyText = formatPercent(summary.tradeReturnAverageMonthly, 2);
+        const yearlyText = formatPercent(summary.tradeReturnAverageYearly, 2);
+        const tradeCountText = Number.isFinite(summary.executedTrades) ? summary.executedTrades : 0;
+        return `${prefix}測試勝率${testText}｜交易報酬中位數${medianText}｜單次平均報酬${singleAverage}｜月平均報酬${monthlyText}｜年平均報酬${yearlyText}｜交易次數${tradeCountText}`;
     };
 
-    const applySeedDefaultName = (summary) => {
-        if (!elements.seedName) return;
-        const defaultName = buildSeedDefaultName(summary);
+    const applySeedDefaultName = (summary, modelType = globalState.activeModel, options = {}) => {
+        const modelState = getModelState(modelType);
+        const previousDefault = modelState?.lastSeedDefault || '';
+        const defaultName = buildSeedDefaultName(summary, modelType);
+        if (modelState) {
+            modelState.lastSeedDefault = defaultName;
+        }
+        if (!elements.seedName || globalState.activeModel !== modelType) {
+            return;
+        }
+        const currentValue = elements.seedName.value || '';
+        const previousDatasetDefault = elements.seedName.dataset?.defaultName || '';
+        const shouldUpdate = Boolean(options.force)
+            || !currentValue
+            || currentValue === previousDatasetDefault
+            || currentValue === previousDefault;
         elements.seedName.dataset.defaultName = defaultName;
-        const modelState = getActiveModelState();
-        if (!elements.seedName.value || elements.seedName.value === modelState.lastSeedDefault) {
+        if (shouldUpdate) {
             elements.seedName.value = defaultName;
         }
-        modelState.lastSeedDefault = defaultName;
     };
 
     const showStatus = (message, type = 'info') => {
@@ -280,7 +1329,19 @@
 
     const handleAIWorkerMessage = (event) => {
         if (!event || !event.data) return;
-        const { type, id, data, error, message } = event.data;
+        const { type, id, data, error, message, payload } = event.data;
+        if (type === ANN_META_MESSAGE) {
+            if (payload && typeof payload === 'object') {
+                persistAnnMeta(payload);
+            }
+            return;
+        }
+        if (type === LSTM_META_MESSAGE) {
+            if (payload && typeof payload === 'object') {
+                persistLstmMeta(payload);
+            }
+            return;
+        }
         const isProgress = type === 'ai-train-lstm-progress' || type === 'ai-train-ann-progress';
         if (isProgress) {
             const pending = id ? aiWorkerRequests.get(id) : null;
@@ -368,10 +1429,16 @@
 
     const toggleRunning = (flag) => {
         globalState.running = Boolean(flag);
-        if (!elements.runButton) return;
-        elements.runButton.disabled = globalState.running;
-        elements.runButton.classList.toggle('opacity-60', globalState.running);
-        elements.runButton.classList.toggle('cursor-not-allowed', globalState.running);
+        if (elements.runButton) {
+            elements.runButton.disabled = globalState.running;
+            elements.runButton.classList.toggle('opacity-60', globalState.running);
+            elements.runButton.classList.toggle('cursor-not-allowed', globalState.running);
+        }
+        if (elements.freshRunButton) {
+            elements.freshRunButton.disabled = globalState.running;
+            elements.freshRunButton.classList.toggle('opacity-60', globalState.running);
+            elements.freshRunButton.classList.toggle('cursor-not-allowed', globalState.running);
+        }
     };
 
     const parseNumberInput = (el, fallback, options = {}) => {
@@ -415,49 +1482,101 @@
         return null;
     };
 
-    const buildDataset = (rows, lookback) => {
+    const buildDataset = (rows, lookback, volatilityOverrides = DEFAULT_VOLATILITY_THRESHOLDS, classificationOverride = CLASSIFICATION_MODES.MULTICLASS) => {
+        const classificationMode = normalizeClassificationMode(classificationOverride);
         if (!Array.isArray(rows)) {
-            return { sequences: [], labels: [], meta: [], returns: [], baseRows: [] };
+            return { sequences: [], labels: [], meta: [], returns: [], swingTargets: [], baseRows: [] };
         }
+        const volatilityThresholds = sanitizeVolatilityThresholds(volatilityOverrides);
         const sorted = rows
             .filter((row) => row && typeof row.date === 'string')
-            .map((row) => ({
-                date: row.date,
-                close: resolveCloseValue(row),
-            }))
+            .map((row) => {
+                const close = resolveCloseValue(row);
+                return {
+                    date: row.date,
+                    close,
+                    open: resolveOpenValue(row, close),
+                    low: resolveLowValue(row, close),
+                };
+            })
             .filter((row) => Number.isFinite(row.close) && row.close > 0)
             .sort((a, b) => a.date.localeCompare(b.date));
 
         if (sorted.length <= lookback + 2) {
-            return { sequences: [], labels: [], meta: [], returns: [], baseRows: sorted };
+            return {
+                sequences: [],
+                labels: [],
+                meta: [],
+                returns: [],
+                swingTargets: [],
+                baseRows: sorted,
+                lastClose: sorted.length > 0 ? sorted[sorted.length - 1].close : null,
+            };
         }
 
-        const returns = [];
+        const priceChanges = [];
+        const tradeReturns = [];
         const meta = [];
         for (let i = 1; i < sorted.length; i += 1) {
             const prev = sorted[i - 1];
             const curr = sorted[i];
-            if (!Number.isFinite(prev.close) || prev.close <= 0) continue;
-            const change = (curr.close - prev.close) / prev.close;
-            returns.push(change);
+            if (!Number.isFinite(prev.close) || prev.close <= 0 || !Number.isFinite(curr.close)) continue;
+            const rawChange = (curr.close - prev.close) / prev.close;
+            const nextLow = Number.isFinite(curr.low) ? curr.low : prev.close;
+            const entryTrigger = prev.close;
+            const nextOpen = Number.isFinite(curr.open) ? curr.open : entryTrigger;
+            const entryEligible = Number.isFinite(nextLow) && nextLow < entryTrigger;
+            const closeEntryBuyPrice = entryEligible
+                ? (Number.isFinite(nextOpen) && nextOpen < entryTrigger ? nextOpen : entryTrigger)
+                : entryTrigger;
+            const sellPrice = curr.close;
+            const closeEntryReturn = entryEligible && Number.isFinite(closeEntryBuyPrice) && closeEntryBuyPrice > 0
+                ? (sellPrice - closeEntryBuyPrice) / closeEntryBuyPrice
+                : 0;
+            const openEntryBuyPrice = Number.isFinite(nextOpen) && nextOpen > 0 ? nextOpen : entryTrigger;
+            const openEntryEligible = Number.isFinite(openEntryBuyPrice) && openEntryBuyPrice > 0 && Number.isFinite(sellPrice);
+            const openEntryReturn = openEntryEligible
+                ? (sellPrice - openEntryBuyPrice) / openEntryBuyPrice
+                : 0;
+            const actualReturn = closeEntryReturn;
+            priceChanges.push(rawChange);
+            tradeReturns.push(actualReturn);
             meta.push({
                 buyDate: prev.date,
                 sellDate: curr.date,
+                tradeDate: curr.date,
                 buyClose: prev.close,
                 sellClose: curr.close,
-                actualReturn: change,
+                buyPrice: closeEntryBuyPrice,
+                sellPrice,
+                nextOpen,
+                nextLow,
+                entryEligible,
+                closeEntryEligible: entryEligible,
+                closeEntryBuyPrice,
+                closeEntryReturn,
+                openEntryEligible,
+                openEntryBuyPrice,
+                openEntrySellPrice: sellPrice,
+                openEntryReturn,
+                actualReturn,
+                buyTrigger: entryTrigger,
+                swingReturn: rawChange,
+                classLabel: classificationMode === CLASSIFICATION_MODES.BINARY ? Number(actualReturn > 0) : 1,
             });
         }
 
         const sequences = [];
         const labels = [];
         const targetReturns = [];
-        for (let i = lookback; i < returns.length; i += 1) {
-            const feature = returns.slice(i - lookback, i);
+        const swingTargets = [];
+        for (let i = lookback; i < priceChanges.length; i += 1) {
+            const feature = priceChanges.slice(i - lookback, i);
             if (feature.length !== lookback) continue;
             sequences.push(feature);
-            labels.push(returns[i] > 0 ? 1 : 0);
-            targetReturns.push(returns[i]);
+            labels.push(1);
+            swingTargets.push(priceChanges[i]);
+            targetReturns.push(tradeReturns[i]);
         }
 
         const metaAligned = meta.slice(lookback);
@@ -466,7 +1585,11 @@
             labels,
             meta: metaAligned,
             returns: targetReturns,
+            swingTargets,
             baseRows: sorted,
+            lastClose: sorted.length > 0 ? sorted[sorted.length - 1].close : null,
+            volatilityThresholds,
+            classificationMode,
         };
     };
 
@@ -496,17 +1619,39 @@
         elements.datasetSummary.textContent = `可用資料 ${sorted.length} 筆，區間 ${firstDate} ~ ${lastDate}。`;
     };
 
-    const renderTrades = (records, forecast) => {
+    const renderTrades = (records, forecast, showingAll = false) => {
         if (!elements.tradeTableBody) return;
         const rows = Array.isArray(records) ? records : [];
+        const modelState = getActiveModelState();
+        const fallbackMode = normalizeClassificationMode(modelState?.classification || CLASSIFICATION_MODES.MULTICLASS);
+        const fallbackBounds = resolveVolatilityBounds(modelState?.volatilityThresholds || DEFAULT_VOLATILITY_THRESHOLDS);
         if (rows.length === 0) {
-            elements.tradeTableBody.innerHTML = forecast && Number.isFinite(forecast.probability)
+            const forecastMode = normalizeClassificationMode(forecast?.classificationMode || fallbackMode);
+            const upperBound = Number.isFinite(forecast?.volatilityUpper) ? forecast.volatilityUpper : fallbackBounds.upper;
+            const lowerBound = Number.isFinite(forecast?.volatilityLower) ? forecast.volatilityLower : fallbackBounds.lower;
+            const swingText = formatPredictedSwingText(forecast?.predictedClass ?? 1, forecastMode, { upper: upperBound, lower: lowerBound });
+            const surgeText = forecastMode === CLASSIFICATION_MODES.MULTICLASS && Number.isFinite(upperBound)
+                ? formatPercent(upperBound, 2)
+                : '—';
+            const dropText = forecastMode === CLASSIFICATION_MODES.MULTICLASS && Number.isFinite(lowerBound)
+                ? formatPercent(lowerBound, 2)
+                : '—';
+            const probabilityDetail = forecast && forecast.classLabel
+                ? `<div class="text-[10px]" style="color: var(--muted-foreground);">${escapeHTML(forecast.classLabel)}</div>`
+                : '';
+            elements.tradeTableBody.innerHTML = forecast && Number.isFinite(forecast?.probability)
                 ? `
                     <tr class="bg-muted/30">
-                        <td class="px-3 py-2 whitespace-nowrap">${escapeHTML(forecast.referenceDate || '最近收盤')}
+                        <td class="px-3 py-2 whitespace-nowrap">${escapeHTML(forecast.buyDate || forecast.referenceDate || '最近收盤')}</td>
+                        <td class="px-3 py-2 whitespace-nowrap">${escapeHTML(forecast.tradeDate || computeNextTradingDate(forecast.referenceDate) || forecast.referenceDate || '—')}
                             <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium" style="background-color: color-mix(in srgb, var(--primary) 20%, transparent); color: var(--primary-foreground);">隔日預測</span>
                         </td>
-                        <td class="px-3 py-2 text-right">${formatPercent(forecast.probability, 1)}</td>
+                        <td class="px-3 py-2 text-right">${formatPercent(forecast.probability, 1)}${probabilityDetail}</td>
+                        <td class="px-3 py-2 text-right">${swingText}</td>
+                        <td class="px-3 py-2 text-right">${surgeText}</td>
+                        <td class="px-3 py-2 text-right">${dropText}</td>
+                        <td class="px-3 py-2 text-right">${formatPrice(forecast.buyPrice)}</td>
+                        <td class="px-3 py-2 text-right">—</td>
                         <td class="px-3 py-2 text-right">—</td>
                         <td class="px-3 py-2 text-right">${formatPercent(forecast.fraction, 2)}</td>
                         <td class="px-3 py-2 text-right">—</td>
@@ -515,21 +1660,59 @@
                 : '';
             return;
         }
-        const limited = rows.slice(-200);
-        const htmlParts = limited.map((trade) => {
+        const sourceRows = showingAll ? rows : rows.slice(-200);
+        const htmlParts = sourceRows.map((trade) => {
             const probabilityText = formatPercent(trade.probability, 1);
+            const detailParts = [];
+            if (trade.predictedClassLabel) {
+                detailParts.push(escapeHTML(trade.predictedClassLabel));
+            }
+            if (showingAll) {
+                const statusText = trade.executed
+                    ? '已執行'
+                    : (trade.triggered ? '達門檻（未成交）' : '未達門檻');
+                detailParts.push(statusText);
+            }
+            const probabilityDetail = detailParts.length > 0
+                ? `<div class="text-[10px]" style="color: var(--muted-foreground);">${detailParts.join('｜')}</div>`
+                : '';
+            const recordMode = normalizeClassificationMode(trade.classificationMode || fallbackMode);
+            const recordUpper = Number.isFinite(trade.volatilityUpper) ? trade.volatilityUpper : fallbackBounds.upper;
+            const recordLower = Number.isFinite(trade.volatilityLower) ? trade.volatilityLower : fallbackBounds.lower;
+            const predictedSwingText = formatPredictedSwingText(trade.predictedClass, recordMode, { upper: recordUpper, lower: recordLower });
+            const surgeThresholdText = recordMode === CLASSIFICATION_MODES.MULTICLASS && Number.isFinite(recordUpper)
+                ? formatPercent(recordUpper, 2)
+                : '—';
+            const dropThresholdText = recordMode === CLASSIFICATION_MODES.MULTICLASS && Number.isFinite(recordLower)
+                ? formatPercent(recordLower, 2)
+                : '—';
             const actualReturnText = formatPercent(trade.actualReturn, 2);
             const fractionText = formatPercent(trade.fraction, 2);
             const tradeReturnText = formatPercent(trade.tradeReturn, 2);
+            const buyPriceText = formatPrice(trade.buyPrice);
+            const sellPriceText = formatPrice(trade.sellPrice);
             const actualClass = Number.isFinite(trade.actualReturn) && trade.actualReturn < 0 ? 'text-rose-600' : 'text-emerald-600';
             const tradeReturnClass = Number.isFinite(trade.tradeReturn) && trade.tradeReturn < 0 ? 'text-rose-600' : 'text-emerald-600';
             const badge = trade.isForecast
                 ? `<span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium" style="background-color: color-mix(in srgb, var(--primary) 20%, transparent); color: var(--primary-foreground);">隔日預測</span>`
                 : '';
+            const rowClass = [];
+            if (trade.isForecast) {
+                rowClass.push('bg-muted/30');
+            } else if (showingAll && !trade.executed) {
+                rowClass.push('opacity-75');
+            }
+            const rowClassAttr = rowClass.length > 0 ? ` class="${rowClass.join(' ')}"` : '';
             return `
-                <tr${trade.isForecast ? ' class="bg-muted/30"' : ''}>
-                    <td class="px-3 py-2 whitespace-nowrap">${escapeHTML(trade.tradeDate || '—')}${badge}</td>
-                    <td class="px-3 py-2 text-right">${probabilityText}</td>
+                <tr${rowClassAttr}>
+                    <td class="px-3 py-2 whitespace-nowrap">${escapeHTML(trade.buyDate || '—')}</td>
+                    <td class="px-3 py-2 whitespace-nowrap">${escapeHTML(trade.sellDate || trade.tradeDate || '—')}${badge}</td>
+                    <td class="px-3 py-2 text-right">${probabilityText}${probabilityDetail}</td>
+                    <td class="px-3 py-2 text-right">${predictedSwingText}</td>
+                    <td class="px-3 py-2 text-right">${surgeThresholdText}</td>
+                    <td class="px-3 py-2 text-right">${dropThresholdText}</td>
+                    <td class="px-3 py-2 text-right">${buyPriceText}</td>
+                    <td class="px-3 py-2 text-right">${sellPriceText}</td>
                     <td class="px-3 py-2 text-right ${actualClass}">${actualReturnText}</td>
                     <td class="px-3 py-2 text-right">${fractionText}</td>
                     <td class="px-3 py-2 text-right ${tradeReturnClass}">${tradeReturnText}</td>
@@ -538,10 +1721,30 @@
         });
 
         if (forecast && Number.isFinite(forecast.probability)) {
+            const tradeDateLabel = forecast.tradeDate || computeNextTradingDate(forecast.referenceDate) || forecast.referenceDate || '最近收盤';
+            const forecastMode = normalizeClassificationMode(forecast.classificationMode || fallbackMode);
+            const upperBound = Number.isFinite(forecast.volatilityUpper) ? forecast.volatilityUpper : fallbackBounds.upper;
+            const lowerBound = Number.isFinite(forecast.volatilityLower) ? forecast.volatilityLower : fallbackBounds.lower;
+            const swingText = formatPredictedSwingText(forecast.predictedClass ?? 1, forecastMode, { upper: upperBound, lower: lowerBound });
+            const surgeText = forecastMode === CLASSIFICATION_MODES.MULTICLASS && Number.isFinite(upperBound)
+                ? formatPercent(upperBound, 2)
+                : '—';
+            const dropText = forecastMode === CLASSIFICATION_MODES.MULTICLASS && Number.isFinite(lowerBound)
+                ? formatPercent(lowerBound, 2)
+                : '—';
+            const forecastDetail = forecast.classLabel
+                ? `<div class="text-[10px]" style="color: var(--muted-foreground);">${escapeHTML(forecast.classLabel)}</div>`
+                : '';
             htmlParts.push(`
                 <tr class="bg-muted/30">
-                    <td class="px-3 py-2 whitespace-nowrap">${escapeHTML(forecast.referenceDate || '最近收盤')}<span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium" style="background-color: color-mix(in srgb, var(--primary) 20%, transparent); color: var(--primary-foreground);">隔日預測</span></td>
-                    <td class="px-3 py-2 text-right">${formatPercent(forecast.probability, 1)}</td>
+                    <td class="px-3 py-2 whitespace-nowrap">${escapeHTML(forecast.buyDate || forecast.referenceDate || '最近收盤')}</td>
+                    <td class="px-3 py-2 whitespace-nowrap">${escapeHTML(tradeDateLabel)}<span class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium" style="background-color: color-mix(in srgb, var(--primary) 20%, transparent); color: var(--primary-foreground);">隔日預測</span></td>
+                    <td class="px-3 py-2 text-right">${formatPercent(forecast.probability, 1)}${forecastDetail}</td>
+                    <td class="px-3 py-2 text-right">${swingText}</td>
+                    <td class="px-3 py-2 text-right">${surgeText}</td>
+                    <td class="px-3 py-2 text-right">${dropText}</td>
+                    <td class="px-3 py-2 text-right">${formatPrice(forecast.buyPrice)}</td>
+                    <td class="px-3 py-2 text-right">—</td>
                     <td class="px-3 py-2 text-right">—</td>
                     <td class="px-3 py-2 text-right">${formatPercent(forecast.fraction, 2)}</td>
                     <td class="px-3 py-2 text-right">—</td>
@@ -552,7 +1755,33 @@
         elements.tradeTableBody.innerHTML = htmlParts.join('');
     };
 
+    const updateAllPredictionsToggleButton = (modelState) => {
+        if (!elements.toggleAllTrades) return;
+        const total = Array.isArray(modelState?.allPredictionRows) ? modelState.allPredictionRows.length : 0;
+        const executed = Array.isArray(modelState?.currentTrades) ? modelState.currentTrades.length : 0;
+        const showingAll = Boolean(globalState.showAllPredictions && total > 0);
+        elements.toggleAllTrades.disabled = total === 0;
+        if (total === 0) {
+            elements.toggleAllTrades.classList.add('opacity-60', 'cursor-not-allowed');
+        } else {
+            elements.toggleAllTrades.classList.remove('opacity-60', 'cursor-not-allowed');
+        }
+        elements.toggleAllTrades.setAttribute('aria-pressed', showingAll ? 'true' : 'false');
+        if (total === 0) {
+            elements.toggleAllTrades.textContent = '顯示全部預測紀錄';
+        } else if (showingAll) {
+            elements.toggleAllTrades.textContent = `僅顯示觸發交易（${executed} 筆）`;
+        } else {
+            elements.toggleAllTrades.textContent = `顯示全部預測紀錄（共 ${total} 筆）`;
+        }
+    };
+
     const resetOutputs = () => {
+        globalState.showAllPredictions = false;
+        const activeState = getActiveModelState();
+        if (activeState) {
+            activeState.volatilityDiagnostics = null;
+        }
         if (elements.trainAccuracy) elements.trainAccuracy.textContent = '—';
         if (elements.trainLoss) elements.trainLoss.textContent = 'Loss：—';
         if (elements.testAccuracy) elements.testAccuracy.textContent = '—';
@@ -560,35 +1789,91 @@
         if (elements.tradeCount) elements.tradeCount.textContent = '—';
         if (elements.hitRate) elements.hitRate.textContent = '命中率：—｜勝率門檻：—';
         if (elements.totalReturn) elements.totalReturn.textContent = '—';
-        if (elements.averageProfit) elements.averageProfit.textContent = '平均報酬%：—｜交易次數：0｜標準差：—';
+        if (elements.averageProfit) elements.averageProfit.textContent = '單次平均報酬%：—｜月平均報酬%：—｜年平均報酬%：—｜交易次數：0｜標準差：—';
         if (elements.tradeSummary) elements.tradeSummary.textContent = '尚未生成交易結果。';
         if (elements.nextDayForecast) elements.nextDayForecast.textContent = '尚未計算隔日預測。';
         if (elements.tradeTableBody) elements.tradeTableBody.innerHTML = '';
+        if (elements.toggleAllTrades) {
+            elements.toggleAllTrades.disabled = true;
+            elements.toggleAllTrades.classList.add('opacity-60', 'cursor-not-allowed');
+            elements.toggleAllTrades.textContent = '顯示全部預測紀錄';
+            elements.toggleAllTrades.setAttribute('aria-pressed', 'false');
+        }
+        const rule = getTradeRuleForModel();
+        if (elements.tradeRuleSelect) {
+            elements.tradeRuleSelect.value = rule;
+        }
+        updateTradeRuleDescription(rule);
+        updateVolatilityDiagnosticsDisplay(null, getActiveModelState()?.classification);
     };
 
     const updateSummaryMetrics = (summary) => {
         if (!summary) return;
+        const activeClassification = normalizeClassificationMode(summary.classificationMode || getActiveModelState()?.classification);
+        updateTradeRuleDescription(summary.tradeRule || getTradeRuleForModel());
+        if (elements.tradeRuleSelect && summary.tradeRule) {
+            elements.tradeRuleSelect.value = normalizeTradeRule(summary.tradeRule);
+        }
+        if (elements.fixedFraction) {
+            syncFractionInputDisplay(summary.fixedFraction);
+        }
         if (elements.trainAccuracy) elements.trainAccuracy.textContent = formatPercent(summary.trainAccuracy, 2);
         if (elements.trainLoss) elements.trainLoss.textContent = `Loss：${formatNumber(summary.trainLoss, 4)}`;
         if (elements.testAccuracy) elements.testAccuracy.textContent = formatPercent(summary.testAccuracy, 2);
+        if (elements.testAccuracyLabel) {
+            const accuracyLabel = summary.testAccuracyLabel
+                || (activeClassification === CLASSIFICATION_MODES.MULTICLASS ? '大漲命中率' : '測試期預測正確率');
+            elements.testAccuracyLabel.textContent = accuracyLabel;
+        }
         if (elements.testLoss) elements.testLoss.textContent = `Loss：${formatNumber(summary.testLoss, 4)}`;
         if (elements.tradeCount) elements.tradeCount.textContent = Number.isFinite(summary.executedTrades) ? summary.executedTrades : '—';
         if (elements.hitRate) {
-            const thresholdPercent = Number.isFinite(summary.threshold) ? `${Math.round(summary.threshold * 100)}%` : '—';
+            const thresholdValue = Number.isFinite(summary.threshold)
+                ? summary.threshold
+                : getDefaultWinThresholdForMode(activeClassification);
+            const thresholdPercent = Number.isFinite(thresholdValue)
+                ? `${Math.round(thresholdValue * 100)}%`
+                : '—';
             elements.hitRate.textContent = `命中率：${formatPercent(summary.hitRate, 2)}｜勝率門檻：${thresholdPercent}`;
         }
         if (elements.totalReturn) elements.totalReturn.textContent = formatPercent(summary.tradeReturnMedian, 2);
         if (elements.averageProfit) {
             const stdText = formatPercent(summary.tradeReturnStdDev, 2);
-            elements.averageProfit.textContent = `平均報酬%：${formatPercent(summary.tradeReturnAverage, 2)}｜交易次數：${Number.isFinite(summary.executedTrades) ? summary.executedTrades : 0}｜標準差：${stdText}`;
+            const singleText = formatPercent(Number.isFinite(summary.tradeReturnAverageSingle)
+                ? summary.tradeReturnAverageSingle
+                : summary.tradeReturnAverage, 2);
+            const monthlyText = formatPercent(summary.tradeReturnAverageMonthly, 2);
+            const yearlyText = formatPercent(summary.tradeReturnAverageYearly, 2);
+            const tradeCount = Number.isFinite(summary.executedTrades) ? summary.executedTrades : 0;
+            const aiWinText = formatPercent(summary.testAccuracy, 2);
+            const buyHoldAnnualText = formatPercent(summary.buyHoldAnnualized, 2);
+            elements.averageProfit.textContent = `AI勝率：${aiWinText}｜單次平均報酬%：${singleText}｜月平均報酬%：${monthlyText}｜年平均報酬%：${yearlyText}｜買入持有年化報酬%：${buyHoldAnnualText}｜交易次數：${tradeCount}｜標準差：${stdText}`;
         }
         if (elements.tradeSummary) {
             const strategyLabel = summary.usingKelly
                 ? '已啟用凱利公式'
                 : `固定投入 ${formatPercent(summary.fixedFraction, 2)}`;
             const medianText = formatPercent(summary.tradeReturnMedian, 2);
-            const averageText = formatPercent(summary.tradeReturnAverage, 2);
-            elements.tradeSummary.textContent = `共評估 ${summary.totalPredictions} 筆測試樣本，勝率門檻設定為 ${Math.round((summary.threshold || 0.5) * 100)}%，執行 ${summary.executedTrades} 筆交易，${strategyLabel}。交易報酬% 中位數 ${medianText}，平均報酬% ${averageText}。`;
+            const singleText = formatPercent(Number.isFinite(summary.tradeReturnAverageSingle)
+                ? summary.tradeReturnAverageSingle
+                : summary.tradeReturnAverage, 2);
+            const monthlyText = formatPercent(summary.tradeReturnAverageMonthly, 2);
+            const yearlyText = formatPercent(summary.tradeReturnAverageYearly, 2);
+            const totalText = Number.isFinite(summary.tradeReturnTotal)
+                ? formatPercent(summary.tradeReturnTotal, 2)
+                : null;
+            const totalPredictions = Number.isFinite(summary.totalPredictions) ? summary.totalPredictions : 0;
+            const executedCount = Number.isFinite(summary.executedTrades) ? summary.executedTrades : 0;
+            const periodClause = summary.tradePeriodStart && summary.tradePeriodEnd
+                ? `測試期間 ${summary.tradePeriodStart} ~ ${summary.tradePeriodEnd}，`
+                : '';
+            const totalClause = totalText ? `交易報酬% 總和 ${totalText}，` : '';
+            const aiWinText = formatPercent(summary.testAccuracy, 2);
+            const buyHoldAnnualText = formatPercent(summary.buyHoldAnnualized, 2);
+            const thresholdValue = Number.isFinite(summary.threshold)
+                ? summary.threshold
+                : getDefaultWinThresholdForMode(activeClassification);
+            elements.tradeSummary.textContent = `${periodClause}共評估 ${totalPredictions} 筆測試樣本，勝率門檻設定為 ${Math.round(thresholdValue * 100)}%，執行 ${executedCount} 筆交易，${strategyLabel}。${totalClause}交易報酬% 中位數 ${medianText}，單次平均報酬% ${singleText}，月平均報酬% ${monthlyText}，年平均報酬% ${yearlyText}，AI勝率 ${aiWinText}，買入持有年化報酬% ${buyHoldAnnualText}。`;
         }
         if (elements.nextDayForecast) {
             const threshold = Number.isFinite(summary.threshold) ? summary.threshold : parseWinThreshold();
@@ -605,56 +1890,391 @@
                 const kellyText = summary.usingKelly && Number.isFinite(forecast.fraction)
                     ? `凱利公式建議投入比例約 ${formatPercent(forecast.fraction, 2)}。`
                     : '';
-                elements.nextDayForecast.textContent = `${baseLabel} 的隔日上漲機率為 ${formatPercent(forecast.probability, 1)}；勝率門檻 ${Math.round(threshold * 100)}%，${meetsThreshold}${kellyText}`;
+                const classLabel = forecast.classLabel || formatClassLabel(forecast.predictedClass ?? (forecast.probability >= threshold ? 2 : 1), activeClassification);
+                elements.nextDayForecast.textContent = `${baseLabel} 的隔日大漲機率為 ${formatPercent(forecast.probability, 1)}（預測分類：${classLabel}）；勝率門檻 ${Math.round(threshold * 100)}%，${meetsThreshold}${kellyText}`;
             }
         }
+        updateVolatilityDiagnosticsDisplay(summary.volatilityDiagnostics, activeClassification);
     };
 
     const computeTradeOutcomes = (payload, options, trainingOdds) => {
         const predictions = Array.isArray(payload?.predictions) ? payload.predictions : [];
         const meta = Array.isArray(payload?.meta) ? payload.meta : [];
         const returns = Array.isArray(payload?.returns) ? payload.returns : [];
-        const threshold = Number.isFinite(options.threshold) ? options.threshold : 0.5;
+        const classificationMode = normalizeClassificationMode(payload?.classificationMode || payload?.hyperparameters?.classificationMode);
+        const defaultThreshold = getDefaultWinThresholdForMode(classificationMode);
+        const threshold = Number.isFinite(options.threshold) ? options.threshold : defaultThreshold;
         const useKelly = Boolean(options.useKelly);
         const fixedFraction = sanitizeFraction(options.fixedFraction);
+        const tradeRule = normalizeTradeRule(options.tradeRule);
+        const volatilityThresholds = sanitizeVolatilityThresholds(options.volatilityThresholds || payload?.volatilityThresholds || DEFAULT_VOLATILITY_THRESHOLDS);
+        const volatilityBounds = resolveVolatilityBounds(volatilityThresholds);
+        const volatilityUpper = volatilityBounds.upper;
+        const volatilityLower = volatilityBounds.lower;
 
         const executedTrades = [];
         const tradeReturns = [];
+        const executedDateValues = [];
+        const dailyRecords = [];
         let wins = 0;
 
-        for (let i = 0; i < predictions.length; i += 1) {
-            const probability = Number(predictions[i]);
-            const metaItem = meta[i];
-            const actualReturn = returns[i];
-            if (!Number.isFinite(probability) || !metaItem || !Number.isFinite(actualReturn)) {
-                continue;
+        const parseDateToUTC = (value) => {
+            if (typeof value !== 'string' || !value) return NaN;
+            const isoCandidate = value.length <= 10 ? `${value}T00:00:00Z` : value;
+            const timestamp = Date.parse(isoCandidate);
+            if (Number.isFinite(timestamp)) {
+                return timestamp;
             }
-            if (probability < threshold) {
-                continue;
+            const fallback = Date.parse(value);
+            return Number.isFinite(fallback) ? fallback : NaN;
+        };
+
+        if (tradeRule === 'volatility-tier') {
+            let position = null;
+            for (let i = 0; i < predictions.length; i += 1) {
+                const metaItem = meta[i] || {};
+                const parsed = parsePredictionEntry(predictions[i], classificationMode);
+                const classIndex = parsed.classIndex;
+                const entryProbability = parsed.pUp;
+                const exitProbability = parsed.pDown;
+                const dayClose = Number(metaItem.buyClose);
+                const nextClose = Number(metaItem.sellClose);
+                const exitDateCandidate = metaItem.sellDate || metaItem.tradeDate || metaItem.buyDate || null;
+                const entryDateCandidate = metaItem.buyDate || metaItem.tradeDate || metaItem.sellDate || exitDateCandidate;
+
+                if (position && Number.isFinite(dayClose) && dayClose > 0) {
+                    position.lastPrice = dayClose;
+                }
+
+                const baseBuyPrice = Number.isFinite(metaItem.closeSameDayBuyPrice) && metaItem.closeSameDayBuyPrice > 0
+                    ? metaItem.closeSameDayBuyPrice
+                    : (Number.isFinite(metaItem.buyClose) ? metaItem.buyClose : NaN);
+                const baseSellPrice = Number.isFinite(metaItem.sellPrice)
+                    ? metaItem.sellPrice
+                    : (Number.isFinite(metaItem.sellClose) ? metaItem.sellClose : NaN);
+                const baseReturn = Number.isFinite(metaItem.swingReturn)
+                    ? metaItem.swingReturn
+                    : (Number.isFinite(metaItem.closeSameDayReturn)
+                        ? metaItem.closeSameDayReturn
+                        : (Number.isFinite(metaItem.actualReturn) ? metaItem.actualReturn : NaN));
+                const entryEligible = Boolean(typeof metaItem.closeSameDayEligible === 'boolean'
+                    ? metaItem.closeSameDayEligible
+                    : (Number.isFinite(baseBuyPrice) && Number.isFinite(baseSellPrice)));
+                const recordIndex = dailyRecords.length;
+                const record = {
+                    buyDate: entryDateCandidate || metaItem.buyDate || null,
+                    sellDate: exitDateCandidate || metaItem.sellDate || entryDateCandidate || null,
+                    tradeDate: exitDateCandidate || entryDateCandidate || null,
+                    probability: entryProbability,
+                    predictedClass: classIndex,
+                    predictedClassLabel: formatClassLabel(classIndex, classificationMode),
+                    classificationMode,
+                    tradeRule,
+                    entryEligible,
+                    executed: false,
+                    triggered: entryProbability >= threshold && classIndex === 2,
+                    buyPrice: Number.isFinite(baseBuyPrice) ? baseBuyPrice : NaN,
+                    sellPrice: Number.isFinite(baseSellPrice) ? baseSellPrice : NaN,
+                    actualReturn: Number.isFinite(baseReturn) ? baseReturn : NaN,
+                    fraction: 0,
+                    tradeReturn: 0,
+                    holdDays: 1,
+                    probabilities: parsed.probabilities,
+                    exitClass: classIndex,
+                    volatilityUpper,
+                    volatilityLower,
+                };
+
+                let openedThisBar = false;
+                if (!position && record.triggered && entryEligible && Number.isFinite(baseBuyPrice) && baseBuyPrice > 0) {
+                    const fraction = useKelly
+                        ? computeKellyFraction(entryProbability, trainingOdds)
+                        : fixedFraction;
+                    position = {
+                        entryIndex: i,
+                        entryRecordIndex: recordIndex,
+                        entryDate: entryDateCandidate,
+                        entrySellDateCandidate: exitDateCandidate,
+                        entryPrice: baseBuyPrice,
+                        entryProbability,
+                        entryClassIndex: classIndex,
+                        fraction,
+                        holdDays: 0,
+                        lastPrice: Number.isFinite(nextClose) && nextClose > 0
+                            ? nextClose
+                            : (Number.isFinite(dayClose) && dayClose > 0 ? dayClose : baseBuyPrice),
+                    };
+                    record.executed = true;
+                    record.fraction = fraction;
+                    openedThisBar = true;
+                }
+
+                const exitSignal = classIndex === 0 && exitProbability >= threshold;
+                const isLastSample = i === predictions.length - 1;
+                if (position && !openedThisBar && (exitSignal || isLastSample)) {
+                    let exitPrice = position.lastPrice;
+                    let exitDate = exitDateCandidate || entryDateCandidate;
+                    if (exitSignal) {
+                        if (Number.isFinite(dayClose) && dayClose > 0) {
+                            exitPrice = dayClose;
+                        }
+                        exitDate = entryDateCandidate || exitDateCandidate;
+                    } else if (Number.isFinite(nextClose) && nextClose > 0) {
+                        exitPrice = nextClose;
+                    }
+
+                    if (Number.isFinite(exitPrice) && exitPrice > 0 && Number.isFinite(position.entryPrice) && position.entryPrice > 0) {
+                        const grossReturn = (exitPrice - position.entryPrice) / position.entryPrice;
+                        const fraction = Number.isFinite(position.fraction)
+                            ? position.fraction
+                            : (useKelly ? computeKellyFraction(position.entryProbability, trainingOdds) : fixedFraction);
+                        const tradeReturn = grossReturn * fraction;
+                        if (grossReturn > 0) {
+                            wins += 1;
+                        }
+                        const tradeTimestamp = parseDateToUTC(exitDate);
+                        if (Number.isFinite(tradeTimestamp)) {
+                            executedDateValues.push(tradeTimestamp);
+                        }
+                        executedTrades.push({
+                            buyDate: position.entryDate,
+                            sellDate: exitDate,
+                            tradeDate: exitDate,
+                            probability: position.entryProbability,
+                            actualReturn: grossReturn,
+                            fraction,
+                            tradeReturn,
+                            buyPrice: position.entryPrice,
+                            sellPrice: exitPrice,
+                            tradeRule,
+                            predictedClass: position.entryClassIndex,
+                            predictedClassLabel: formatClassLabel(position.entryClassIndex, classificationMode),
+                            exitClass: classIndex,
+                            holdDays: position.holdDays + 1,
+                            probabilities: parsed.probabilities,
+                            classificationMode,
+                            executed: true,
+                            volatilityUpper,
+                            volatilityLower,
+                        });
+                        tradeReturns.push(tradeReturn);
+                        record.executed = true;
+                        record.triggered = record.triggered || exitSignal || isLastSample;
+                        record.buyDate = position.entryDate || record.buyDate;
+                        record.sellDate = exitDate || record.sellDate;
+                        record.tradeDate = exitDate || record.tradeDate;
+                        record.buyPrice = position.entryPrice;
+                        record.sellPrice = exitPrice;
+                        record.actualReturn = grossReturn;
+                        record.fraction = fraction;
+                        record.tradeReturn = tradeReturn;
+                        record.holdDays = position.holdDays + 1;
+                        const entryRecord = dailyRecords[position.entryRecordIndex];
+                        if (entryRecord) {
+                            entryRecord.sellDate = exitDate || entryRecord.sellDate;
+                            entryRecord.sellPrice = exitPrice;
+                            entryRecord.actualReturn = grossReturn;
+                            entryRecord.tradeReturn = tradeReturn;
+                            entryRecord.holdDays = position.holdDays + 1;
+                            entryRecord.executed = true;
+                        }
+                    }
+                    position = null;
+                } else if (position) {
+                    position.holdDays += 1;
+                    if (Number.isFinite(nextClose) && nextClose > 0) {
+                        position.lastPrice = nextClose;
+                    }
+                }
+
+                dailyRecords.push(record);
             }
-            const tradeDate = typeof metaItem.sellDate === 'string' && metaItem.sellDate
-                ? metaItem.sellDate
-                : (typeof metaItem.tradeDate === 'string' && metaItem.tradeDate
-                    ? metaItem.tradeDate
-                    : (typeof metaItem.date === 'string' && metaItem.date ? metaItem.date : null));
-            if (!tradeDate) {
-                continue;
+        } else {
+            for (let i = 0; i < predictions.length; i += 1) {
+                const parsed = parsePredictionEntry(predictions[i], classificationMode);
+                const probability = parsed.pUp;
+                const classIndex = parsed.classIndex;
+                const meetsClassRequirement = classificationMode === CLASSIFICATION_MODES.MULTICLASS ? classIndex === 2 : true;
+                const metaItem = meta[i] || {};
+                if (!Number.isFinite(probability)) {
+                    continue;
+                }
+
+                const baseSellPrice = Number.isFinite(metaItem.sellPrice)
+                    ? metaItem.sellPrice
+                    : (Number.isFinite(metaItem.sellClose) ? metaItem.sellClose : NaN);
+                let resolvedBuyPrice = NaN;
+                let resolvedSellPrice = baseSellPrice;
+                let entryEligible;
+                let actualReturn;
+                const buyDate = metaItem.buyDate || metaItem.tradeDate || null;
+                const sellDate = metaItem.sellDate || metaItem.tradeDate || null;
+
+                if (tradeRule === 'open-entry') {
+                    const openEligible = typeof metaItem.openEntryEligible === 'boolean'
+                        ? metaItem.openEntryEligible
+                        : null;
+                    resolvedBuyPrice = Number(metaItem.openEntryBuyPrice);
+                    if (!Number.isFinite(resolvedBuyPrice) || resolvedBuyPrice <= 0) {
+                        const nextOpen = Number(metaItem.nextOpen);
+                        if (Number.isFinite(nextOpen) && nextOpen > 0) {
+                            resolvedBuyPrice = nextOpen;
+                        } else if (Number.isFinite(metaItem.buyPrice) && metaItem.buyPrice > 0) {
+                            resolvedBuyPrice = metaItem.buyPrice;
+                        }
+                    }
+                    if (!Number.isFinite(resolvedSellPrice)) {
+                        const openSell = Number(metaItem.openEntrySellPrice);
+                        if (Number.isFinite(openSell)) {
+                            resolvedSellPrice = openSell;
+                        }
+                    }
+                    actualReturn = Number(metaItem.openEntryReturn);
+                    entryEligible = typeof openEligible === 'boolean'
+                        ? openEligible
+                        : (Number.isFinite(resolvedBuyPrice) && resolvedBuyPrice > 0 && Number.isFinite(resolvedSellPrice));
+                } else if (tradeRule === 'close-entry') {
+                    const prevClose = Number(metaItem.buyClose);
+                    const sameDayEligible = typeof metaItem.closeSameDayEligible === 'boolean'
+                        ? metaItem.closeSameDayEligible
+                        : null;
+                    if (typeof sameDayEligible === 'boolean') {
+                        entryEligible = sameDayEligible;
+                    } else {
+                        entryEligible = Number.isFinite(prevClose) && prevClose > 0 && Number.isFinite(resolvedSellPrice);
+                    }
+                    resolvedBuyPrice = Number(metaItem.closeSameDayBuyPrice);
+                    if (!Number.isFinite(resolvedBuyPrice) || resolvedBuyPrice <= 0) {
+                        if (Number.isFinite(prevClose) && prevClose > 0) {
+                            resolvedBuyPrice = prevClose;
+                        } else if (Number.isFinite(metaItem.buyPrice) && metaItem.buyPrice > 0) {
+                            resolvedBuyPrice = metaItem.buyPrice;
+                        }
+                    }
+                    if (!Number.isFinite(resolvedSellPrice)) {
+                        const sameDaySell = Number(metaItem.closeSameDaySellPrice);
+                        if (Number.isFinite(sameDaySell)) {
+                            resolvedSellPrice = sameDaySell;
+                        }
+                    }
+                    actualReturn = Number(metaItem.closeSameDayReturn);
+                    if (!Number.isFinite(actualReturn) && Number.isFinite(prevClose) && prevClose > 0 && Number.isFinite(resolvedSellPrice)) {
+                        actualReturn = (resolvedSellPrice - prevClose) / prevClose;
+                    }
+                } else {
+                    const prevClose = Number(metaItem.buyClose);
+                    const nextLow = Number(metaItem.nextLow);
+                    const closeEligible = typeof metaItem.closeEntryEligible === 'boolean'
+                        ? metaItem.closeEntryEligible
+                        : (typeof metaItem.entryEligible === 'boolean' ? metaItem.entryEligible : null);
+                    if (closeEligible === null) {
+                        entryEligible = Number.isFinite(nextLow) && Number.isFinite(prevClose)
+                            ? nextLow < prevClose
+                            : true;
+                    } else {
+                        entryEligible = closeEligible;
+                    }
+                    resolvedBuyPrice = Number(metaItem.closeEntryBuyPrice);
+                    if (!Number.isFinite(resolvedBuyPrice) || resolvedBuyPrice <= 0) {
+                        if (Number.isFinite(metaItem.buyPrice) && metaItem.buyPrice > 0) {
+                            resolvedBuyPrice = metaItem.buyPrice;
+                        } else if (Number.isFinite(prevClose)) {
+                            const nextOpen = Number(metaItem.nextOpen);
+                            if (Number.isFinite(nextOpen) && nextOpen < prevClose) {
+                                resolvedBuyPrice = nextOpen;
+                            } else {
+                                resolvedBuyPrice = prevClose;
+                            }
+                        }
+                    }
+                    actualReturn = Number(returns[i]);
+                    if (!Number.isFinite(actualReturn)) {
+                        actualReturn = Number(metaItem.closeEntryReturn);
+                    }
+                    if (!Number.isFinite(actualReturn)) {
+                        actualReturn = Number(metaItem.actualReturn);
+                    }
+                }
+
+                if (typeof entryEligible !== 'boolean') {
+                    entryEligible = true;
+                }
+
+                if (!Number.isFinite(resolvedSellPrice)) {
+                    resolvedSellPrice = Number(metaItem.sellClose);
+                }
+
+                if (!Number.isFinite(actualReturn) && Number.isFinite(resolvedBuyPrice) && resolvedBuyPrice > 0 && Number.isFinite(resolvedSellPrice)) {
+                    actualReturn = (resolvedSellPrice - resolvedBuyPrice) / resolvedBuyPrice;
+                }
+
+                const tradeDate = sellDate || metaItem.tradeDate || metaItem.date || buyDate || null;
+                const triggered = probability >= threshold && meetsClassRequirement;
+                const executed = Boolean(triggered
+                    && entryEligible
+                    && Number.isFinite(resolvedBuyPrice) && resolvedBuyPrice > 0
+                    && Number.isFinite(resolvedSellPrice));
+                let fraction = 0;
+                let tradeReturn = 0;
+                if (executed && Number.isFinite(actualReturn)) {
+                    fraction = useKelly
+                        ? computeKellyFraction(probability, trainingOdds)
+                        : fixedFraction;
+                    tradeReturn = actualReturn * fraction;
+                    if (actualReturn > 0) {
+                        wins += 1;
+                    }
+                    if (tradeDate) {
+                        const tradeTimestamp = parseDateToUTC(tradeDate);
+                        if (Number.isFinite(tradeTimestamp)) {
+                            executedDateValues.push(tradeTimestamp);
+                        }
+                    }
+                    executedTrades.push({
+                        buyDate,
+                        sellDate: tradeDate,
+                        tradeDate,
+                        probability,
+                        actualReturn,
+                        fraction,
+                        tradeReturn,
+                        buyPrice: resolvedBuyPrice,
+                        sellPrice: resolvedSellPrice,
+                        tradeRule,
+                        predictedClass: classIndex,
+                        predictedClassLabel: formatClassLabel(classIndex, classificationMode),
+                        probabilities: parsed.probabilities,
+                        classificationMode,
+                        executed: true,
+                        volatilityUpper,
+                        volatilityLower,
+                    });
+                    tradeReturns.push(tradeReturn);
+                }
+
+                dailyRecords.push({
+                    buyDate,
+                    sellDate: tradeDate || sellDate,
+                    tradeDate: tradeDate || sellDate,
+                    probability,
+                    predictedClass: parsed.classIndex,
+                    predictedClassLabel: formatClassLabel(parsed.classIndex, classificationMode),
+                    classificationMode,
+                    tradeRule,
+                    entryEligible,
+                    executed,
+                    triggered,
+                    buyPrice: Number.isFinite(resolvedBuyPrice) ? resolvedBuyPrice : NaN,
+                    sellPrice: Number.isFinite(resolvedSellPrice) ? resolvedSellPrice : NaN,
+                    actualReturn: Number.isFinite(actualReturn) ? actualReturn : NaN,
+                    fraction,
+                    tradeReturn,
+                    holdDays: 1,
+                    probabilities: parsed.probabilities,
+                    volatilityUpper,
+                    volatilityLower,
+                });
             }
-            const fraction = useKelly
-                ? computeKellyFraction(probability, trainingOdds)
-                : fixedFraction;
-            const tradeReturn = actualReturn * fraction;
-            if (actualReturn > 0) {
-                wins += 1;
-            }
-            executedTrades.push({
-                tradeDate,
-                probability,
-                actualReturn,
-                fraction,
-                tradeReturn,
-            });
-            tradeReturns.push(tradeReturn);
         }
 
         const executed = executedTrades.length;
@@ -662,6 +2282,68 @@
         const median = tradeReturns.length > 0 ? computeMedian(tradeReturns) : NaN;
         const average = tradeReturns.length > 0 ? computeMean(tradeReturns) : NaN;
         const stdDev = tradeReturns.length > 1 ? computeStd(tradeReturns, average) : NaN;
+        const totalReturn = tradeReturns.reduce((acc, value) => acc + value, 0);
+
+        const metaDates = meta
+            .map((item) => parseDateToUTC(item?.sellDate || item?.tradeDate || item?.date || item?.buyDate))
+            .filter((value) => Number.isFinite(value));
+        const dateCandidates = metaDates.length > 0 ? metaDates : executedDateValues;
+        let averageMonthly = NaN;
+        let averageYearly = NaN;
+        let periodStart = null;
+        let periodEnd = null;
+        let periodMonths = NaN;
+        let periodYears = NaN;
+        if (dateCandidates.length > 0) {
+            const minTime = Math.min(...dateCandidates);
+            const maxTime = Math.max(...dateCandidates);
+            if (Number.isFinite(minTime) && Number.isFinite(maxTime) && maxTime >= minTime) {
+                const diffMs = Math.max(0, maxTime - minTime);
+                const diffDays = Math.max(1, (diffMs / DAY_MS) + 1);
+                periodMonths = diffDays / 30.4375;
+                periodYears = diffDays / 365.25;
+                if (periodMonths > 0) {
+                    averageMonthly = totalReturn / periodMonths;
+                }
+                if (periodYears > 0) {
+                    averageYearly = totalReturn / periodYears;
+                }
+                periodStart = new Date(minTime).toISOString().slice(0, 10);
+                periodEnd = new Date(maxTime).toISOString().slice(0, 10);
+            }
+        }
+
+        let buyHoldReturn = NaN;
+        let buyHoldAnnualized = NaN;
+        if (meta.length > 0) {
+            let firstClose = NaN;
+            for (let i = 0; i < meta.length; i += 1) {
+                const candidate = Number(meta[i]?.buyClose);
+                if (Number.isFinite(candidate) && candidate > 0) {
+                    firstClose = candidate;
+                    break;
+                }
+            }
+            let lastClose = NaN;
+            for (let i = meta.length - 1; i >= 0; i -= 1) {
+                const sellCandidate = Number(meta[i]?.sellClose);
+                if (Number.isFinite(sellCandidate) && sellCandidate > 0) {
+                    lastClose = sellCandidate;
+                    break;
+                }
+                const fallbackSell = Number(meta[i]?.sellPrice);
+                if (Number.isFinite(fallbackSell) && fallbackSell > 0) {
+                    lastClose = fallbackSell;
+                    break;
+                }
+            }
+            if (Number.isFinite(firstClose) && Number.isFinite(lastClose) && firstClose > 0) {
+                buyHoldReturn = (lastClose - firstClose) / firstClose;
+                if (Number.isFinite(periodYears) && periodYears > 0) {
+                    buyHoldAnnualized = ((1 + buyHoldReturn) ** (1 / periodYears)) - 1;
+                }
+            }
+        }
 
         return {
             trades: executedTrades,
@@ -671,7 +2353,19 @@
                 median,
                 average,
                 stdDev,
+                total: totalReturn,
+                averageMonthly,
+                averageYearly,
+                periodStart,
+                periodEnd,
+                periodMonths,
+                periodYears,
+                buyHoldReturn,
+                buyHoldAnnualized,
             },
+            rule: tradeRule,
+            volatilityThresholds,
+            allRecords: dailyRecords,
         };
     };
 
@@ -687,15 +2381,45 @@
         };
         const fallbackOdds = Number.isFinite(modelState.odds) ? modelState.odds : 1;
         const trainingOdds = Number.isFinite(payload.trainingOdds) ? payload.trainingOdds : fallbackOdds;
-        const evaluation = computeTradeOutcomes(payload, options, trainingOdds);
+        const selectedRule = normalizeTradeRule(options.tradeRule);
+        const sanitizedFixedFraction = sanitizeFraction(options.fixedFraction);
+        const resolvedVolatility = sanitizeVolatilityThresholds(options.volatilityThresholds || modelState.volatilityThresholds);
+        modelState.volatilityThresholds = resolvedVolatility;
+        const classificationMode = normalizeClassificationMode(payload?.classificationMode || modelState.classification);
+        const defaultThreshold = getDefaultWinThresholdForMode(classificationMode);
+        const threshold = Number.isFinite(options.threshold) ? options.threshold : defaultThreshold;
+        payload.classificationMode = classificationMode;
+        const diagnostics = payload?.volatilityDiagnostics && typeof payload.volatilityDiagnostics === 'object'
+            ? { ...payload.volatilityDiagnostics }
+            : null;
+        const evaluation = computeTradeOutcomes(payload, {
+            ...options,
+            tradeRule: selectedRule,
+            fixedFraction: sanitizedFixedFraction,
+            volatilityThresholds: resolvedVolatility,
+        }, trainingOdds);
+        const evaluationRule = normalizeTradeRule(evaluation.rule || selectedRule);
+        const allRecords = Array.isArray(evaluation.allRecords) ? evaluation.allRecords : [];
         const forecast = payload.forecast && Number.isFinite(payload.forecast?.probability)
-            ? { ...payload.forecast }
+            ? annotateForecast({ ...payload.forecast }, payload) || { ...payload.forecast }
             : null;
         if (forecast) {
+            forecast.classificationMode = classificationMode;
+            forecast.classLabel = formatClassLabel(forecast.predictedClass ?? (forecast.probability >= threshold ? 2 : 1), classificationMode);
             const forecastFraction = options.useKelly
                 ? computeKellyFraction(forecast.probability, trainingOdds)
-                : sanitizeFraction(options.fixedFraction);
+                : sanitizedFixedFraction;
             forecast.fraction = forecastFraction;
+            forecast.tradeRule = evaluationRule;
+            if (!Number.isFinite(forecast.volatilityUpper)) {
+                forecast.volatilityUpper = volatilityUpper;
+            }
+            if (!Number.isFinite(forecast.volatilityLower)) {
+                forecast.volatilityLower = volatilityLower;
+            }
+            if (evaluationRule === 'open-entry') {
+                forecast.buyPrice = Number.isFinite(forecast.buyPrice) ? NaN : forecast.buyPrice;
+            }
         }
 
         const summary = {
@@ -711,24 +2435,60 @@
             hitRate: evaluation.stats.hitRate,
             tradeReturnMedian: evaluation.stats.median,
             tradeReturnAverage: evaluation.stats.average,
+            tradeReturnAverageSingle: evaluation.stats.average,
+            tradeReturnAverageMonthly: evaluation.stats.averageMonthly,
+            tradeReturnAverageYearly: evaluation.stats.averageYearly,
+            tradeReturnTotal: evaluation.stats.total,
             tradeReturnStdDev: evaluation.stats.stdDev,
+            tradePeriodStart: evaluation.stats.periodStart,
+            tradePeriodEnd: evaluation.stats.periodEnd,
+            tradePeriodMonths: evaluation.stats.periodMonths,
+            tradePeriodYears: evaluation.stats.periodYears,
+            buyHoldReturn: evaluation.stats.buyHoldReturn,
+            buyHoldAnnualized: evaluation.stats.buyHoldAnnualized,
             usingKelly: Boolean(options.useKelly),
-            fixedFraction: sanitizeFraction(options.fixedFraction),
-            threshold: Number.isFinite(options.threshold) ? options.threshold : 0.5,
+            fixedFraction: sanitizedFixedFraction,
+            threshold: Number.isFinite(options.threshold) ? options.threshold : defaultThreshold,
+            seed: Number.isFinite(payload?.hyperparameters?.seed) ? payload.hyperparameters.seed : null,
             forecast,
+            tradeRule: evaluationRule,
+            volatilityThresholds: resolvedVolatility,
+            classificationMode,
+            testAccuracyLabel: classificationMode === CLASSIFICATION_MODES.MULTICLASS ? '大漲命中率' : '測試期預測正確率',
+            volatilityDiagnostics: diagnostics,
         };
 
         modelState.trainingMetrics = metrics;
         modelState.lastSummary = summary;
         modelState.currentTrades = evaluation.trades;
+        modelState.allPredictionRows = allRecords;
         modelState.odds = trainingOdds;
+        modelState.volatilityDiagnostics = diagnostics;
+        payload.tradeRule = evaluationRule;
+        payload.volatilityThresholds = resolvedVolatility;
+        payload.allRecords = allRecords;
+        payload.volatilityDiagnostics = diagnostics;
         modelState.predictionsPayload = payload;
+        modelState.tradeRule = evaluationRule;
+        modelState.classification = classificationMode;
+
+        applySeedDefaultName(summary, modelType);
 
         if (globalState.activeModel === modelType) {
             updateSummaryMetrics(summary);
-            renderTrades(evaluation.trades, summary.forecast);
-            applySeedDefaultName(summary);
+            if (!allRecords.length && globalState.showAllPredictions) {
+                globalState.showAllPredictions = false;
+            }
+            const rowsToRender = globalState.showAllPredictions ? allRecords : evaluation.trades;
+            renderTrades(rowsToRender, summary.forecast, globalState.showAllPredictions);
+            updateAllPredictionsToggleButton(modelState);
+            if (elements.tradeRuleSelect) {
+                elements.tradeRuleSelect.value = evaluationRule;
+            }
+        } else {
+            updateAllPredictionsToggleButton(modelState);
         }
+        updateAnnDiagnosticsButtonState();
     };
 
     const captureActiveModelSettings = () => {
@@ -739,6 +2499,9 @@
         const batchSize = Math.round(parseNumberInput(elements.batchSize, modelState.hyperparameters.batchSize, { min: 8, max: 512 }));
         const learningRate = parseNumberInput(elements.learningRate, modelState.hyperparameters.learningRate, { min: 0.0001, max: 0.05 });
         const trainRatio = parseTrainRatio();
+        const currentSeed = Number.isFinite(modelState.hyperparameters?.seed)
+            ? modelState.hyperparameters.seed
+            : null;
 
         modelState.hyperparameters = {
             lookback,
@@ -746,10 +2509,16 @@
             batchSize,
             learningRate,
             trainRatio,
+            seed: currentSeed,
         };
         modelState.winThreshold = parseWinThreshold();
         modelState.kellyEnabled = Boolean(elements.enableKelly?.checked);
-        modelState.fixedFraction = sanitizeFraction(parseNumberInput(elements.fixedFraction, modelState.fixedFraction, { min: 0.01, max: 1 }));
+        modelState.fixedFraction = readFractionFromInput(modelState.fixedFraction);
+        modelState.tradeRule = normalizeTradeRule(elements.tradeRuleSelect?.value);
+        modelState.volatilityThresholds = readVolatilityThresholdsFromInputs(modelState.volatilityThresholds);
+        if (elements.classificationMode) {
+            modelState.classification = normalizeClassificationMode(elements.classificationMode.value);
+        }
     };
 
     const applyModelSettingsToUI = (modelState) => {
@@ -758,6 +2527,10 @@
             elements.modelType.value = globalState.activeModel;
         }
         const hyper = modelState.hyperparameters || {};
+        const classificationMode = normalizeClassificationMode(modelState.classification);
+        if (elements.classificationMode) {
+            elements.classificationMode.value = classificationMode;
+        }
         if (elements.lookback) {
             elements.lookback.value = Number.isFinite(hyper.lookback) ? hyper.lookback : 20;
         }
@@ -779,32 +2552,60 @@
             elements.enableKelly.checked = Boolean(modelState.kellyEnabled);
         }
         if (elements.fixedFraction) {
-            elements.fixedFraction.value = sanitizeFraction(modelState.fixedFraction || 0.2);
+            syncFractionInputDisplay(modelState.fixedFraction ?? DEFAULT_FIXED_FRACTION);
         }
         if (elements.winThreshold) {
-            const thresholdPercent = Math.round(((Number.isFinite(modelState.winThreshold) ? modelState.winThreshold : 0.5) * 100));
+            const thresholdPercent = Math.round(resolveWinThreshold(modelState) * 100);
             elements.winThreshold.value = String(thresholdPercent);
         }
+        if (elements.tradeRuleSelect) {
+            const rule = getTradeRuleForModel(globalState.activeModel);
+            elements.tradeRuleSelect.value = rule;
+        }
+        const thresholds = sanitizeVolatilityThresholds(modelState.volatilityThresholds);
+        const percent = volatilityToPercent(thresholds);
+        if (elements.volatilitySurge) {
+            elements.volatilitySurge.value = percent.surge.toFixed(2);
+        }
+        if (elements.volatilityDrop) {
+            elements.volatilityDrop.value = percent.drop.toFixed(2);
+        }
+        updateVolatilityDiagnosticsDisplay(modelState.volatilityDiagnostics, classificationMode);
+        updateClassificationUIState(classificationMode);
         parseTrainRatio();
         parseWinThreshold();
     };
 
     const renderActiveModelOutputs = () => {
-        const modelState = getActiveModelState();
+        const modelType = globalState.activeModel;
+        const modelState = getModelState(modelType);
         if (modelState && modelState.lastSummary) {
             updateSummaryMetrics(modelState.lastSummary);
-            renderTrades(modelState.currentTrades, modelState.lastSummary.forecast);
-            applySeedDefaultName(modelState.lastSummary);
+            const hasAllRecords = Array.isArray(modelState.allPredictionRows) && modelState.allPredictionRows.length > 0;
+            if (!hasAllRecords && globalState.showAllPredictions) {
+                globalState.showAllPredictions = false;
+            }
+            const rowsToRender = globalState.showAllPredictions && hasAllRecords
+                ? modelState.allPredictionRows
+                : modelState.currentTrades;
+            renderTrades(rowsToRender, modelState.lastSummary.forecast, globalState.showAllPredictions && hasAllRecords);
+            updateAllPredictionsToggleButton(modelState);
+            applySeedDefaultName(modelState.lastSummary, modelType, { force: true });
         } else {
             resetOutputs();
-            applySeedDefaultName(null);
+            updateAllPredictionsToggleButton(modelState);
+            applySeedDefaultName(null, modelType, { force: true });
         }
+        updateAnnDiagnosticsButtonState();
     };
 
-    const runLstmModel = async (modelState, rows, hyperparameters, riskOptions) => {
+    const runLstmModel = async (modelState, rows, hyperparameters, riskOptions, runtimeOptions = {}) => {
         const modelType = MODEL_TYPES.LSTM;
         const label = formatModelLabel(modelType);
-        const dataset = buildDataset(rows, hyperparameters.lookback);
+        const classificationMode = normalizeClassificationMode(modelState.classification);
+        let resolvedVolatility = sanitizeVolatilityThresholds(riskOptions?.volatilityThresholds || modelState.volatilityThresholds);
+        modelState.volatilityThresholds = resolvedVolatility;
+        const dataset = buildDataset(rows, hyperparameters.lookback, resolvedVolatility, classificationMode);
         const minimumSamples = Math.max(45, hyperparameters.lookback * 3);
         if (dataset.sequences.length < minimumSamples) {
             showStatus(`[${label}] 資料樣本不足（需至少 ${minimumSamples} 筆有效樣本，目前 ${dataset.sequences.length} 筆），請延長回測期間。`, 'warning');
@@ -825,8 +2626,58 @@
             showStatus(`[${label}] 批次大小 ${hyperparameters.batchSize} 大於訓練樣本數 ${boundedTrainSize}，已自動調整為 ${effectiveBatchSize}。`, 'warning');
         }
 
+        const sampleCount = dataset.sequences.length;
+        const datasetLabels = new Array(sampleCount);
+        let recalibratedVolatility = resolvedVolatility;
+        let volatilityDiagnostics = null;
+        if (classificationMode === CLASSIFICATION_MODES.BINARY) {
+            for (let i = 0; i < sampleCount; i += 1) {
+                const metaItem = dataset.meta[i] || {};
+                const actualReturn = Number.isFinite(metaItem?.actualReturn)
+                    ? metaItem.actualReturn
+                    : dataset.returns[i];
+                const label = Number(actualReturn > 0);
+                datasetLabels[i] = label;
+                if (metaItem) {
+                    metaItem.classLabel = label;
+                }
+            }
+        } else {
+            const swingTargets = Array.isArray(dataset.swingTargets)
+                ? dataset.swingTargets
+                : dataset.meta.map((item) => Number(item?.swingReturn));
+            const trainingSwings = swingTargets
+                .slice(0, boundedTrainSize)
+                .filter((value) => Number.isFinite(value));
+            const diagnosticsPayload = {};
+            recalibratedVolatility = deriveVolatilityThresholdsFromReturns(trainingSwings, resolvedVolatility, diagnosticsPayload);
+            diagnosticsPayload.expectedTrainSamples = trainingSwings.length;
+            volatilityDiagnostics = diagnosticsPayload;
+            for (let i = 0; i < sampleCount; i += 1) {
+                const metaItem = dataset.meta[i] || {};
+                const swingValue = Number.isFinite(swingTargets[i])
+                    ? swingTargets[i]
+                    : Number(metaItem?.swingReturn);
+                const label = classifySwingReturn(swingValue, recalibratedVolatility);
+                datasetLabels[i] = label;
+                if (metaItem) {
+                    metaItem.classLabel = label;
+                }
+            }
+        }
+        dataset.labels = datasetLabels;
+        dataset.volatilityThresholds = recalibratedVolatility;
+        dataset.volatilityDiagnostics = volatilityDiagnostics;
+        resolvedVolatility = recalibratedVolatility;
+        modelState.volatilityThresholds = resolvedVolatility;
+        modelState.volatilityDiagnostics = volatilityDiagnostics;
+
+        const requestedSeed = Number.isFinite(runtimeOptions?.seedOverride)
+            ? Math.max(1, Math.round(runtimeOptions.seedOverride))
+            : (Number.isFinite(hyperparameters.seed) ? Math.max(1, Math.round(hyperparameters.seed)) : null);
+
         showStatus(`[${label}] 訓練中（共 ${hyperparameters.epochs} 輪）...`, 'info');
-        const workerResult = await sendAIWorkerTrainingTask('ai-train-lstm', {
+        const workerPayload = {
             dataset,
             hyperparameters: {
                 lookback: hyperparameters.lookback,
@@ -836,8 +2687,15 @@
                 totalSamples,
                 trainSize: boundedTrainSize,
                 trainRatio: hyperparameters.trainRatio,
+                seed: Number.isFinite(requestedSeed) ? requestedSeed : (Number.isFinite(hyperparameters.seed) ? hyperparameters.seed : null),
+                volatility: resolvedVolatility,
+                classificationMode,
             },
-        }, { modelType });
+        };
+        if (Number.isFinite(requestedSeed)) {
+            workerPayload.overrides = { seed: requestedSeed };
+        }
+        const workerResult = await sendAIWorkerTrainingTask('ai-train-lstm', workerPayload, { modelType });
 
         const resultModelType = workerResult.modelType || modelType;
         const trainingMetrics = workerResult?.trainingMetrics || {
@@ -848,36 +2706,74 @@
             totalPredictions: 0,
         };
         const predictionsPayload = workerResult?.predictionsPayload || null;
+        const hyperparametersUsed = workerResult?.hyperparametersUsed && typeof workerResult.hyperparametersUsed === 'object'
+            ? workerResult.hyperparametersUsed
+            : null;
         if (!predictionsPayload || !Array.isArray(predictionsPayload.predictions)) {
             throw new Error('AI Worker 未回傳有效的預測結果。');
         }
 
-        predictionsPayload.hyperparameters = {
-            lookback: hyperparameters.lookback,
-            epochs: hyperparameters.epochs,
-            batchSize: effectiveBatchSize,
-            learningRate: hyperparameters.learningRate,
-            trainRatio: hyperparameters.trainRatio,
+        const resolvedHyper = {
+            lookback: Number.isFinite(hyperparametersUsed?.lookback) ? hyperparametersUsed.lookback : hyperparameters.lookback,
+            epochs: Number.isFinite(hyperparametersUsed?.epochs) ? hyperparametersUsed.epochs : hyperparameters.epochs,
+            batchSize: Number.isFinite(hyperparametersUsed?.batchSize) ? hyperparametersUsed.batchSize : effectiveBatchSize,
+            learningRate: Number.isFinite(hyperparametersUsed?.learningRate) ? hyperparametersUsed.learningRate : hyperparameters.learningRate,
+            trainRatio: Number.isFinite(hyperparametersUsed?.trainRatio) ? hyperparametersUsed.trainRatio : hyperparameters.trainRatio,
             modelType: resultModelType,
+            splitIndex: Number.isFinite(hyperparametersUsed?.splitIndex) ? hyperparametersUsed.splitIndex : (predictionsPayload.hyperparameters?.splitIndex ?? boundedTrainSize),
+            threshold: Number.isFinite(hyperparametersUsed?.threshold)
+                ? hyperparametersUsed.threshold
+                : (Number.isFinite(predictionsPayload.hyperparameters?.threshold)
+                    ? predictionsPayload.hyperparameters.threshold
+                    : getDefaultWinThresholdForMode(classificationMode)),
+            seed: Number.isFinite(hyperparametersUsed?.seed)
+                ? hyperparametersUsed.seed
+                : (Number.isFinite(requestedSeed) ? requestedSeed : (Number.isFinite(hyperparameters.seed) ? hyperparameters.seed : null)),
+            classificationMode,
         };
+
+        predictionsPayload.hyperparameters = { ...resolvedHyper, volatility: resolvedVolatility };
+        predictionsPayload.volatilityThresholds = resolvedVolatility;
+        predictionsPayload.classificationMode = classificationMode;
+        if (!predictionsPayload.volatilityDiagnostics && volatilityDiagnostics) {
+            predictionsPayload.volatilityDiagnostics = { ...volatilityDiagnostics };
+        }
 
         modelState.hyperparameters = {
-            lookback: hyperparameters.lookback,
-            epochs: hyperparameters.epochs,
-            batchSize: effectiveBatchSize,
-            learningRate: hyperparameters.learningRate,
-            trainRatio: hyperparameters.trainRatio,
+            lookback: resolvedHyper.lookback,
+            epochs: resolvedHyper.epochs,
+            batchSize: resolvedHyper.batchSize,
+            learningRate: resolvedHyper.learningRate,
+            trainRatio: resolvedHyper.trainRatio,
+            seed: resolvedHyper.seed,
         };
 
-        applyTradeEvaluation(resultModelType, predictionsPayload, trainingMetrics, riskOptions);
+        modelState.winThreshold = resolvedHyper.threshold;
+
+        const evaluationOptions = {
+            ...riskOptions,
+            threshold: resolvedHyper.threshold,
+            volatilityThresholds: resolvedVolatility,
+        };
+
+        applyTradeEvaluation(resultModelType, predictionsPayload, trainingMetrics, evaluationOptions);
+
+        if (workerResult?.confusion && modelState?.lastSummary) {
+            modelState.lastSummary.confusion = { ...workerResult.confusion };
+        }
 
         const finalMessage = typeof workerResult?.finalMessage === 'string'
             ? workerResult.finalMessage
             : `完成：訓練勝率 ${formatPercent(trainingMetrics.trainAccuracy, 2)}，測試正確率 ${formatPercent(trainingMetrics.testAccuracy, 2)}。`;
-        showStatus(`[${formatModelLabel(resultModelType)}] ${finalMessage}`, 'success');
+        const seedSuffix = Number.isFinite(resolvedHyper.seed) ? `（Seed ${resolvedHyper.seed}）` : '';
+        const summary = modelState.lastSummary;
+        const appended = summary
+            ? `｜交易報酬% 中位數 ${formatPercent(summary.tradeReturnMedian, 2)}｜單次平均報酬% ${formatPercent(Number.isFinite(summary.tradeReturnAverageSingle) ? summary.tradeReturnAverageSingle : summary.tradeReturnAverage, 2)}｜月平均報酬% ${formatPercent(summary.tradeReturnAverageMonthly, 2)}｜年平均報酬% ${formatPercent(summary.tradeReturnAverageYearly, 2)}｜AI勝率 ${formatPercent(summary.testAccuracy, 2)}｜買入持有年化報酬% ${formatPercent(summary.buyHoldAnnualized, 2)}｜交易次數 ${Number.isFinite(summary.executedTrades) ? summary.executedTrades : 0}`
+            : '';
+        showStatus(`[${formatModelLabel(resultModelType)}] ${finalMessage}${seedSuffix}${appended}`, 'success');
     };
 
-    const runAnnModel = async (modelState, rows, hyperparameters, riskOptions) => {
+    const runAnnModel = async (modelState, rows, hyperparameters, riskOptions, runtimeOptions = {}) => {
         const modelType = MODEL_TYPES.ANNS;
         const label = formatModelLabel(modelType);
         if (!Array.isArray(rows) || rows.length < 60) {
@@ -885,8 +2781,16 @@
             return;
         }
 
+        const requestedSeed = Number.isFinite(runtimeOptions?.seedOverride)
+            ? Math.max(1, Math.round(runtimeOptions.seedOverride))
+            : (Number.isFinite(hyperparameters.seed) ? Math.max(1, Math.round(hyperparameters.seed)) : null);
+
+        let resolvedVolatility = sanitizeVolatilityThresholds(riskOptions?.volatilityThresholds || modelState.volatilityThresholds);
+        modelState.volatilityThresholds = resolvedVolatility;
+        const classificationMode = normalizeClassificationMode(modelState.classification);
+
         showStatus(`[${label}] 訓練中（共 ${hyperparameters.epochs} 輪）...`, 'info');
-        const workerResult = await sendAIWorkerTrainingTask('ai-train-ann', {
+        const taskPayload = {
             rows,
             options: {
                 epochs: hyperparameters.epochs,
@@ -894,8 +2798,14 @@
                 learningRate: hyperparameters.learningRate,
                 trainRatio: hyperparameters.trainRatio,
                 lookback: hyperparameters.lookback,
+                volatility: resolvedVolatility,
+                classificationMode,
             },
-        }, { modelType });
+        };
+        if (Number.isFinite(requestedSeed)) {
+            taskPayload.overrides = { seed: requestedSeed };
+        }
+        const workerResult = await sendAIWorkerTrainingTask('ai-train-ann', taskPayload, { modelType });
 
         const trainingMetrics = workerResult?.trainingMetrics || {
             trainAccuracy: NaN,
@@ -905,55 +2815,106 @@
             totalPredictions: 0,
         };
         const predictionsPayload = workerResult?.predictionsPayload || null;
+        modelState.annDiagnostics = workerResult?.diagnostics ? { ...workerResult.diagnostics } : null;
+        updateAnnDiagnosticsButtonState();
+        const hyperparametersUsed = workerResult?.hyperparametersUsed && typeof workerResult.hyperparametersUsed === 'object'
+            ? workerResult.hyperparametersUsed
+            : null;
         if (!predictionsPayload || !Array.isArray(predictionsPayload.predictions)) {
             throw new Error('AI Worker 未回傳有效的預測結果。');
         }
 
-        predictionsPayload.hyperparameters = {
-            lookback: hyperparameters.lookback,
-            epochs: hyperparameters.epochs,
-            batchSize: hyperparameters.batchSize,
-            learningRate: hyperparameters.learningRate,
-            trainRatio: hyperparameters.trainRatio,
+        const workerVolatility = sanitizeVolatilityThresholds(predictionsPayload?.volatilityThresholds || resolvedVolatility);
+        resolvedVolatility = workerVolatility;
+        modelState.volatilityThresholds = resolvedVolatility;
+
+        const resolvedHyper = {
+            lookback: Number.isFinite(hyperparametersUsed?.lookback) ? hyperparametersUsed.lookback : hyperparameters.lookback,
+            epochs: Number.isFinite(hyperparametersUsed?.epochs) ? hyperparametersUsed.epochs : hyperparameters.epochs,
+            batchSize: Number.isFinite(hyperparametersUsed?.batchSize) ? hyperparametersUsed.batchSize : hyperparameters.batchSize,
+            learningRate: Number.isFinite(hyperparametersUsed?.learningRate) ? hyperparametersUsed.learningRate : hyperparameters.learningRate,
+            trainRatio: Number.isFinite(hyperparametersUsed?.trainRatio) ? hyperparametersUsed.trainRatio : hyperparameters.trainRatio,
             modelType,
+            splitIndex: Number.isFinite(hyperparametersUsed?.splitIndex) ? hyperparametersUsed.splitIndex : (predictionsPayload.hyperparameters?.splitIndex ?? null),
+            threshold: Number.isFinite(hyperparametersUsed?.threshold)
+                ? hyperparametersUsed.threshold
+                : (Number.isFinite(predictionsPayload.hyperparameters?.threshold)
+                    ? predictionsPayload.hyperparameters.threshold
+                    : getDefaultWinThresholdForMode(classificationMode)),
+            seed: Number.isFinite(hyperparametersUsed?.seed)
+                ? hyperparametersUsed.seed
+                : (Number.isFinite(requestedSeed) ? requestedSeed : (Number.isFinite(hyperparameters.seed) ? hyperparameters.seed : null)),
+            classificationMode,
         };
+
+        predictionsPayload.hyperparameters = { ...resolvedHyper, volatility: resolvedVolatility };
+        predictionsPayload.volatilityThresholds = resolvedVolatility;
+        predictionsPayload.classificationMode = classificationMode;
 
         modelState.hyperparameters = {
-            lookback: hyperparameters.lookback,
-            epochs: hyperparameters.epochs,
-            batchSize: hyperparameters.batchSize,
-            learningRate: hyperparameters.learningRate,
-            trainRatio: hyperparameters.trainRatio,
+            lookback: resolvedHyper.lookback,
+            epochs: resolvedHyper.epochs,
+            batchSize: resolvedHyper.batchSize,
+            learningRate: resolvedHyper.learningRate,
+            trainRatio: resolvedHyper.trainRatio,
+            seed: resolvedHyper.seed,
         };
 
-        applyTradeEvaluation(modelType, predictionsPayload, trainingMetrics, riskOptions);
+        modelState.winThreshold = resolvedHyper.threshold;
+
+        const evaluationOptions = {
+            ...riskOptions,
+            threshold: resolvedHyper.threshold,
+            volatilityThresholds: resolvedVolatility,
+        };
+
+        applyTradeEvaluation(modelType, predictionsPayload, trainingMetrics, evaluationOptions);
+
+        if (workerResult?.confusion && modelState?.lastSummary) {
+            modelState.lastSummary.confusion = { ...workerResult.confusion };
+        }
 
         const finalMessage = typeof workerResult?.finalMessage === 'string'
             ? workerResult.finalMessage
             : `完成：測試正確率 ${formatPercent(trainingMetrics.testAccuracy, 2)}，混淆矩陣已同步更新。`;
-        showStatus(`[${label}] ${finalMessage}`, 'success');
+        const seedSuffix = Number.isFinite(resolvedHyper.seed) ? `（Seed ${resolvedHyper.seed}）` : '';
+        const summary = modelState.lastSummary;
+        const appended = summary
+            ? `｜交易報酬% 中位數 ${formatPercent(summary.tradeReturnMedian, 2)}｜單次平均報酬% ${formatPercent(Number.isFinite(summary.tradeReturnAverageSingle) ? summary.tradeReturnAverageSingle : summary.tradeReturnAverage, 2)}｜月平均報酬% ${formatPercent(summary.tradeReturnAverageMonthly, 2)}｜年平均報酬% ${formatPercent(summary.tradeReturnAverageYearly, 2)}｜AI勝率 ${formatPercent(summary.testAccuracy, 2)}｜買入持有年化報酬% ${formatPercent(summary.buyHoldAnnualized, 2)}｜交易次數 ${Number.isFinite(summary.executedTrades) ? summary.executedTrades : 0}`
+            : '';
+        showStatus(`[${label}] ${finalMessage}${seedSuffix}${appended}`, 'success');
     };
 
     const recomputeTradesFromState = (modelType = globalState.activeModel) => {
         const modelState = getModelState(modelType);
         if (!modelState || !modelState.predictionsPayload || !modelState.trainingMetrics) return;
 
-        let threshold = Number.isFinite(modelState.winThreshold) ? modelState.winThreshold : 0.5;
+        let threshold = resolveWinThreshold(modelState);
         let useKelly = Boolean(modelState.kellyEnabled);
         let fixedFraction = sanitizeFraction(modelState.fixedFraction);
+        let tradeRule = getTradeRuleForModel(modelType);
 
         if (modelType === globalState.activeModel) {
             threshold = parseWinThreshold();
             useKelly = Boolean(elements.enableKelly?.checked);
-            fixedFraction = parseNumberInput(elements.fixedFraction, 0.2, { min: 0.01, max: 1 });
+            fixedFraction = readFractionFromInput(modelState.fixedFraction);
+            tradeRule = normalizeTradeRule(elements.tradeRuleSelect?.value);
+            modelState.volatilityThresholds = readVolatilityThresholdsFromInputs(modelState.volatilityThresholds);
             modelState.kellyEnabled = useKelly;
-            modelState.fixedFraction = sanitizeFraction(fixedFraction);
+            modelState.fixedFraction = fixedFraction;
+            modelState.tradeRule = tradeRule;
+            updateTradeRuleDescription(tradeRule);
+            if (elements.tradeRuleSelect) {
+                elements.tradeRuleSelect.value = tradeRule;
+            }
         }
 
         applyTradeEvaluation(modelType, modelState.predictionsPayload, modelState.trainingMetrics, {
             threshold,
             useKelly,
             fixedFraction,
+            tradeRule,
+            volatilityThresholds: modelState.volatilityThresholds,
         });
     };
 
@@ -965,44 +2926,104 @@
             return;
         }
         const useKelly = Boolean(elements.enableKelly?.checked);
-        const fixedFraction = parseNumberInput(elements.fixedFraction, 0.2, { min: 0.01, max: 1 });
+        const fixedFraction = readFractionFromInput(modelState.fixedFraction);
+        const tradeRule = normalizeTradeRule(elements.tradeRuleSelect?.value);
+        modelState.fixedFraction = fixedFraction;
+        modelState.tradeRule = tradeRule;
+        updateTradeRuleDescription(tradeRule);
+        if (elements.tradeRuleSelect) {
+            elements.tradeRuleSelect.value = tradeRule;
+        }
         const payload = modelState.predictionsPayload;
         const trainingOdds = Number.isFinite(payload.trainingOdds)
             ? payload.trainingOdds
             : (Number.isFinite(modelState.odds) ? modelState.odds : 1);
-        let bestThreshold = modelState.winThreshold || 0.5;
-        let bestMedian = Number.NEGATIVE_INFINITY;
-        let bestAverage = Number.NEGATIVE_INFINITY;
+        const target = elements.optimizeTarget?.value || 'median';
+        const targetFieldMap = {
+            median: 'median',
+            single: 'average',
+            monthly: 'averageMonthly',
+            yearly: 'averageYearly',
+        };
+        const targetLabelMap = {
+            median: '交易報酬% 中位數',
+            single: '單次平均報酬%',
+            monthly: '月平均報酬%',
+            yearly: '年平均報酬%',
+        };
+        const targetField = targetFieldMap[target] || 'median';
+        const minTradesRaw = parseNumberInput(elements.optimizeMinTrades, 1, { min: 0, max: 10000 });
+        const minTrades = Math.max(0, Math.floor(Number.isFinite(minTradesRaw) ? minTradesRaw : 1));
+        if (elements.optimizeMinTrades) {
+            elements.optimizeMinTrades.value = String(minTrades);
+        }
+        let bestThreshold = resolveWinThreshold(modelState);
+        let bestValue = Number.NEGATIVE_INFINITY;
+        let bestStats = null;
         for (let percent = 50; percent <= 100; percent += 1) {
             const threshold = percent / 100;
             const evaluation = computeTradeOutcomes(payload, {
                 threshold,
                 useKelly,
                 fixedFraction,
+                tradeRule,
+                volatilityThresholds: modelState.volatilityThresholds,
             }, trainingOdds);
-            const median = evaluation.stats.median;
-            const average = evaluation.stats.average;
-            const normalizedMedian = Number.isFinite(median) ? median : Number.NEGATIVE_INFINITY;
-            const normalizedAverage = Number.isFinite(average) ? average : Number.NEGATIVE_INFINITY;
+            const executedCount = Number.isFinite(evaluation.stats.executed) ? evaluation.stats.executed : 0;
+            if (executedCount < minTrades) {
+                continue;
+            }
+            const statValue = evaluation.stats[targetField];
+            const normalizedValue = Number.isFinite(statValue) ? statValue : Number.NEGATIVE_INFINITY;
+            const currentMedian = Number.isFinite(evaluation.stats.median) ? evaluation.stats.median : Number.NEGATIVE_INFINITY;
+            const currentAverage = Number.isFinite(evaluation.stats.average) ? evaluation.stats.average : Number.NEGATIVE_INFINITY;
+            const bestMedian = Number.isFinite(bestStats?.median) ? bestStats.median : Number.NEGATIVE_INFINITY;
+            const bestAverage = Number.isFinite(bestStats?.average) ? bestStats.average : Number.NEGATIVE_INFINITY;
             if (
-                normalizedMedian > bestMedian
-                || (normalizedMedian === bestMedian && normalizedAverage > bestAverage)
-                || (normalizedMedian === bestMedian && normalizedAverage === bestAverage && threshold < bestThreshold)
+                normalizedValue > bestValue
+                || (normalizedValue === bestValue && currentMedian > bestMedian)
+                || (normalizedValue === bestValue && currentMedian === bestMedian && currentAverage > bestAverage)
+                || (normalizedValue === bestValue && currentMedian === bestMedian && currentAverage === bestAverage && threshold < bestThreshold)
             ) {
-                bestMedian = normalizedMedian;
-                bestAverage = normalizedAverage;
+                bestValue = normalizedValue;
                 bestThreshold = threshold;
+                bestStats = { ...evaluation.stats, executed: executedCount };
             }
         }
-        if (!Number.isFinite(bestMedian) || bestMedian === Number.NEGATIVE_INFINITY) {
-            showStatus('門檻掃描後仍無符合條件的交易。已維持原門檻設定。', 'warning');
+        if (!bestStats || bestValue === Number.NEGATIVE_INFINITY) {
+            const requirementText = minTrades > 0
+                ? `（至少需 ${minTrades} 筆交易）`
+                : '';
+            showStatus(`門檻掃描後仍無符合條件的交易${requirementText}。已維持原門檻設定。`, 'warning');
             return;
         }
         elements.winThreshold.value = String(Math.round(bestThreshold * 100));
         modelState.winThreshold = bestThreshold;
         parseWinThreshold();
         recomputeTradesFromState(modelType);
-        showStatus(`最佳化完成：勝率門檻 ${Math.round(bestThreshold * 100)}% 對應交易報酬% 中位數 ${formatPercent(bestMedian, 2)}。`, 'success');
+        const updatedSummary = getModelState(modelType)?.lastSummary;
+        const targetLabel = targetLabelMap[target] || targetLabelMap.median;
+        const summaryValue = updatedSummary
+            ? (() => {
+                switch (targetField) {
+                    case 'average':
+                        return Number.isFinite(updatedSummary.tradeReturnAverageSingle)
+                            ? updatedSummary.tradeReturnAverageSingle
+                            : updatedSummary.tradeReturnAverage;
+                    case 'averageMonthly':
+                        return updatedSummary.tradeReturnAverageMonthly;
+                    case 'averageYearly':
+                        return updatedSummary.tradeReturnAverageYearly;
+                    case 'median':
+                    default:
+                        return updatedSummary.tradeReturnMedian;
+                }
+            })()
+            : bestValue;
+        const appendMetrics = updatedSummary
+            ? `｜交易報酬% 中位數 ${formatPercent(updatedSummary.tradeReturnMedian, 2)}｜單次平均報酬% ${formatPercent(Number.isFinite(updatedSummary.tradeReturnAverageSingle) ? updatedSummary.tradeReturnAverageSingle : updatedSummary.tradeReturnAverage, 2)}｜月平均報酬% ${formatPercent(updatedSummary.tradeReturnAverageMonthly, 2)}｜年平均報酬% ${formatPercent(updatedSummary.tradeReturnAverageYearly, 2)}｜交易次數 ${Number.isFinite(updatedSummary.executedTrades) ? updatedSummary.executedTrades : 0}`
+            : '';
+        showStatus(`最佳化完成：勝率門檻 ${Math.round(bestThreshold * 100)}% 對應${targetLabel} ${formatPercent(summaryValue, 2)}${appendMetrics}。`, 'success');
     };
 
     const handleSaveSeed = () => {
@@ -1018,7 +3039,7 @@
         }
         const seeds = loadStoredSeeds();
         const summary = modelState.lastSummary;
-        const defaultName = buildSeedDefaultName(summary) || '未命名種子';
+        const defaultName = buildSeedDefaultName(summary, modelType) || '未命名種子';
         const inputName = elements.seedName?.value?.trim();
         const seedName = inputName || defaultName;
         const newSeed = {
@@ -1033,13 +3054,28 @@
                 trainingOdds: modelState.predictionsPayload.trainingOdds,
                 forecast: modelState.predictionsPayload.forecast,
                 datasetLastDate: modelState.predictionsPayload.datasetLastDate,
+                lastClose: modelState.predictionsPayload.lastClose,
                 hyperparameters: modelState.predictionsPayload.hyperparameters,
+                volatilityThresholds: modelState.volatilityThresholds,
+                classificationMode: modelState.classification,
+                volatilityDiagnostics: modelState.volatilityDiagnostics,
             },
             trainingMetrics: modelState.trainingMetrics,
             summary: {
                 threshold: summary.threshold,
                 usingKelly: summary.usingKelly,
                 fixedFraction: summary.fixedFraction,
+                executedTrades: summary.executedTrades,
+                tradeReturnMedian: summary.tradeReturnMedian,
+                tradeReturnAverage: summary.tradeReturnAverage,
+                tradeReturnAverageSingle: summary.tradeReturnAverageSingle,
+                tradeReturnAverageMonthly: summary.tradeReturnAverageMonthly,
+                tradeReturnAverageYearly: summary.tradeReturnAverageYearly,
+                tradeReturnTotal: summary.tradeReturnTotal,
+                tradeRule: summary.tradeRule,
+                volatilityThresholds: summary.volatilityThresholds,
+                classificationMode: summary.classificationMode,
+                volatilityDiagnostics: summary.volatilityDiagnostics,
             },
             version: VERSION_TAG,
         };
@@ -1047,6 +3083,30 @@
         persistSeeds(seeds);
         refreshSeedOptions();
         showStatus(`已儲存種子「${seedName}」。`, 'success');
+        if (elements.saveSeedButton) {
+            const button = elements.saveSeedButton;
+            const baseLabel = button.dataset.originalLabel || button.textContent.trim();
+            button.dataset.originalLabel = baseLabel;
+            button.disabled = true;
+            button.classList.add('bg-emerald-500', 'text-white', 'ring-2', 'ring-emerald-400');
+            button.textContent = '已儲存種子 ✓';
+            if (typeof window !== 'undefined') {
+                if (seedSaveFeedbackTimer) {
+                    window.clearTimeout(seedSaveFeedbackTimer);
+                }
+                seedSaveFeedbackTimer = window.setTimeout(() => {
+                    button.disabled = false;
+                    button.classList.remove('bg-emerald-500', 'text-white', 'ring-2', 'ring-emerald-400');
+                    button.textContent = baseLabel;
+                    seedSaveFeedbackTimer = null;
+                }, 1800);
+            } else {
+                button.disabled = false;
+                button.classList.remove('bg-emerald-500', 'text-white', 'ring-2', 'ring-emerald-400');
+                button.textContent = baseLabel;
+                seedSaveFeedbackTimer = null;
+            }
+        }
     };
 
     const activateSeed = (seed) => {
@@ -1060,8 +3120,21 @@
             trainingOdds: seed.payload?.trainingOdds,
             forecast: seed.payload?.forecast || null,
             datasetLastDate: seed.payload?.datasetLastDate || null,
+            lastClose: Number.isFinite(seed.payload?.lastClose) ? seed.payload.lastClose : null,
             hyperparameters: seed.payload?.hyperparameters || null,
+            volatilityThresholds: sanitizeVolatilityThresholds(seed.payload?.volatilityThresholds || seed.summary?.volatilityThresholds || modelState.volatilityThresholds),
+            classificationMode: normalizeClassificationMode(seed.payload?.classificationMode || seed.summary?.classificationMode || modelState.classification),
         };
+        const seedDiagnostics = (seed.payload?.volatilityDiagnostics && typeof seed.payload.volatilityDiagnostics === 'object')
+            ? seed.payload.volatilityDiagnostics
+            : (seed.summary?.volatilityDiagnostics && typeof seed.summary.volatilityDiagnostics === 'object'
+                ? seed.summary.volatilityDiagnostics
+                : null);
+        modelState.volatilityDiagnostics = seedDiagnostics ? { ...seedDiagnostics } : null;
+        if (modelState.volatilityDiagnostics) {
+            modelState.predictionsPayload.volatilityDiagnostics = { ...modelState.volatilityDiagnostics };
+        }
+        modelState.classification = modelState.predictionsPayload.classificationMode;
         const metrics = seed.trainingMetrics || {
             trainAccuracy: NaN,
             trainLoss: NaN,
@@ -1073,8 +3146,12 @@
         };
         modelState.trainingMetrics = metrics;
         modelState.odds = Number.isFinite(seed.payload?.trainingOdds) ? seed.payload.trainingOdds : modelState.odds;
+        modelState.volatilityThresholds = sanitizeVolatilityThresholds(seed.summary?.volatilityThresholds || modelState.predictionsPayload.volatilityThresholds || modelState.volatilityThresholds);
+        updateClassificationUIState(modelState.classification);
 
         const hyper = seed.payload?.hyperparameters || {};
+        const existingHyper = modelState.hyperparameters || {};
+
         if (elements.lookback && Number.isFinite(hyper.lookback)) {
             elements.lookback.value = hyper.lookback;
         }
@@ -1092,30 +3169,40 @@
         }
 
         modelState.hyperparameters = {
-            lookback: Number.isFinite(hyper.lookback) ? hyper.lookback : modelState.hyperparameters.lookback,
-            epochs: Number.isFinite(hyper.epochs) ? hyper.epochs : modelState.hyperparameters.epochs,
-            batchSize: Number.isFinite(hyper.batchSize) ? hyper.batchSize : modelState.hyperparameters.batchSize,
-            learningRate: Number.isFinite(hyper.learningRate) ? hyper.learningRate : modelState.hyperparameters.learningRate,
-            trainRatio: Number.isFinite(hyper.trainRatio) ? hyper.trainRatio : modelState.hyperparameters.trainRatio,
+            lookback: Number.isFinite(hyper.lookback) ? hyper.lookback : existingHyper.lookback,
+            epochs: Number.isFinite(hyper.epochs) ? hyper.epochs : existingHyper.epochs,
+            batchSize: Number.isFinite(hyper.batchSize) ? hyper.batchSize : existingHyper.batchSize,
+            learningRate: Number.isFinite(hyper.learningRate) ? hyper.learningRate : existingHyper.learningRate,
+            trainRatio: Number.isFinite(hyper.trainRatio) ? hyper.trainRatio : existingHyper.trainRatio,
+            seed: Number.isFinite(hyper.seed) ? hyper.seed : existingHyper.seed,
         };
 
         if (elements.enableKelly && typeof seed.summary?.usingKelly === 'boolean') {
             elements.enableKelly.checked = seed.summary.usingKelly;
         }
-        if (elements.fixedFraction && Number.isFinite(seed.summary?.fixedFraction)) {
-            elements.fixedFraction.value = seed.summary.fixedFraction;
+        const summaryFraction = Number.isFinite(seed.summary?.fixedFraction)
+            ? sanitizeFraction(seed.summary.fixedFraction)
+            : null;
+        if (summaryFraction !== null) {
+            modelState.fixedFraction = summaryFraction;
+            syncFractionInputDisplay(summaryFraction);
+        } else {
+            syncFractionInputDisplay(modelState.fixedFraction);
         }
         if (elements.winThreshold && Number.isFinite(seed.summary?.threshold)) {
             elements.winThreshold.value = String(Math.round(seed.summary.threshold * 100));
         }
 
         modelState.kellyEnabled = Boolean(seed.summary?.usingKelly);
-        modelState.fixedFraction = Number.isFinite(seed.summary?.fixedFraction)
-            ? sanitizeFraction(seed.summary.fixedFraction)
-            : modelState.fixedFraction;
         modelState.winThreshold = Number.isFinite(seed.summary?.threshold)
             ? seed.summary.threshold
             : modelState.winThreshold;
+        const summaryRule = normalizeTradeRule(seed.summary?.tradeRule);
+        modelState.tradeRule = summaryRule;
+        if (elements.tradeRuleSelect) {
+            elements.tradeRuleSelect.value = summaryRule;
+        }
+        updateTradeRuleDescription(summaryRule);
 
         parseTrainRatio();
         parseWinThreshold();
@@ -1143,7 +3230,28 @@
         activateSeed(latestSeed);
     };
 
-    const runPrediction = async () => {
+    const handleDeleteSeeds = () => {
+        if (!elements.savedSeedList) return;
+        const selectedIds = Array.from(elements.savedSeedList.selectedOptions || []).map((option) => option.value).filter(Boolean);
+        if (selectedIds.length === 0) {
+            showStatus('請先選擇要刪除的種子。', 'warning');
+            return;
+        }
+        const seeds = loadStoredSeeds();
+        const remaining = seeds.filter((seed) => !selectedIds.includes(seed.id));
+        if (remaining.length === seeds.length) {
+            showStatus('未刪除任何種子。', 'warning');
+            return;
+        }
+        persistSeeds(remaining);
+        refreshSeedOptions();
+        if (elements.savedSeedList) {
+            elements.savedSeedList.selectedIndex = -1;
+        }
+        showStatus(`已刪除 ${selectedIds.length} 筆種子。`, 'success');
+    };
+
+    const runPrediction = async (options = {}) => {
         if (globalState.running) return;
         toggleRunning(true);
 
@@ -1164,9 +3272,11 @@
 
             const hyperparameters = { ...modelState.hyperparameters };
             const riskOptions = {
-                threshold: Number.isFinite(modelState.winThreshold) ? modelState.winThreshold : 0.5,
+                threshold: resolveWinThreshold(modelState),
                 useKelly: Boolean(modelState.kellyEnabled),
                 fixedFraction: sanitizeFraction(modelState.fixedFraction),
+                tradeRule: getTradeRuleForModel(normalizedModel),
+                volatilityThresholds: sanitizeVolatilityThresholds(modelState.volatilityThresholds),
             };
 
             const rows = getVisibleData();
@@ -1175,10 +3285,36 @@
                 return;
             }
 
+            let annRuntimeOptions = {};
+            let lstmRuntimeOptions = {};
+            if (normalizedModel === MODEL_TYPES.ANNS) {
+                const storedSeed = Number.isFinite(hyperparameters.seed) ? hyperparameters.seed : null;
+                if (options?.freshSeed) {
+                    const freshSeed = generateRuntimeSeed();
+                    annRuntimeOptions = {
+                        seedOverride: freshSeed,
+                    };
+                } else if (Number.isFinite(storedSeed)) {
+                    annRuntimeOptions = { seedOverride: storedSeed };
+                }
+            }
+
             if (normalizedModel === MODEL_TYPES.LSTM) {
-                await runLstmModel(modelState, rows, hyperparameters, riskOptions);
+                const storedSeed = Number.isFinite(hyperparameters.seed) ? hyperparameters.seed : null;
+                if (options?.freshSeed) {
+                    const freshSeed = generateRuntimeSeed();
+                    lstmRuntimeOptions = {
+                        seedOverride: freshSeed,
+                    };
+                } else if (Number.isFinite(storedSeed)) {
+                    lstmRuntimeOptions = { seedOverride: storedSeed };
+                }
+            }
+
+            if (normalizedModel === MODEL_TYPES.LSTM) {
+                await runLstmModel(modelState, rows, hyperparameters, riskOptions, lstmRuntimeOptions);
             } else {
-                await runAnnModel(modelState, rows, hyperparameters, riskOptions);
+                await runAnnModel(modelState, rows, hyperparameters, riskOptions, annRuntimeOptions);
             }
         } catch (error) {
             const activeLabel = formatModelLabel(globalState.activeModel);
@@ -1213,6 +3349,7 @@
         elements.datasetSummary = document.getElementById('ai-dataset-summary');
         elements.status = document.getElementById('ai-status');
         elements.runButton = document.getElementById('ai-run-button');
+        elements.freshRunButton = document.getElementById('ai-run-fresh-button');
         elements.modelType = document.getElementById('ai-model-type');
         elements.trainRatio = document.getElementById('ai-train-ratio');
         elements.trainRatioBadge = document.getElementById('ai-train-ratio-badge');
@@ -1224,6 +3361,8 @@
         elements.fixedFraction = document.getElementById('ai-fixed-fraction');
         elements.winThreshold = document.getElementById('ai-win-threshold');
         elements.optimizeThreshold = document.getElementById('ai-optimize-threshold');
+        elements.optimizeTarget = document.getElementById('ai-optimize-target');
+        elements.optimizeMinTrades = document.getElementById('ai-optimize-min-trades');
         elements.trainAccuracy = document.getElementById('ai-train-accuracy');
         elements.trainLoss = document.getElementById('ai-train-loss');
         elements.testAccuracy = document.getElementById('ai-test-accuracy');
@@ -1235,14 +3374,59 @@
         elements.tradeTableBody = document.getElementById('ai-trade-table-body');
         elements.tradeSummary = document.getElementById('ai-trade-summary');
         elements.nextDayForecast = document.getElementById('ai-next-day-forecast');
+        elements.toggleAllTrades = document.getElementById('ai-toggle-all-trades');
         elements.seedName = document.getElementById('ai-seed-name');
         elements.saveSeedButton = document.getElementById('ai-save-seed');
         elements.savedSeedList = document.getElementById('ai-saved-seeds');
         elements.loadSeedButton = document.getElementById('ai-load-seed');
+        elements.deleteSeedButton = document.getElementById('ai-delete-seed');
+        elements.classificationMode = document.getElementById('ai-classification-mode');
+        elements.tradeRuleSelect = document.getElementById('ai-trade-rule');
+        elements.tradeRules = document.getElementById('ai-trade-rules');
+        elements.volatilitySurge = document.getElementById('ai-volatility-surge');
+        elements.volatilityDrop = document.getElementById('ai-volatility-drop');
+        elements.volatilityDiagnostics = document.getElementById('ai-volatility-diagnostics');
+        elements.volatilitySampleSummary = document.getElementById('ai-volatility-sample-summary');
+        elements.volatilitySurgeSummary = document.getElementById('ai-volatility-surge-summary');
+        elements.volatilityDropSummary = document.getElementById('ai-volatility-drop-summary');
+        elements.annDiagnosticsButton = document.getElementById('ai-ann-diagnostics');
+        elements.testAccuracyLabel = document.getElementById('ai-test-accuracy-label');
 
         if (elements.runButton) {
             elements.runButton.addEventListener('click', () => {
                 runPrediction();
+            });
+        }
+
+        if (elements.freshRunButton) {
+            elements.freshRunButton.addEventListener('click', () => {
+                runPrediction({ freshSeed: true });
+            });
+        }
+
+        if (elements.toggleAllTrades) {
+            elements.toggleAllTrades.addEventListener('click', () => {
+                const modelState = getActiveModelState();
+                const totalRecords = Array.isArray(modelState?.allPredictionRows) ? modelState.allPredictionRows.length : 0;
+                if (elements.toggleAllTrades.disabled || totalRecords === 0) {
+                    return;
+                }
+                globalState.showAllPredictions = !globalState.showAllPredictions;
+                updateAllPredictionsToggleButton(modelState);
+                if (modelState?.lastSummary) {
+                    const rowsToRender = globalState.showAllPredictions
+                        ? modelState.allPredictionRows
+                        : modelState.currentTrades;
+                    renderTrades(rowsToRender, modelState.lastSummary.forecast, globalState.showAllPredictions);
+                }
+            });
+        }
+
+        updateAllPredictionsToggleButton(getActiveModelState());
+
+        if (elements.annDiagnosticsButton) {
+            elements.annDiagnosticsButton.addEventListener('click', () => {
+                openAnnDiagnosticsWindow();
             });
         }
 
@@ -1274,6 +3458,47 @@
             });
         }
 
+        if (elements.classificationMode) {
+            elements.classificationMode.addEventListener('change', () => {
+                const mode = normalizeClassificationMode(elements.classificationMode.value);
+                const modelState = getActiveModelState();
+                if (modelState) {
+                    modelState.classification = mode;
+                }
+                updateClassificationUIState(mode);
+                captureActiveModelSettings();
+                recomputeTradesFromState();
+            });
+        }
+
+        if (elements.tradeRuleSelect) {
+            elements.tradeRuleSelect.addEventListener('change', () => {
+                const rule = normalizeTradeRule(elements.tradeRuleSelect.value);
+                const modelState = getActiveModelState();
+                if (modelState) {
+                    modelState.tradeRule = rule;
+                }
+                updateTradeRuleDescription(rule);
+                recomputeTradesFromState();
+            });
+        }
+
+        const bindVolatilityInput = (elKey, updater) => {
+            const el = elements[elKey];
+            if (!el) return;
+            el.addEventListener('change', updater);
+            el.addEventListener('blur', updater);
+        };
+
+        bindVolatilityInput('volatilitySurge', () => {
+            captureActiveModelSettings();
+            recomputeTradesFromState();
+        });
+        bindVolatilityInput('volatilityDrop', () => {
+            captureActiveModelSettings();
+            recomputeTradesFromState();
+        });
+
         if (elements.winThreshold) {
             elements.winThreshold.addEventListener('change', () => {
                 recomputeTradesFromState();
@@ -1301,11 +3526,20 @@
             });
         }
 
+        if (elements.deleteSeedButton) {
+            elements.deleteSeedButton.addEventListener('click', () => {
+                handleDeleteSeeds();
+            });
+        }
+
         applyModelSettingsToUI(getActiveModelState());
         renderActiveModelOutputs();
         refreshSeedOptions();
 
         updateDatasetSummary(getVisibleData());
+
+        updateTradeRuleDescription(getTradeRuleForModel());
+        updateAnnDiagnosticsButtonState();
 
         const bridge = ensureBridge();
         if (bridge) {

--- a/js/worker.js
+++ b/js/worker.js
@@ -1,12 +1,331 @@
 
+// Patch Tag: LB-AI-ANNS-REPRO-20251224B — Deterministic trade pricing & metadata expansion.
+// Patch Tag: LB-AI-TRADE-RULE-20251229A — Added close-entry metadata for ANN trades.
+// Patch Tag: LB-AI-TRADE-VOLATILITY-20251230A — Multiclass volatility tiers & shared metadata.
+// Patch Tag: LB-AI-LSTM-CLASS-20251230A — LSTM binary/multiclass toggle & probability normalisation.
+// Patch Tag: LB-AI-VOL-QUARTILE-20251231A — Train-set quartile thresholds for volatility tiers.
+// Patch Tag: LB-AI-VOL-QUARTILE-20260105A — Positive/negative quartile separation for volatility tiers.
+// Patch Tag: LB-AI-VOL-QUARTILE-20260110A — Volatility quartile diagnostics for reproducibility.
+// Patch Tag: LB-AI-VOL-QUARTILE-20260111A — Quartile fallback indicators and share diagnostics for AI volatility tiers.
+// Patch Tag: LB-AI-PRECISION-20260118A — Multiclass precision metrics & diagnostics parity.
+// Patch Tag: LB-AI-THRESHOLD-20260122A — Multiclass threshold defaults for deterministic gating.
+// Patch Tag: LB-AI-THRESHOLD-20260124A — Binary default win threshold tuned to 50%.
+// Patch Tag: LB-AI-VOL-QUARTILE-20260128A — Align ANN class分佈與波動門檻紀錄並回傳實際閾值。
 importScripts('shared-lookback.js');
 importScripts('config.js');
+
+const TFJS_VERSION = '4.20.0';
+const TF_BACKEND_TARGET = 'wasm';
+const ANN_DEFAULT_SEED = 1337;
+const ANN_MODEL_STORAGE_KEY = 'anns_v1_model';
+const ANN_META_MESSAGE = 'ANN_META';
+const ANN_REPRO_VERSION = 'anns_v1';
+const ANN_REPRO_PATCH = 'LB-AI-ANNS-REPRO-20260128A';
+const ANN_DIAGNOSTIC_VERSION = 'LB-AI-ANN-DIAG-20260128A';
+const LSTM_DEFAULT_SEED = 7331;
+const LSTM_MODEL_STORAGE_KEY = 'lstm_v1_model';
+const LSTM_META_MESSAGE = 'LSTM_META';
+const LSTM_REPRO_VERSION = 'lstm_v1';
+const LSTM_REPRO_PATCH = 'LB-AI-LSTM-REPRO-20260118A';
+const LSTM_THRESHOLD = 0.5;
+const DEFAULT_VOLATILITY_THRESHOLDS = { surge: 0.03, drop: 0.03 };
+const CLASSIFICATION_MODES = {
+  BINARY: 'binary',
+  MULTICLASS: 'multiclass',
+};
+
+const ANN_FEATURE_NAMES = [
+  'SMA30',
+  'WMA15',
+  'EMA12',
+  'Momentum10',
+  'StochK14',
+  'StochD3',
+  'RSI14',
+  'MACDdiff',
+  'MACDsignal',
+  'MACDhist',
+  'CCI20',
+  'WilliamsR14',
+];
+
+function normalizeClassificationMode(mode) {
+  return mode === CLASSIFICATION_MODES.BINARY ? CLASSIFICATION_MODES.BINARY : CLASSIFICATION_MODES.MULTICLASS;
+}
+
+function getDefaultThresholdForMode(mode) {
+  return normalizeClassificationMode(mode) === CLASSIFICATION_MODES.MULTICLASS ? 0 : 0.5;
+}
+
+function sanitizeVolatilityThresholds(input = {}) {
+  const fallbackSurge = DEFAULT_VOLATILITY_THRESHOLDS.surge;
+  const fallbackDrop = DEFAULT_VOLATILITY_THRESHOLDS.drop;
+  const rawSurge = Number(input?.surge);
+  const rawDrop = Number(input?.drop);
+  const rawLower = Number(input?.lowerQuantile);
+  const rawUpper = Number(input?.upperQuantile);
+
+  let surge = Number.isFinite(rawSurge) && Math.abs(rawSurge) > 0 ? Math.abs(rawSurge) : NaN;
+  let drop = Number.isFinite(rawDrop) && Math.abs(rawDrop) > 0 ? Math.abs(rawDrop) : NaN;
+
+  if (!(surge > 0) && Number.isFinite(rawUpper) && Math.abs(rawUpper) > 0) {
+    surge = Math.abs(rawUpper);
+  }
+  if (!(drop > 0) && Number.isFinite(rawLower) && Math.abs(rawLower) > 0) {
+    drop = Math.abs(rawLower);
+  }
+
+  if (!(surge > 0)) {
+    surge = fallbackSurge;
+  }
+  if (!(drop > 0)) {
+    drop = fallbackDrop;
+  }
+
+  surge = Math.min(Math.max(surge, 0.0001), 0.5);
+  drop = Math.min(Math.max(drop, 0.0001), 0.5);
+
+  let lowerQuantile;
+  if (Number.isFinite(rawLower) && Math.abs(rawLower) > 0) {
+    lowerQuantile = rawLower > 0 ? -Math.abs(rawLower) : Math.max(rawLower, -0.5);
+  } else {
+    lowerQuantile = -drop;
+  }
+
+  let upperQuantile;
+  if (Number.isFinite(rawUpper) && Math.abs(rawUpper) > 0) {
+    upperQuantile = rawUpper < 0 ? Math.abs(rawUpper) : Math.min(rawUpper, 0.5);
+  } else {
+    upperQuantile = surge;
+  }
+
+  upperQuantile = Math.min(Math.max(upperQuantile, 0.0001), 0.5);
+  lowerQuantile = Math.max(Math.min(lowerQuantile, -0.0001), -0.5);
+
+  return {
+    surge,
+    drop,
+    lowerQuantile,
+    upperQuantile,
+  };
+}
+
+function computeQuantileValue(sortedValues, percentile) {
+  if (!Array.isArray(sortedValues) || sortedValues.length === 0) return NaN;
+  const clampedPercentile = Math.min(Math.max(percentile, 0), 1);
+  if (sortedValues.length === 1 || clampedPercentile === 0) {
+    return sortedValues[0];
+  }
+  if (clampedPercentile === 1) {
+    return sortedValues[sortedValues.length - 1];
+  }
+  const position = (sortedValues.length - 1) * clampedPercentile;
+  const lowerIndex = Math.floor(position);
+  const upperIndex = Math.min(lowerIndex + 1, sortedValues.length - 1);
+  const weight = position - lowerIndex;
+  const lowerValue = sortedValues[lowerIndex];
+  const upperValue = sortedValues[upperIndex];
+  if (!Number.isFinite(lowerValue)) return upperValue;
+  if (!Number.isFinite(upperValue)) return lowerValue;
+  return lowerValue + ((upperValue - lowerValue) * weight);
+}
+
+function deriveVolatilityThresholdsFromReturns(values, fallback = DEFAULT_VOLATILITY_THRESHOLDS, diagnosticsRef = null) {
+  const fallbackSanitized = sanitizeVolatilityThresholds(fallback);
+  if (!Array.isArray(values) || values.length === 0) {
+    return fallbackSanitized;
+  }
+  const filtered = values.filter((value) => Number.isFinite(value));
+  if (filtered.length === 0) {
+    return fallbackSanitized;
+  }
+
+  const sorted = filtered.slice().sort((a, b) => a - b);
+  const positives = sorted.filter((value) => value > 0);
+  const negatives = sorted.filter((value) => value < 0);
+  const zeroCount = filtered.length - positives.length - negatives.length;
+
+  const combinedUpperQuartile = computeQuantileValue(sorted, 0.75);
+  const combinedLowerQuartile = computeQuantileValue(sorted, 0.25);
+  const positiveOnlyQuartile = positives.length > 0 ? computeQuantileValue(positives, 0.75) : NaN;
+  const negativeOnlyQuartile = negatives.length > 0 ? computeQuantileValue(negatives, 0.25) : NaN;
+
+  let positiveSource = 'combined';
+  let negativeSource = 'combined';
+
+  let upperCandidate = Number.isFinite(combinedUpperQuartile) ? combinedUpperQuartile : NaN;
+  if (!(upperCandidate > 0)) {
+    if (Number.isFinite(positiveOnlyQuartile) && positiveOnlyQuartile > 0) {
+      upperCandidate = positiveOnlyQuartile;
+      positiveSource = 'positive-only';
+    } else {
+      const fallbackUpper = Number.isFinite(fallbackSanitized.upperQuantile) && fallbackSanitized.upperQuantile > 0
+        ? fallbackSanitized.upperQuantile
+        : (fallbackSanitized.surge > 0 ? fallbackSanitized.surge : NaN);
+      upperCandidate = Number.isFinite(fallbackUpper) ? fallbackUpper : NaN;
+      positiveSource = 'default';
+    }
+  }
+
+  let lowerCandidate = Number.isFinite(combinedLowerQuartile) ? combinedLowerQuartile : NaN;
+  if (!(lowerCandidate < 0)) {
+    if (Number.isFinite(negativeOnlyQuartile) && negativeOnlyQuartile < 0) {
+      lowerCandidate = negativeOnlyQuartile;
+      negativeSource = 'negative-only';
+    } else {
+      const fallbackLower = Number.isFinite(fallbackSanitized.lowerQuantile) && fallbackSanitized.lowerQuantile < 0
+        ? fallbackSanitized.lowerQuantile
+        : (fallbackSanitized.drop > 0 ? -fallbackSanitized.drop : NaN);
+      lowerCandidate = Number.isFinite(fallbackLower) ? fallbackLower : NaN;
+      negativeSource = 'default';
+    }
+  }
+
+  const sanitized = sanitizeVolatilityThresholds({
+    surge: upperCandidate,
+    drop: Math.abs(lowerCandidate),
+    lowerQuantile: lowerCandidate,
+    upperQuantile: upperCandidate,
+  });
+
+  if (diagnosticsRef && typeof diagnosticsRef === 'object') {
+    const positiveThreshold = Number.isFinite(sanitized.upperQuantile)
+      ? sanitized.upperQuantile
+      : (Number.isFinite(sanitized.surge) ? sanitized.surge : NaN);
+    const negativeThreshold = Number.isFinite(sanitized.lowerQuantile)
+      ? sanitized.lowerQuantile
+      : (Number.isFinite(sanitized.drop) ? -sanitized.drop : NaN);
+
+    let positiveExceedCount = 0;
+    let negativeExceedCount = 0;
+    if (Number.isFinite(positiveThreshold) || Number.isFinite(negativeThreshold)) {
+      for (let i = 0; i < filtered.length; i += 1) {
+        const value = filtered[i];
+        if (Number.isFinite(positiveThreshold) && value >= positiveThreshold) {
+          positiveExceedCount += 1;
+        } else if (Number.isFinite(negativeThreshold) && value <= negativeThreshold) {
+          negativeExceedCount += 1;
+        }
+      }
+    }
+
+    let midbandCount = filtered.length - positiveExceedCount - negativeExceedCount;
+    if (!Number.isFinite(midbandCount) || midbandCount < 0) {
+      midbandCount = Math.max(filtered.length - positiveExceedCount - negativeExceedCount, 0);
+    }
+
+    diagnosticsRef.totalSamples = filtered.length;
+    if (!Number.isFinite(diagnosticsRef.expectedTrainSamples)) {
+      diagnosticsRef.expectedTrainSamples = filtered.length;
+    }
+    diagnosticsRef.positiveSamples = positives.length;
+    diagnosticsRef.negativeSamples = negatives.length;
+    diagnosticsRef.zeroSamples = zeroCount;
+    diagnosticsRef.upperQuartile = Number.isFinite(combinedUpperQuartile) ? combinedUpperQuartile : null;
+    diagnosticsRef.lowerQuartile = Number.isFinite(combinedLowerQuartile) ? combinedLowerQuartile : null;
+    diagnosticsRef.combinedUpperQuartile = diagnosticsRef.upperQuartile;
+    diagnosticsRef.combinedLowerQuartile = diagnosticsRef.lowerQuartile;
+    diagnosticsRef.positiveQuartile = diagnosticsRef.upperQuartile;
+    diagnosticsRef.negativeQuartile = diagnosticsRef.lowerQuartile;
+    diagnosticsRef.positiveOnlyQuartile = Number.isFinite(positiveOnlyQuartile) ? positiveOnlyQuartile : null;
+    diagnosticsRef.negativeOnlyQuartile = Number.isFinite(negativeOnlyQuartile) ? negativeOnlyQuartile : null;
+    diagnosticsRef.positiveThreshold = Number.isFinite(positiveThreshold) ? positiveThreshold : null;
+    diagnosticsRef.negativeThreshold = Number.isFinite(negativeThreshold) ? negativeThreshold : null;
+    diagnosticsRef.positiveExceedCount = positiveExceedCount;
+    diagnosticsRef.negativeExceedCount = negativeExceedCount;
+    const positiveExceedShare = positives.length > 0 ? (positiveExceedCount / positives.length) : NaN;
+    const negativeExceedShare = negatives.length > 0 ? (negativeExceedCount / negatives.length) : NaN;
+    const totalPositiveShare = filtered.length > 0 ? (positiveExceedCount / filtered.length) : NaN;
+    const totalNegativeShare = filtered.length > 0 ? (negativeExceedCount / filtered.length) : NaN;
+    const zeroShare = filtered.length > 0 ? (zeroCount / filtered.length) : NaN;
+    const midbandShare = filtered.length > 0 ? (midbandCount / filtered.length) : NaN;
+    diagnosticsRef.positiveExceedShare = Number.isFinite(positiveExceedShare) ? positiveExceedShare : null;
+    diagnosticsRef.negativeExceedShare = Number.isFinite(negativeExceedShare) ? negativeExceedShare : null;
+    diagnosticsRef.totalPositiveShare = Number.isFinite(totalPositiveShare) ? totalPositiveShare : null;
+    diagnosticsRef.totalNegativeShare = Number.isFinite(totalNegativeShare) ? totalNegativeShare : null;
+    diagnosticsRef.zeroShare = Number.isFinite(zeroShare) ? zeroShare : null;
+    diagnosticsRef.midbandCount = midbandCount;
+    diagnosticsRef.midbandShare = Number.isFinite(midbandShare) ? midbandShare : null;
+    diagnosticsRef.usedPositiveFallback = positiveSource !== 'combined';
+    diagnosticsRef.usedNegativeFallback = negativeSource !== 'combined';
+    diagnosticsRef.positiveSource = positiveSource;
+    diagnosticsRef.negativeSource = negativeSource;
+    diagnosticsRef.fallbackUpperQuartile = null;
+    diagnosticsRef.fallbackLowerQuartile = null;
+  }
+
+  return sanitized;
+}
+
+function classifySwingReturn(swingValue, thresholds) {
+  if (!Number.isFinite(swingValue)) {
+    return 1;
+  }
+  const upper = Number.isFinite(thresholds?.upperQuantile) ? thresholds.upperQuantile : thresholds?.surge;
+  const lower = Number.isFinite(thresholds?.lowerQuantile)
+    ? thresholds.lowerQuantile
+    : (Number.isFinite(thresholds?.drop) ? -thresholds.drop : -DEFAULT_VOLATILITY_THRESHOLDS.drop);
+  if (Number.isFinite(upper) && swingValue >= upper) {
+    return 2;
+  }
+  if (Number.isFinite(lower) && swingValue <= lower) {
+    return 0;
+  }
+  const fallbackSurge = Number.isFinite(thresholds?.surge) ? thresholds.surge : DEFAULT_VOLATILITY_THRESHOLDS.surge;
+  const fallbackDrop = Number.isFinite(thresholds?.drop) ? thresholds.drop : DEFAULT_VOLATILITY_THRESHOLDS.drop;
+  if (Number.isFinite(fallbackSurge) && swingValue >= fallbackSurge) {
+    return 2;
+  }
+  if (Number.isFinite(fallbackDrop) && swingValue <= -fallbackDrop) {
+    return 0;
+  }
+  return 1;
+}
+
+function clampProbability(value) {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+let tfBackendReadyPromise = Promise.resolve();
+
 try {
   if (typeof tf === 'undefined') {
-    importScripts('https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.20.0/dist/tf.min.js');
+    importScripts(`https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@${TFJS_VERSION}/dist/tf.min.js`);
+  }
+  if (typeof tf !== 'undefined' && typeof tf?.setBackend === 'function') {
+    try {
+      importScripts(`https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@${TFJS_VERSION}/dist/tf-backend-wasm.min.js`);
+    } catch (wasmError) {
+      console.warn('[Worker][AI] 無法載入 TFJS WASM 後端：', wasmError);
+    }
+    if (tf?.wasm?.setWasmPaths) {
+      tf.wasm.setWasmPaths(`https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@${TFJS_VERSION}/dist/`);
+    }
+    if (typeof tf?.util?.seedrandom === 'function') {
+      tf.util.seedrandom(ANN_DEFAULT_SEED);
+    }
+    tfBackendReadyPromise = (async () => {
+      try {
+        if (tf.getBackend() !== TF_BACKEND_TARGET) {
+          await tf.setBackend(TF_BACKEND_TARGET);
+        }
+      } catch (backendError) {
+        console.warn(`[Worker][AI] 無法設定 ${TF_BACKEND_TARGET} 後端，退回 CPU：`, backendError);
+        try {
+          await tf.setBackend('cpu');
+        } catch (cpuError) {
+          console.warn('[Worker][AI] 無法切換至 CPU 後端：', cpuError);
+        }
+      }
+      await tf.ready();
+      return tf.getBackend();
+    })();
   }
 } catch (error) {
-  console.warn('[Worker][AI] 無法載入 TensorFlow.js：', error);
+  console.warn('[Worker][AI] 無法初始化 TensorFlow.js：', error);
 }
 
 // --- Worker Data Acquisition & Cache (v11.7 - Netlify blob range fast path) ---
@@ -95,16 +414,54 @@ function aiNormaliseSequences(sequences, normaliser) {
   return sequences.map((seq) => seq.map((value) => (value - mean) / divisor));
 }
 
-function aiCreateModel(lookback, learningRate) {
+function aiCreateModel(lookback, learningRate, seed = LSTM_DEFAULT_SEED, classificationMode = CLASSIFICATION_MODES.BINARY) {
+  const baseSeed = Number.isFinite(seed) ? Math.max(1, Math.round(seed)) : LSTM_DEFAULT_SEED;
+  const buildKernelInitializer = (offset = 0) =>
+    tf.initializers.glorotUniform({ seed: baseSeed + offset });
+  const buildRecurrentInitializer = (offset = 0) =>
+    tf.initializers.orthogonal({ seed: baseSeed + 100 + offset });
+  const biasInitializer = tf.initializers.zeros();
+  const normalizedMode = normalizeClassificationMode(classificationMode);
+  const isBinary = normalizedMode === CLASSIFICATION_MODES.BINARY;
+
   const model = tf.sequential();
-  model.add(tf.layers.lstm({ units: 32, returnSequences: true, inputShape: [lookback, 1] }));
-  model.add(tf.layers.dropout({ rate: 0.2 }));
-  model.add(tf.layers.lstm({ units: 16 }));
-  model.add(tf.layers.dropout({ rate: 0.1 }));
-  model.add(tf.layers.dense({ units: 16, activation: 'relu' }));
-  model.add(tf.layers.dense({ units: 1, activation: 'sigmoid' }));
+  model.add(
+    tf.layers.lstm({
+      units: 32,
+      returnSequences: true,
+      inputShape: [lookback, 1],
+      kernelInitializer: buildKernelInitializer(1),
+      recurrentInitializer: buildRecurrentInitializer(1),
+      biasInitializer,
+    }),
+  );
+  model.add(
+    tf.layers.lstm({
+      units: 16,
+      kernelInitializer: buildKernelInitializer(2),
+      recurrentInitializer: buildRecurrentInitializer(2),
+      biasInitializer,
+    }),
+  );
+  model.add(
+    tf.layers.dense({
+      units: 16,
+      activation: 'relu',
+      kernelInitializer: buildKernelInitializer(3),
+      biasInitializer,
+    }),
+  );
+  model.add(
+    tf.layers.dense({
+      units: isBinary ? 1 : 3,
+      activation: isBinary ? 'sigmoid' : 'softmax',
+      kernelInitializer: buildKernelInitializer(4),
+      biasInitializer,
+    }),
+  );
   const optimizer = tf.train.adam(learningRate);
-  model.compile({ optimizer, loss: 'binaryCrossentropy', metrics: ['accuracy'] });
+  const loss = isBinary ? 'binaryCrossentropy' : 'categoricalCrossentropy';
+  model.compile({ optimizer, loss, metrics: ['accuracy'] });
   return model;
 }
 
@@ -129,18 +486,49 @@ async function handleAITrainLSTMMessage(message) {
     return;
   }
   const payload = message?.payload || {};
+  const overrides = payload.overrides || {};
+  const hyper = payload.hyperparameters || {};
+  const overrideSeed = Number.isFinite(overrides?.seed)
+    ? Math.max(1, Math.round(overrides.seed))
+    : null;
+  const hyperSeed = Number.isFinite(hyper?.seed)
+    ? Math.max(1, Math.round(hyper.seed))
+    : null;
+  const seedToUse = overrideSeed || hyperSeed || LSTM_DEFAULT_SEED;
+
   try {
+    await tfBackendReadyPromise;
     if (typeof tf === 'undefined' || typeof tf.tensor !== 'function') {
       throw new Error('TensorFlow.js 尚未在背景執行緒載入，請重新整理頁面。');
     }
+    if (typeof tf?.util?.seedrandom === 'function') {
+      tf.util.seedrandom(seedToUse);
+    }
+
     const dataset = payload.dataset || {};
     if (!Array.isArray(dataset.sequences) || dataset.sequences.length === 0) {
       throw new Error('缺少有效的訓練樣本。');
     }
-    const hyper = payload.hyperparameters || {};
-    const inferredLookback = Array.isArray(dataset.sequences[0]) ? dataset.sequences[0].length : 20;
-    const lookback = Math.max(5, Math.round(Number.isFinite(hyper.lookback) ? hyper.lookback : inferredLookback));
-    const totalSamples = Number.isFinite(hyper.totalSamples) ? hyper.totalSamples : dataset.sequences.length;
+
+    const volatilityThresholds = sanitizeVolatilityThresholds(dataset.volatilityThresholds);
+    let volatilityDiagnostics = dataset.volatilityDiagnostics
+      && typeof dataset.volatilityDiagnostics === 'object'
+        ? { ...dataset.volatilityDiagnostics }
+        : null;
+    const classificationMode = normalizeClassificationMode(hyper.classificationMode || dataset.classificationMode);
+    const isBinary = classificationMode === CLASSIFICATION_MODES.BINARY;
+    const gatingThreshold = getDefaultThresholdForMode(classificationMode);
+
+    const inferredLookback = Array.isArray(dataset.sequences[0])
+      ? dataset.sequences[0].length
+      : 20;
+    const lookback = Math.max(
+      5,
+      Math.round(Number.isFinite(hyper.lookback) ? hyper.lookback : inferredLookback),
+    );
+    const totalSamples = Number.isFinite(hyper.totalSamples)
+      ? hyper.totalSamples
+      : dataset.sequences.length;
     const rawRatio = Number.isFinite(hyper.trainRatio) ? hyper.trainRatio : 0.8;
     const trainRatio = Math.min(Math.max(rawRatio, 0.6), 0.95);
     const fallbackTrainSize = Math.max(Math.floor(totalSamples * trainRatio), lookback);
@@ -150,12 +538,23 @@ async function handleAITrainLSTMMessage(message) {
     if (boundedTrainSize <= 0 || testSize <= 0) {
       throw new Error('訓練/測試樣本不足，請延長回測期間。');
     }
+
     const epochs = Math.max(1, Math.round(Number.isFinite(hyper.epochs) ? hyper.epochs : 80));
     const learningRate = Number.isFinite(hyper.learningRate) ? hyper.learningRate : 0.005;
-    const batchSize = Math.max(1, Math.min(Math.round(Number.isFinite(hyper.batchSize) ? hyper.batchSize : 32), boundedTrainSize));
+    const rawBatchSize = Math.max(
+      1,
+      Math.round(Number.isFinite(hyper.batchSize) ? hyper.batchSize : 32),
+    );
+    const batchSize = Math.min(rawBatchSize, boundedTrainSize);
 
     const sequences = Array.isArray(dataset.sequences) ? dataset.sequences : [];
     const labels = Array.isArray(dataset.labels) ? dataset.labels : [];
+    const labelIndices = labels.map((label) => {
+      if (isBinary) {
+        return label > 0 ? 1 : 0;
+      }
+      return Number.isInteger(label) ? Math.max(0, Math.min(2, label)) : 0;
+    });
     if (labels.length !== sequences.length) {
       throw new Error('樣本與標籤數量不一致，無法訓練模型。');
     }
@@ -164,7 +563,13 @@ async function handleAITrainLSTMMessage(message) {
     const normalizedSequences = aiNormaliseSequences(sequences, normaliser);
     const tensorInput = normalizedSequences.map((seq) => seq.map((value) => [value]));
     const xAll = tf.tensor(tensorInput);
-    const yAll = tf.tensor(labels.map((label) => [label]));
+    const yAll = isBinary
+      ? tf.tensor2d(labelIndices.map((value) => [value]), [labelIndices.length, 1])
+      : tf.tensor2d(labelIndices.map((index) => {
+        const arr = [0, 0, 0];
+        arr[index] = 1;
+        return arr;
+      }));
 
     const tensorsToDispose = [xAll, yAll];
     let model = null;
@@ -175,30 +580,40 @@ async function handleAITrainLSTMMessage(message) {
 
     try {
       xTrain = xAll.slice([0, 0, 0], [boundedTrainSize, lookback, 1]);
-      yTrain = yAll.slice([0, 0], [boundedTrainSize, 1]);
       xTest = xAll.slice([boundedTrainSize, 0, 0], [testSize, lookback, 1]);
-      yTest = yAll.slice([boundedTrainSize, 0], [testSize, 1]);
+      if (isBinary) {
+        yTrain = yAll.slice([0, 0], [boundedTrainSize, 1]);
+        yTest = yAll.slice([boundedTrainSize, 0], [testSize, 1]);
+      } else {
+        yTrain = yAll.slice([0, 0], [boundedTrainSize, 3]);
+        yTest = yAll.slice([boundedTrainSize, 0], [testSize, 3]);
+      }
       tensorsToDispose.push(xTrain, yTrain, xTest, yTest);
 
-      model = aiCreateModel(lookback, learningRate);
+      model = aiCreateModel(lookback, learningRate, seedToUse, classificationMode);
 
       aiPostProgress(id, `訓練中（共 ${epochs} 輪）...`);
       const history = await model.fit(xTrain, yTrain, {
         epochs,
         batchSize,
-        validationSplit: Math.min(0.2, Math.max(0.1, boundedTrainSize > 50 ? 0.2 : 0.1)),
-        shuffle: true,
+        shuffle: false,
         callbacks: {
           onEpochEnd: (epoch, logs) => {
             const lossText = Number.isFinite(logs.loss) ? logs.loss.toFixed(4) : '—';
             const accValue = logs.acc ?? logs.accuracy;
-            const accPercent = Number.isFinite(accValue) ? `${(accValue * 100).toFixed(2)}%` : '—';
-            aiPostProgress(id, `訓練中（${epoch + 1}/${epochs}） Loss ${lossText} / Acc ${accPercent}`);
+            const accPercent = Number.isFinite(accValue)
+              ? `${(accValue * 100).toFixed(2)}%`
+              : '—';
+            aiPostProgress(id, `訓練中（${epoch + 1}/${epochs}）Loss ${lossText} / Acc ${accPercent}`);
           },
         },
       });
 
-      const accuracyKey = history.history.acc ? 'acc' : (history.history.accuracy ? 'accuracy' : null);
+      const accuracyKey = history.history.acc
+        ? 'acc'
+        : history.history.accuracy
+          ? 'accuracy'
+          : null;
       const finalTrainAccuracy = accuracyKey
         ? history.history[accuracyKey][history.history[accuracyKey].length - 1]
         : NaN;
@@ -217,53 +632,172 @@ async function handleAITrainLSTMMessage(message) {
       const testAccuracy = evalValues[1] ?? NaN;
 
       const predictionsTensor = model.predict(xTest);
-      const predictionValues = Array.from(await predictionsTensor.data());
+      const rawPredictions = await predictionsTensor.array();
       predictionsTensor.dispose();
 
-      const testLabels = labels.slice(boundedTrainSize, boundedTrainSize + predictionValues.length);
+      const predictionArray = rawPredictions.map((row) => {
+        if (isBinary) {
+          const rawValue = Array.isArray(row) ? row[0] : row;
+          const probUp = clampProbability(Number(rawValue));
+          const probDown = clampProbability(1 - probUp);
+          return [probDown, 0, probUp];
+        }
+        const source = Array.isArray(row) ? row : [Number(row) || 0];
+        const pDown = clampProbability(source[0]);
+        const pFlat = clampProbability(source[1]);
+        const pUp = clampProbability(source[2]);
+        const sum = pDown + pFlat + pUp;
+        if (sum > 0) {
+          return [pDown / sum, pFlat / sum, pUp / sum];
+        }
+        return [0, 0, 0];
+      });
+
+      const testLabels = labelIndices.slice(boundedTrainSize, boundedTrainSize + predictionArray.length);
+      let TP = 0;
+      let TN = 0;
+      let FP = 0;
+      let FN = 0;
       let correctPredictions = 0;
-      for (let i = 0; i < predictionValues.length; i += 1) {
-        const predictedLabel = predictionValues[i] >= 0.5 ? 1 : 0;
-        if (predictedLabel === testLabels[i]) {
+      let positivePredictions = 0;
+      let positiveHits = 0;
+      let positiveActuals = 0;
+      const threshold = LSTM_THRESHOLD;
+      const predictedLabels = predictionArray.map((row) => {
+        if (!Array.isArray(row) || row.length === 0) return isBinary ? 0 : 0;
+        if (isBinary) {
+          return row[2] >= threshold ? 1 : 0;
+        }
+        let maxIndex = 0;
+        let maxValue = row[0];
+        for (let idx = 1; idx < row.length; idx += 1) {
+          if (row[idx] > maxValue) {
+            maxValue = row[idx];
+            maxIndex = idx;
+          }
+        }
+        return maxIndex;
+      });
+      for (let i = 0; i < predictedLabels.length; i += 1) {
+        const predictedLabel = predictedLabels[i];
+        const actual = isBinary ? (testLabels[i] > 0 ? 1 : 0) : testLabels[i];
+        if (predictedLabel === (isBinary ? actual : actual)) {
           correctPredictions += 1;
         }
+        if (isBinary) {
+          if (actual === 1) positiveActuals += 1;
+          if (predictedLabel === 1) {
+            positivePredictions += 1;
+            if (actual === 1) positiveHits += 1;
+          }
+          if (actual === 1 && predictedLabel === 1) TP += 1;
+          else if (actual === 0 && predictedLabel === 0) TN += 1;
+          else if (actual === 0 && predictedLabel === 1) FP += 1;
+          else if (actual === 1 && predictedLabel === 0) FN += 1;
+        } else {
+          if (actual === 2) positiveActuals += 1;
+          if (predictedLabel === 2) {
+            positivePredictions += 1;
+            if (actual === 2) positiveHits += 1;
+          }
+          if (actual === 2 && predictedLabel === 2) TP += 1;
+          else if (actual !== 2 && predictedLabel !== 2) TN += 1;
+          else if (actual !== 2 && predictedLabel === 2) FP += 1;
+          else if (actual === 2 && predictedLabel !== 2) FN += 1;
+        }
       }
-      const manualAccuracy = predictionValues.length > 0 ? correctPredictions / predictionValues.length : 0;
-      const resolvedTestAccuracy = Number.isFinite(testAccuracy) ? testAccuracy : manualAccuracy;
+      const positivePrecision = positivePredictions > 0 ? positiveHits / positivePredictions : NaN;
+      const positiveRecall = positiveActuals > 0 ? positiveHits / positiveActuals : NaN;
+      const positiveF1 = (Number.isFinite(positivePrecision)
+        && Number.isFinite(positiveRecall)
+        && (positivePrecision + positiveRecall) > 0)
+        ? (2 * positivePrecision * positiveRecall) / (positivePrecision + positiveRecall)
+        : NaN;
+      const deterministicTestAccuracy = isBinary
+        ? (predictedLabels.length > 0 ? correctPredictions / predictedLabels.length : NaN)
+        : positivePrecision;
+      const resolvedTestAccuracy = (isBinary && Number.isFinite(testAccuracy))
+        ? testAccuracy
+        : deterministicTestAccuracy;
+      const confusion = { TP, TN, FP, FN };
 
       const trainingOdds = aiComputeTrainingOdds(dataset.returns, boundedTrainSize);
       const testMeta = Array.isArray(dataset.meta) ? dataset.meta.slice(boundedTrainSize) : [];
-      const testReturns = Array.isArray(dataset.returns) ? dataset.returns.slice(boundedTrainSize) : [];
+      const testReturns = Array.isArray(dataset.returns)
+        ? dataset.returns.slice(boundedTrainSize)
+        : [];
 
       let nextDayForecast = null;
       if (Array.isArray(dataset.returns) && dataset.returns.length >= lookback) {
         const tailWindow = dataset.returns.slice(dataset.returns.length - lookback);
         if (tailWindow.length === lookback) {
-          const normalizedTail = tailWindow.map((value) => (value - normaliser.mean) / (normaliser.std || 1));
+          const normalizedTail = tailWindow.map(
+            (value) => (value - normaliser.mean) / (normaliser.std || 1),
+          );
           const forecastInput = tf.tensor([normalizedTail.map((value) => [value])]);
           const forecastTensor = model.predict(forecastInput);
-          const forecastArray = Array.from(await forecastTensor.data());
+          const forecastArray = await forecastTensor.array();
+          let forecastRow = Array.isArray(forecastArray?.[0]) ? forecastArray[0] : forecastArray?.[0];
+          let forecastProbs;
+          if (isBinary) {
+            const rawValue = Array.isArray(forecastRow) ? forecastRow[0] : forecastRow;
+            const probUp = clampProbability(Number(rawValue));
+            const probDown = clampProbability(1 - probUp);
+            forecastProbs = [probDown, 0, probUp];
+          } else {
+            const pDown = clampProbability(Array.isArray(forecastRow) ? forecastRow[0] : Number(forecastRow) || 0);
+            const pFlat = clampProbability(Array.isArray(forecastRow) ? forecastRow[1] : 0);
+            const pUp = clampProbability(Array.isArray(forecastRow) ? forecastRow[2] : 0);
+            const sum = pDown + pFlat + pUp;
+            forecastProbs = sum > 0 ? [pDown / sum, pFlat / sum, pUp / sum] : [0, 0, 0];
+          }
+          let forecastClass = 0;
+          let forecastProb = forecastProbs[2] ?? 0;
+          let maxValue = forecastProbs[0];
+          for (let idx = 1; idx < forecastProbs.length; idx += 1) {
+            if (forecastProbs[idx] > maxValue) {
+              maxValue = forecastProbs[idx];
+              forecastClass = idx;
+            }
+          }
+          if (isBinary) {
+            forecastClass = forecastProb >= LSTM_THRESHOLD ? 2 : 0;
+          }
           nextDayForecast = {
-            probability: forecastArray[0],
+            probability: forecastProb,
             referenceDate: Array.isArray(dataset.baseRows) && dataset.baseRows.length > 0
               ? dataset.baseRows[dataset.baseRows.length - 1]?.date || null
               : null,
+            probabilities: forecastProbs,
+            predictedClass: forecastClass,
+            classificationMode,
           };
+          const lastClose = Array.isArray(dataset.baseRows) && dataset.baseRows.length > 0
+            ? Number(dataset.baseRows[dataset.baseRows.length - 1]?.close)
+            : null;
+          if (Number.isFinite(lastClose)) {
+            nextDayForecast.buyPrice = lastClose;
+          }
           forecastTensor.dispose();
           forecastInput.dispose();
         }
       }
 
+      const trainRatioUsed = boundedTrainSize / totalSamples;
       const trainingMetrics = {
         trainAccuracy: finalTrainAccuracy,
         trainLoss: finalTrainLoss,
         testAccuracy: resolvedTestAccuracy,
         testLoss,
-        totalPredictions: predictionValues.length,
+        totalPredictions: predictedLabels.length,
       };
 
+      if (volatilityDiagnostics && typeof volatilityDiagnostics === 'object') {
+        volatilityDiagnostics.expectedTrainSamples = boundedTrainSize;
+      }
+
       const predictionsPayload = {
-        predictions: predictionValues,
+        predictions: predictionArray,
         meta: testMeta,
         returns: testReturns,
         trainingOdds,
@@ -271,16 +805,96 @@ async function handleAITrainLSTMMessage(message) {
         datasetLastDate: Array.isArray(dataset.baseRows) && dataset.baseRows.length > 0
           ? dataset.baseRows[dataset.baseRows.length - 1]?.date || null
           : null,
+        lastClose: Array.isArray(dataset.baseRows) && dataset.baseRows.length > 0
+          ? Number(dataset.baseRows[dataset.baseRows.length - 1]?.close) || null
+          : null,
         hyperparameters: {
           lookback,
           epochs,
           batchSize,
           learningRate,
-          trainRatio,
+          trainRatio: trainRatioUsed,
+          splitIndex: boundedTrainSize,
+          threshold: gatingThreshold,
+          volatility: volatilityThresholds,
+          seed: seedToUse,
+          classificationMode,
         },
+        predictedLabels,
+        volatilityThresholds,
+        classificationMode,
+        volatilityDiagnostics: volatilityDiagnostics ? { ...volatilityDiagnostics } : null,
       };
 
-      aiPostResult(id, { trainingMetrics, predictionsPayload });
+      const backendInUse = typeof tf.getBackend === 'function' ? tf.getBackend() : null;
+      const runMeta = {
+        version: LSTM_REPRO_VERSION,
+        patch: LSTM_REPRO_PATCH,
+        seed: seedToUse,
+        backend: backendInUse,
+        tfjs: TFJS_VERSION,
+        lookback,
+        epochs,
+        batchSize,
+        trainRatio: trainRatioUsed,
+        splitIndex: boundedTrainSize,
+        threshold: gatingThreshold,
+        mean: normaliser.mean,
+        std: normaliser.std,
+        totalSamples,
+        trainSamples: boundedTrainSize,
+        testSamples: testSize,
+        volatility: volatilityThresholds,
+        classificationMode,
+        volatilityDiagnostics: volatilityDiagnostics ? { ...volatilityDiagnostics } : null,
+      };
+      workerLastMeta = runMeta;
+
+      try {
+        self.postMessage({ type: LSTM_META_MESSAGE, payload: runMeta });
+      } catch (metaError) {
+        console.warn('[Worker][AI] 回傳 LSTM 執行資訊失敗：', metaError);
+      }
+
+      try {
+        await model.save(`indexeddb://${LSTM_MODEL_STORAGE_KEY}`);
+      } catch (saveError) {
+        console.warn('[Worker][AI] 無法保存 LSTM 模型：', saveError);
+      }
+
+      const accuracyLabel = isBinary ? '測試正確率' : '大漲命中率';
+      const accuracyText = Number.isFinite(resolvedTestAccuracy)
+        ? (resolvedTestAccuracy * 100).toFixed(2)
+        : '—';
+      let finalMessage = `完成：${accuracyLabel} ${accuracyText}%，TP/TN/FP/FN = ${TP}/${TN}/${FP}/${FN}。`;
+      if (!isBinary) {
+        const precisionText = Number.isFinite(positivePrecision) ? (positivePrecision * 100).toFixed(2) : '—';
+        const recallText = Number.isFinite(positiveRecall) ? (positiveRecall * 100).toFixed(2) : '—';
+        const f1Text = Number.isFinite(positiveF1) ? (positiveF1 * 100).toFixed(2) : '—';
+        finalMessage += `｜Precision ${precisionText}%｜Recall ${recallText}%｜F1 ${f1Text}%`;
+      }
+
+      const hyperparametersUsed = {
+        lookback,
+        epochs,
+        batchSize,
+        learningRate,
+        trainRatio: trainRatioUsed,
+        splitIndex: boundedTrainSize,
+        threshold: gatingThreshold,
+        volatility: volatilityThresholds,
+        seed: seedToUse,
+        modelType: MODEL_TYPES.LSTM,
+        classificationMode,
+      };
+
+      aiPostResult(id, {
+        trainingMetrics,
+        predictionsPayload,
+        confusion,
+        hyperparametersUsed,
+        finalMessage,
+      });
     } finally {
       tensorsToDispose.forEach((tensor) => {
         if (tensor && typeof tensor.dispose === 'function') {
@@ -332,6 +946,20 @@ function annResolveClose(row) {
     if (Number.isFinite(value) && value > 0) return value;
   }
   return NaN;
+}
+
+function annResolveOpen(row, fallback) {
+  const candidates = [
+    row?.open,
+    row?.adjustedOpen,
+    row?.adjOpen,
+    row?.rawOpen,
+  ];
+  for (let i = 0; i < candidates.length; i += 1) {
+    const value = Number(candidates[i]);
+    if (Number.isFinite(value) && value > 0) return value;
+  }
+  return Number.isFinite(fallback) && fallback > 0 ? fallback : NaN;
 }
 
 function annResolveHigh(row, fallback) {
@@ -553,7 +1181,8 @@ function annWilliamsR(high, low, close, period = 14) {
   });
 }
 
-function annPrepareDataset(rows) {
+function annPrepareDataset(rows, volatilityOverrides = DEFAULT_VOLATILITY_THRESHOLDS, classificationOverride = CLASSIFICATION_MODES.MULTICLASS) {
+  const classificationMode = normalizeClassificationMode(classificationOverride);
   const parsed = Array.isArray(rows)
     ? rows
         .filter((row) => row && typeof row.date === 'string')
@@ -562,6 +1191,7 @@ function annPrepareDataset(rows) {
           return {
             date: row.date,
             close,
+            open: annResolveOpen(row, close),
             high: annResolveHigh(row, close),
             low: annResolveLow(row, close),
           };
@@ -574,6 +1204,17 @@ function annPrepareDataset(rows) {
   const high = parsed.map((row) => row.high);
   const low = parsed.map((row) => row.low);
 
+  const indicatorStats = ANN_FEATURE_NAMES.map((name) => ({
+    name,
+    totalSamples: 0,
+    finiteSamples: 0,
+    min: Infinity,
+    max: -Infinity,
+  }));
+  const classDistribution = classificationMode === CLASSIFICATION_MODES.BINARY
+    ? { up: 0, down: 0 }
+    : { surge: 0, flat: 0, drop: 0 };
+
   const ma = annSma(close, 30);
   const wma = annWma(close, 15);
   const ema = annEma(close, 12);
@@ -583,6 +1224,8 @@ function annPrepareDataset(rows) {
   const mac = annMacd(close, 12, 26, 9);
   const cci = annCci(high, low, close, 20);
   const wr = annWilliamsR(high, low, close, 14);
+
+  const volatilityThresholds = sanitizeVolatilityThresholds(volatilityOverrides);
 
   const X = [];
   const y = [];
@@ -606,6 +1249,17 @@ function annPrepareDataset(rows) {
       cci[i],
       wr[i],
     ];
+    for (let f = 0; f < features.length; f += 1) {
+      const stat = indicatorStats[f];
+      if (!stat) continue;
+      stat.totalSamples += 1;
+      const value = Number(features[f]);
+      if (Number.isFinite(value)) {
+        stat.finiteSamples += 1;
+        if (value < stat.min) stat.min = value;
+        if (value > stat.max) stat.max = value;
+      }
+    }
     if (features.every((value) => Number.isFinite(value))) {
       forecastFeature = features.map(Number);
       forecastDate = parsed[i].date;
@@ -618,18 +1272,93 @@ function annPrepareDataset(rows) {
     }
     const current = parsed[i];
     const next = parsed[i + 1];
-    const change = (next.close - current.close) / current.close;
+    const entryTrigger = current.close;
+    const nextLow = Number.isFinite(next.low) ? next.low : entryTrigger;
+    const nextOpen = Number.isFinite(next.open) ? next.open : entryTrigger;
+    const entryEligible = Number.isFinite(nextLow) && nextLow < entryTrigger;
+    const closeEntryBuyPrice = entryEligible
+      ? (Number.isFinite(nextOpen) && nextOpen < entryTrigger ? nextOpen : entryTrigger)
+      : entryTrigger;
+    const sellPrice = next.close;
+    const closeEntryReturn = entryEligible && Number.isFinite(closeEntryBuyPrice) && closeEntryBuyPrice > 0
+      ? (sellPrice - closeEntryBuyPrice) / closeEntryBuyPrice
+      : 0;
+    const swingReturn = Number.isFinite(next.close) && Number.isFinite(current.close) && current.close > 0
+      ? (next.close - current.close) / current.close
+      : NaN;
+    let classLabel;
+    if (classificationMode === CLASSIFICATION_MODES.BINARY) {
+      classLabel = Number(closeEntryReturn > 0);
+      if (classLabel === 1) classDistribution.up += 1;
+      else classDistribution.down += 1;
+    } else if (Number.isFinite(swingReturn)) {
+      if (swingReturn >= volatilityThresholds.surge) {
+        classLabel = 2;
+        classDistribution.surge += 1;
+      } else if (swingReturn <= -volatilityThresholds.drop) {
+        classLabel = 0;
+        classDistribution.drop += 1;
+      } else {
+        classLabel = 1;
+        classDistribution.flat += 1;
+      }
+    } else {
+      classLabel = 1;
+      classDistribution.flat += 1;
+    }
+    const closeSameDayBuyPrice = Number.isFinite(current.close) && current.close > 0 ? current.close : NaN;
+    const closeSameDayEligible = Number.isFinite(closeSameDayBuyPrice) && closeSameDayBuyPrice > 0
+      && Number.isFinite(sellPrice) && sellPrice > 0;
+    const closeSameDayReturn = closeSameDayEligible
+      ? (sellPrice - closeSameDayBuyPrice) / closeSameDayBuyPrice
+      : 0;
+    const openEntryBuyPrice = Number.isFinite(nextOpen) && nextOpen > 0 ? nextOpen : entryTrigger;
+    const openEntryEligible = Number.isFinite(openEntryBuyPrice) && openEntryBuyPrice > 0 && Number.isFinite(sellPrice);
+    const openEntryReturn = openEntryEligible
+      ? (sellPrice - openEntryBuyPrice) / openEntryBuyPrice
+      : 0;
+    const actualReturn = closeEntryReturn;
     X.push(features.map(Number));
-    y.push(next.close > current.close ? 1 : 0);
+    y.push(classLabel);
     meta.push({
       buyDate: current.date,
       sellDate: next.date,
       tradeDate: next.date,
       buyClose: current.close,
       sellClose: next.close,
+      buyPrice: closeEntryBuyPrice,
+      sellPrice,
+      nextOpen,
+      nextLow,
+      entryEligible,
+      closeEntryEligible: entryEligible,
+      closeEntryBuyPrice,
+      closeEntryReturn,
+      openEntryEligible,
+      openEntryBuyPrice,
+      openEntrySellPrice: sellPrice,
+      openEntryReturn,
+      actualReturn,
+      buyTrigger: entryTrigger,
+      closeSameDayEligible,
+      closeSameDayBuyPrice,
+      closeSameDaySellPrice: sellPrice,
+      closeSameDayReturn,
+      swingReturn,
+      classLabel,
     });
-    returns.push(change);
+    returns.push(actualReturn);
   }
+
+  const indicatorDiagnostics = indicatorStats.map((stat) => ({
+    name: stat.name,
+    totalSamples: stat.totalSamples,
+    finiteSamples: stat.finiteSamples,
+    missingSamples: Math.max(stat.totalSamples - stat.finiteSamples, 0),
+    min: stat.finiteSamples > 0 ? stat.min : null,
+    max: stat.finiteSamples > 0 ? stat.max : null,
+    coverage: stat.totalSamples > 0 ? stat.finiteSamples / stat.totalSamples : 0,
+  }));
 
   return {
     X,
@@ -639,6 +1368,12 @@ function annPrepareDataset(rows) {
     forecastFeature,
     forecastDate,
     datasetLastDate: parsed.length > 0 ? parsed[parsed.length - 1].date : null,
+    datasetLastClose: parsed.length > 0 ? parsed[parsed.length - 1].close : null,
+    volatilityThresholds,
+    classificationMode,
+    indicatorDiagnostics,
+    classDistribution,
+    totalParsedRows: parsed.length,
   };
 }
 
@@ -671,9 +1406,12 @@ function annStandardizeVector(vector, mean, std) {
   return vector.map((value, index) => (value - mean[index]) / (std[index] || 1));
 }
 
-function annSplitTrainTest(Z, y, meta, returns, ratio) {
+function annSplitTrainTest(Z, y, meta, returns, ratio, forcedTrainCount = null) {
   const total = Z.length;
-  const trainCount = Math.min(Math.max(Math.floor(total * ratio), 1), total - 1);
+  const computedTrainCount = Math.min(Math.max(Math.floor(total * ratio), 1), total - 1);
+  const trainCount = Number.isFinite(forcedTrainCount)
+    ? Math.min(Math.max(Math.round(forcedTrainCount), 1), total - 1)
+    : computedTrainCount;
   return {
     Xtr: Z.slice(0, trainCount),
     ytr: y.slice(0, trainCount),
@@ -685,15 +1423,120 @@ function annSplitTrainTest(Z, y, meta, returns, ratio) {
   };
 }
 
-// Patch Tag: LB-AI-ANNS-20251215A — Align ANN optimizer/loss with Chen et al. (2024) and extend MACD features.
-function annBuildModel(inputDim, learningRate = 0.01) {
+function annOneHot(labels, numClasses = 3) {
+  return labels.map((label) => {
+    const index = Number.isInteger(label) ? Math.max(0, Math.min(numClasses - 1, label)) : 0;
+    const arr = new Array(numClasses).fill(0);
+    arr[index] = 1;
+    return arr;
+  });
+}
+
+// Patch Tag: LB-AI-ANNS-REPRO-20251223A — Seeded initialisers & deterministic ANN stack.
+function annBuildModel(inputDim, learningRate = 0.01, seed = ANN_DEFAULT_SEED, classificationMode = CLASSIFICATION_MODES.MULTICLASS) {
   const model = tf.sequential();
-  model.add(tf.layers.dense({ units: 32, activation: 'relu', inputShape: [inputDim] }));
-  model.add(tf.layers.dense({ units: 16, activation: 'relu' }));
-  model.add(tf.layers.dense({ units: 1, activation: 'sigmoid' }));
+  const initializerSeed = Number.isFinite(seed) ? seed : ANN_DEFAULT_SEED;
+  const kernelInitializer = tf.initializers.glorotUniform({ seed: initializerSeed });
+  const biasInitializer = tf.initializers.zeros();
+  const normalizedMode = normalizeClassificationMode(classificationMode);
+  const isBinary = normalizedMode === CLASSIFICATION_MODES.BINARY;
+  model.add(tf.layers.dense({
+    units: 32,
+    activation: 'relu',
+    inputShape: [inputDim],
+    kernelInitializer,
+    biasInitializer,
+  }));
+  model.add(tf.layers.dense({
+    units: 16,
+    activation: 'relu',
+    kernelInitializer,
+    biasInitializer,
+  }));
+  model.add(tf.layers.dense({
+    units: isBinary ? 1 : 3,
+    activation: isBinary ? 'sigmoid' : 'softmax',
+    kernelInitializer,
+    biasInitializer,
+  }));
   const optimizer = tf.train.sgd(learningRate);
-  model.compile({ optimizer, loss: 'meanSquaredError', metrics: ['accuracy'] });
+  const loss = isBinary ? 'binaryCrossentropy' : 'categoricalCrossentropy';
+  model.compile({ optimizer, loss, metrics: ['accuracy'] });
   return model;
+}
+
+async function annCollectLayerDiagnostics(model) {
+  if (!model || !Array.isArray(model.layers)) {
+    return [];
+  }
+  const diagnostics = [];
+  for (let index = 0; index < model.layers.length; index += 1) {
+    const layer = model.layers[index];
+    if (!layer) continue;
+    let className = null;
+    try {
+      className = typeof layer.getClassName === 'function' ? layer.getClassName() : null;
+    } catch (error) {
+      className = layer.constructor?.name || null;
+    }
+    let config = {};
+    try {
+      config = typeof layer.getConfig === 'function' ? layer.getConfig() : {};
+    } catch (error) {
+      config = {};
+    }
+    const entry = {
+      index,
+      name: layer.name || `layer_${index}`,
+      className,
+      activation: config.activation || layer.activation?.name || null,
+      units: Number.isFinite(layer.units) ? layer.units : (Number.isFinite(config.units) ? config.units : null),
+      outputShape: Array.isArray(layer.outputShape) ? layer.outputShape : (layer.outputShape || null),
+      weightSummaries: [],
+      hasNaN: false,
+    };
+    const weights = typeof layer.getWeights === 'function' ? layer.getWeights() : [];
+    for (let w = 0; w < weights.length; w += 1) {
+      const tensor = weights[w];
+      if (!tensor || typeof tensor.data !== 'function') continue;
+      let data;
+      try {
+        data = await tensor.data();
+      } catch (error) {
+        data = [];
+      }
+      let finiteCount = 0;
+      let nanCount = 0;
+      let min = Infinity;
+      let max = -Infinity;
+      for (let i = 0; i < data.length; i += 1) {
+        const value = data[i];
+        if (!Number.isFinite(value)) {
+          nanCount += 1;
+          continue;
+        }
+        finiteCount += 1;
+        if (value < min) min = value;
+        if (value > max) max = value;
+      }
+      if (nanCount > 0) {
+        entry.hasNaN = true;
+      }
+      entry.weightSummaries.push({
+        index: w,
+        size: data.length,
+        finiteCount,
+        nanCount,
+        min: finiteCount > 0 ? min : null,
+        max: finiteCount > 0 ? max : null,
+      });
+      if (tensor && typeof tensor.dispose === 'function') {
+        tensor.dispose();
+      }
+    }
+    diagnostics.push(entry);
+  }
+  return diagnostics;
 }
 
 async function handleAITrainANNMessage(message) {
@@ -704,37 +1547,139 @@ async function handleAITrainANNMessage(message) {
   const payload = message?.payload || {};
   const rows = Array.isArray(payload.rows) ? payload.rows : [];
   const options = payload.options || {};
+  const overrides = payload.overrides || {};
+  const overrideSeedRaw = Number.isFinite(overrides?.seed) ? overrides.seed : null;
+  const overrideSeed = Number.isFinite(overrideSeedRaw) ? Math.max(1, Math.round(overrideSeedRaw)) : null;
+  const seedToUse = Number.isFinite(overrideSeed) ? overrideSeed : ANN_DEFAULT_SEED;
 
   try {
+    await tfBackendReadyPromise;
     if (typeof tf === 'undefined' || typeof tf.tensor !== 'function') {
       throw new Error('TensorFlow.js 尚未在背景執行緒載入，請重新整理頁面。');
+    }
+    if (typeof tf?.util?.seedrandom === 'function') {
+      tf.util.seedrandom(seedToUse);
     }
     if (!Array.isArray(rows) || rows.length < 60) {
       throw new Error('資料不足（至少 60 根 K 線）');
     }
 
-    const prepared = annPrepareDataset(rows);
+    const prepared = annPrepareDataset(rows, options.volatility, options.classificationMode);
+    const classificationMode = normalizeClassificationMode(options.classificationMode || prepared.classificationMode);
+    const isBinary = classificationMode === CLASSIFICATION_MODES.BINARY;
     if (!Array.isArray(prepared.X) || prepared.X.length < 40) {
       throw new Error('有效樣本不足，請延長資料範圍。');
     }
 
+    const totalSamples = prepared.X.length;
     const trainRatio = annClampTrainRatio(options.trainRatio);
+    const rawTrainCount = Math.min(Math.max(Math.floor(totalSamples * trainRatio), 1), totalSamples - 1);
+    let volatilityThresholds = sanitizeVolatilityThresholds(prepared.volatilityThresholds);
+    let volatilityDiagnostics = prepared.volatilityDiagnostics
+      && typeof prepared.volatilityDiagnostics === 'object'
+        ? { ...prepared.volatilityDiagnostics }
+        : null;
+    const labels = new Array(totalSamples);
+    if (isBinary) {
+      for (let i = 0; i < totalSamples; i += 1) {
+        const metaItem = prepared.meta[i] || {};
+        const positive = Number(metaItem?.closeEntryReturn ?? prepared.returns[i]) > 0;
+        const label = positive ? 1 : 0;
+        labels[i] = label;
+        if (metaItem) {
+          metaItem.classLabel = label;
+        }
+      }
+    } else {
+      const trainingSwings = prepared.meta
+        .slice(0, rawTrainCount)
+        .map((item) => Number(item?.swingReturn))
+        .filter((value) => Number.isFinite(value));
+      const diagnosticsPayload = {};
+      volatilityThresholds = deriveVolatilityThresholdsFromReturns(trainingSwings, volatilityThresholds, diagnosticsPayload);
+      diagnosticsPayload.expectedTrainSamples = trainingSwings.length;
+      volatilityDiagnostics = diagnosticsPayload;
+      for (let i = 0; i < totalSamples; i += 1) {
+        const metaItem = prepared.meta[i] || {};
+        const swingValue = Number(metaItem?.swingReturn);
+        const label = classifySwingReturn(swingValue, volatilityThresholds);
+        labels[i] = label;
+        if (metaItem) {
+          metaItem.classLabel = label;
+        }
+      }
+    }
+    prepared.y = labels;
+    prepared.volatilityThresholds = volatilityThresholds;
+    prepared.volatilityDiagnostics = volatilityDiagnostics;
+
+    if (isBinary) {
+      const updatedDistribution = { up: 0, down: 0 };
+      for (let i = 0; i < labels.length; i += 1) {
+        const label = labels[i] > 0 ? 1 : 0;
+        if (label === 1) {
+          updatedDistribution.up += 1;
+        } else {
+          updatedDistribution.down += 1;
+        }
+      }
+      prepared.classDistribution = updatedDistribution;
+      if (volatilityDiagnostics && typeof volatilityDiagnostics === 'object') {
+        volatilityDiagnostics.datasetTotalSamples = labels.length;
+        volatilityDiagnostics.datasetPositiveSamples = updatedDistribution.up;
+        volatilityDiagnostics.datasetNegativeSamples = updatedDistribution.down;
+      }
+    } else {
+      const updatedDistribution = { surge: 0, flat: 0, drop: 0 };
+      for (let i = 0; i < labels.length; i += 1) {
+        const label = labels[i];
+        if (label === 2) {
+          updatedDistribution.surge += 1;
+        } else if (label === 0) {
+          updatedDistribution.drop += 1;
+        } else {
+          updatedDistribution.flat += 1;
+        }
+      }
+      prepared.classDistribution = updatedDistribution;
+      if (volatilityDiagnostics && typeof volatilityDiagnostics === 'object') {
+        volatilityDiagnostics.datasetTotalSamples = labels.length;
+        volatilityDiagnostics.datasetSurgeSamples = updatedDistribution.surge;
+        volatilityDiagnostics.datasetFlatSamples = updatedDistribution.flat;
+        volatilityDiagnostics.datasetDropSamples = updatedDistribution.drop;
+      }
+    }
+
     const { Z, mean, std } = annStandardize(prepared.X);
-    const split = annSplitTrainTest(Z, prepared.y, prepared.meta, prepared.returns, trainRatio);
+    const split = annSplitTrainTest(Z, labels, prepared.meta, prepared.returns, trainRatio, rawTrainCount);
     if (split.Xte.length === 0) {
       throw new Error('訓練/測試樣本不足，請延長資料範圍。');
     }
 
-    const epochs = Math.max(1, Math.round(Number.isFinite(options.epochs) ? options.epochs : 60));
-    const batchSizeRaw = Math.max(1, Math.round(Number.isFinite(options.batchSize) ? options.batchSize : 32));
-    const batchSize = Math.min(batchSizeRaw, split.Xtr.length);
+    const epochs = Math.max(1, Math.round(Number.isFinite(options.epochs) ? options.epochs : 200));
     const learningRate = Number.isFinite(options.learningRate) ? options.learningRate : 0.01;
+    const batchSize = split.trainCount;
+    const defaultThreshold = getDefaultThresholdForMode(classificationMode);
+    const threshold = Number.isFinite(options.threshold) ? options.threshold : defaultThreshold;
 
-    const model = annBuildModel(split.Xtr[0].length, learningRate);
+    const model = annBuildModel(split.Xtr[0].length, learningRate, seedToUse, classificationMode);
     const xTrain = tf.tensor2d(split.Xtr);
-    const yTrain = tf.tensor2d(split.ytr, [split.ytr.length, 1]);
-    const xTest = tf.tensor2d(split.Xte);
-    const yTest = tf.tensor2d(split.yte, [split.yte.length, 1]);
+    let yTrain;
+    let xTest;
+    let yTest;
+    if (isBinary) {
+      const yTrainValues = split.ytr.map((label) => (label > 0 ? 1 : 0));
+      const yTestValues = split.yte.map((label) => (label > 0 ? 1 : 0));
+      yTrain = tf.tensor2d(yTrainValues.map((value) => [value]), [yTrainValues.length, 1]);
+      xTest = tf.tensor2d(split.Xte);
+      yTest = tf.tensor2d(yTestValues.map((value) => [value]), [yTestValues.length, 1]);
+    } else {
+      const yTrainArray = annOneHot(split.ytr, 3);
+      const yTestArray = annOneHot(split.yte, 3);
+      yTrain = tf.tensor2d(yTrainArray, [yTrainArray.length, 3]);
+      xTest = tf.tensor2d(split.Xte);
+      yTest = tf.tensor2d(yTestArray, [yTestArray.length, 3]);
+    }
 
     const tensorsToDispose = [xTrain, yTrain, xTest, yTest];
     try {
@@ -742,13 +1687,13 @@ async function handleAITrainANNMessage(message) {
       const history = await model.fit(xTrain, yTrain, {
         epochs,
         batchSize,
-        shuffle: true,
+        shuffle: false,
         callbacks: {
           onEpochEnd: (epoch, logs) => {
             const lossText = Number.isFinite(logs.loss) ? logs.loss.toFixed(4) : '—';
             const accValue = logs.acc ?? logs.accuracy;
             const accPercent = Number.isFinite(accValue) ? `${(accValue * 100).toFixed(2)}%` : '—';
-            annPostProgress(id, `訓練中（${epoch + 1}/${epochs}） Loss ${lossText} / Acc ${accPercent}`);
+            annPostProgress(id, `訓練中（${epoch + 1}/${epochs}）Loss ${lossText} / Acc ${accPercent}`);
           },
         },
       });
@@ -769,13 +1714,108 @@ async function handleAITrainANNMessage(message) {
         tensor.dispose();
       }
       const testLoss = evalValues[0] ?? NaN;
-      const testAccuracy = evalValues[1] ?? NaN;
 
       const predictionsTensor = model.predict(xTest);
-      const predictionValues = Array.from(await predictionsTensor.data());
+      const rawPredictions = await predictionsTensor.array();
       predictionsTensor.dispose();
 
+      const predictionArray = isBinary
+        ? rawPredictions.map((row) => {
+          const rawValue = Array.isArray(row) ? row[0] : row;
+          const probUp = Math.min(Math.max(Number(rawValue) || 0, 0), 1);
+          const probDown = 1 - probUp;
+          return [probDown, 0, probUp];
+        })
+        : rawPredictions.map((row) => (Array.isArray(row) ? row : [Number(row) || 0]));
+
+      const predictedLabels = predictionArray.map((row) => {
+        if (!Array.isArray(row) || row.length === 0) return isBinary ? 0 : 0;
+        if (isBinary) {
+          return row[2] >= threshold ? 1 : 0;
+        }
+        let maxIndex = 0;
+        let maxValue = row[0];
+        for (let idx = 1; idx < row.length; idx += 1) {
+          if (row[idx] > maxValue) {
+            maxValue = row[idx];
+            maxIndex = idx;
+          }
+        }
+        return maxIndex;
+      });
+      const actualLabels = split.yte.map((label) => (isBinary ? (label > 0 ? 1 : 0) : label));
+      let TP = 0;
+      let TN = 0;
+      let FP = 0;
+      let FN = 0;
+      let correct = 0;
+      let positivePredictions = 0;
+      let positiveHits = 0;
+      let positiveActuals = 0;
+      for (let i = 0; i < predictedLabels.length; i += 1) {
+        const predicted = predictedLabels[i];
+        const actual = actualLabels[i];
+        if (predicted === actual) {
+          correct += 1;
+        }
+        if (isBinary) {
+          if (actual === 1) positiveActuals += 1;
+          if (predicted === 1) {
+            positivePredictions += 1;
+            if (actual === 1) positiveHits += 1;
+          }
+          if (actual === 1 && predicted === 1) TP += 1;
+          else if (actual === 0 && predicted === 0) TN += 1;
+          else if (actual === 0 && predicted === 1) FP += 1;
+          else if (actual === 1 && predicted === 0) FN += 1;
+        } else {
+          if (actual === 2) positiveActuals += 1;
+          if (predicted === 2) {
+            positivePredictions += 1;
+            if (actual === 2) positiveHits += 1;
+          }
+          if (actual === 2 && predicted === 2) TP += 1;
+          else if (actual !== 2 && predicted !== 2) TN += 1;
+          else if (actual !== 2 && predicted === 2) FP += 1;
+          else if (actual === 2 && predicted !== 2) FN += 1;
+        }
+      }
+      const deterministicTestAccuracy = isBinary
+        ? (actualLabels.length > 0 ? correct / actualLabels.length : NaN)
+        : (positivePredictions > 0 ? positiveHits / positivePredictions : NaN);
+      const positivePrecision = positivePredictions > 0 ? positiveHits / positivePredictions : NaN;
+      const positiveRecall = positiveActuals > 0 ? positiveHits / positiveActuals : NaN;
+      const positiveF1 = (Number.isFinite(positivePrecision)
+        && Number.isFinite(positiveRecall)
+        && (positivePrecision + positiveRecall) > 0)
+        ? (2 * positivePrecision * positiveRecall) / (positivePrecision + positiveRecall)
+        : NaN;
+      const confusion = { TP, TN, FP, FN };
+
       const trainingOdds = aiComputeTrainingOdds(prepared.returns, split.trainCount);
+      const datasetDiagnostics = {
+        totalParsedRows: Number.isFinite(prepared.totalParsedRows) ? prepared.totalParsedRows : rows.length,
+        usableSamples: totalSamples,
+        trainSamples: split.trainCount,
+        testSamples: split.Xte.length,
+        classificationMode,
+        classDistribution: prepared.classDistribution ? { ...prepared.classDistribution } : null,
+        indicatorDiagnostics: Array.isArray(prepared.indicatorDiagnostics)
+          ? prepared.indicatorDiagnostics.map((entry) => ({ ...entry }))
+          : [],
+      };
+      const performanceDiagnostics = {
+        totalPredictions: actualLabels.length,
+        positivePredictions,
+        positiveHits,
+        positiveActuals,
+        positivePrecision,
+        positiveRecall,
+        positiveF1,
+        confusion: { ...confusion },
+        accuracyLabel: isBinary ? '測試正確率' : '大漲命中率',
+      };
+      const accuracyLabel = performanceDiagnostics.accuracyLabel;
 
       let forecast = null;
       if (Array.isArray(prepared.forecastFeature)) {
@@ -783,11 +1823,41 @@ async function handleAITrainANNMessage(message) {
         if (Array.isArray(standardisedForecast)) {
           const forecastTensor = tf.tensor2d([standardisedForecast]);
           const forecastOutput = model.predict(forecastTensor);
-          const forecastArray = Array.from(await forecastOutput.data());
+          const forecastArray = await forecastOutput.array();
+          const baseForecast = Array.isArray(forecastArray?.[0]) ? forecastArray[0] : [];
+          let forecastProbs;
+          if (isBinary) {
+            const rawValue = Array.isArray(baseForecast) ? baseForecast[0] : baseForecast;
+            const probUp = Math.min(Math.max(Number(rawValue) || 0, 0), 1);
+            const probDown = 1 - probUp;
+            forecastProbs = [probDown, 0, probUp];
+          } else {
+            forecastProbs = baseForecast;
+          }
+          let forecastClass = 0;
+          let forecastProb = isBinary ? forecastProbs[2] : 0;
+          if (forecastProbs.length > 0 && !isBinary) {
+            let maxValue = forecastProbs[0];
+            forecastClass = 0;
+            for (let idx = 1; idx < forecastProbs.length; idx += 1) {
+              if (forecastProbs[idx] > maxValue) {
+                maxValue = forecastProbs[idx];
+                forecastClass = idx;
+              }
+            }
+            forecastProb = forecastProbs[2] ?? 0;
+          } else if (isBinary) {
+            forecastClass = forecastProbs[2] >= threshold ? 2 : 0;
+          }
           forecast = {
-            probability: forecastArray[0],
+            probability: forecastProb,
             referenceDate: prepared.forecastDate || prepared.datasetLastDate || null,
+            probabilities: forecastProbs,
+            predictedClass: forecastClass,
           };
+          if (Number.isFinite(prepared.datasetLastClose)) {
+            forecast.buyPrice = prepared.datasetLastClose;
+          }
           forecastOutput.dispose();
           forecastTensor.dispose();
         }
@@ -796,18 +1866,19 @@ async function handleAITrainANNMessage(message) {
       const trainingMetrics = {
         trainAccuracy: finalTrainAccuracy,
         trainLoss: finalTrainLoss,
-        testAccuracy,
+        testAccuracy: deterministicTestAccuracy,
         testLoss,
-        totalPredictions: predictionValues.length,
+        totalPredictions: performanceDiagnostics.totalPredictions,
       };
 
       const predictionsPayload = {
-        predictions: predictionValues,
+        predictions: predictionArray,
         meta: split.metaTe,
         returns: split.returnsTe,
         trainingOdds,
         forecast,
         datasetLastDate: prepared.datasetLastDate,
+        lastClose: Number.isFinite(prepared.datasetLastClose) ? prepared.datasetLastClose : null,
         hyperparameters: {
           lookback: Number.isFinite(options.lookback) ? options.lookback : null,
           epochs,
@@ -815,12 +1886,90 @@ async function handleAITrainANNMessage(message) {
           learningRate,
           trainRatio,
           modelType: MODEL_TYPES.ANNS,
+          splitIndex: split.trainCount,
+          threshold,
+          volatility: volatilityThresholds,
+          seed: seedToUse,
+          classificationMode,
         },
+        predictedLabels,
+        volatilityThresholds,
+        classificationMode,
+        volatilityDiagnostics: volatilityDiagnostics ? { ...volatilityDiagnostics } : null,
+        datasetDiagnostics,
       };
 
-      const finalMessage = `完成：測試正確率 ${(Number.isFinite(testAccuracy) ? (testAccuracy * 100).toFixed(2) : '—')}%。`;
+      const backendInUse = typeof tf.getBackend === 'function' ? tf.getBackend() : null;
+      const layerDiagnostics = await annCollectLayerDiagnostics(model);
+      const diagnostics = {
+        version: ANN_DIAGNOSTIC_VERSION,
+        timestamp: Date.now(),
+        dataset: datasetDiagnostics,
+        indicatorDiagnostics: datasetDiagnostics.indicatorDiagnostics,
+        layerDiagnostics,
+        performance: {
+          ...performanceDiagnostics,
+          trainAccuracy: finalTrainAccuracy,
+          trainLoss: finalTrainLoss,
+          testAccuracy: deterministicTestAccuracy,
+          testLoss,
+        },
+        volatilityDiagnostics: volatilityDiagnostics ? { ...volatilityDiagnostics } : null,
+      };
+      const runMeta = {
+        version: ANN_REPRO_VERSION,
+        patch: ANN_REPRO_PATCH,
+        seed: seedToUse,
+        backend: backendInUse,
+        tfjs: TFJS_VERSION,
+        trainRatio,
+        epochs,
+        batchSize,
+        splitIndex: split.trainCount,
+        threshold,
+        volatility: volatilityThresholds,
+        lookback: Number.isFinite(options.lookback) ? options.lookback : null,
+        mean,
+        std,
+        featureOrder: ['SMA30', 'WMA15', 'EMA12', 'Momentum10', 'StochK14', 'StochD3', 'RSI14', 'MACDdiff', 'MACDsignal', 'MACDhist', 'CCI20', 'WilliamsR14'],
+        totalSamples,
+        trainSamples: split.trainCount,
+        testSamples: split.Xte.length,
+        classificationMode,
+        volatilityDiagnostics: volatilityDiagnostics ? { ...volatilityDiagnostics } : null,
+        datasetDiagnostics,
+        diagnosticsVersion: ANN_DIAGNOSTIC_VERSION,
+      };
+      workerLastMeta = runMeta;
+      try {
+        self.postMessage({ type: ANN_META_MESSAGE, payload: runMeta });
+      } catch (metaError) {
+        console.warn('[Worker][AI] 回傳 ANN 執行資訊失敗：', metaError);
+      }
 
-      annPostResult(id, { trainingMetrics, predictionsPayload, finalMessage });
+      try {
+        await model.save(`indexeddb://${ANN_MODEL_STORAGE_KEY}`);
+      } catch (saveError) {
+        console.warn('[Worker][AI] 無法保存 ANN 模型：', saveError);
+      }
+
+      const finalMessage = `完成：${accuracyLabel} ${(Number.isFinite(deterministicTestAccuracy) ? (deterministicTestAccuracy * 100).toFixed(2) : '—')}%，TP/TN/FP/FN = ${TP}/${TN}/${FP}/${FN}。`;
+
+      const hyperparametersUsed = {
+        epochs,
+        batchSize,
+        learningRate,
+        trainRatio,
+        splitIndex: split.trainCount,
+        threshold,
+        volatility: volatilityThresholds,
+        modelType: MODEL_TYPES.ANNS,
+        lookback: Number.isFinite(options.lookback) ? options.lookback : null,
+        seed: seedToUse,
+        classificationMode,
+      };
+
+      annPostResult(id, { trainingMetrics, predictionsPayload, confusion, hyperparametersUsed, finalMessage, diagnostics });
       model.dispose();
     } finally {
       tensorsToDispose.forEach((tensor) => {


### PR DESCRIPTION
## Summary
- recompute ANN class distribution after quartile-derived relabeling and persist dataset counts alongside volatility diagnostics metadata
- surface predicted swing ranges plus the actual surge/drop thresholds in the AI trade table for multiclass runs and reuse the values for forecast rows
- bump the AI module version tag and log LB-AI-VOL-QUARTILE-20260128A for the new diagnostics/UI behavior

## Testing
- `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/ai-prediction.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`


------
https://chatgpt.com/codex/tasks/task_e_68dcc3d410ac8324a6862f5bc4e90b14