### PR TITLE
Follow-up: Preserve optimization start date during warmup reuse

### DIFF
--- a/js/worker.js
+++ b/js/worker.js
@@ -11253,27 +11253,33 @@ async function runOptimization(
       message: `測試 ${optParamName}=${curVal}`,
     });
     const testParams = instantiateOptimizationParams(template);
+    const baseUserStart = baseParams?.startDate || null;
     const baseEffectiveStart =
-      baseParams?.effectiveStartDate || baseParams?.startDate || null;
+      baseParams?.effectiveStartDate || null;
     const baseDataStart =
-      baseParams?.dataStartDate || baseEffectiveStart || baseParams?.startDate || null;
+      baseParams?.dataStartDate ||
+      baseEffectiveStart ||
+      null;
     const baseLookback =
       Number.isFinite(baseParams?.lookbackDays) && baseParams.lookbackDays > 0
         ? baseParams.lookbackDays
         : null;
-    if (baseParams?.startDate && !testParams.originalStartDate) {
-      testParams.originalStartDate = baseParams.startDate;
+    if (baseUserStart && !testParams.originalStartDate) {
+      testParams.originalStartDate = baseUserStart;
+    }
+    if (!testParams.startDate && baseUserStart) {
+      testParams.startDate = baseUserStart;
     }
     if (baseEffectiveStart) {
-      testParams.startDate = baseEffectiveStart;
       testParams.effectiveStartDate = baseEffectiveStart;
-    } else if (testParams.effectiveStartDate) {
-      testParams.startDate = testParams.effectiveStartDate;
+    } else if (!testParams.effectiveStartDate && testParams.startDate) {
+      testParams.effectiveStartDate = testParams.startDate;
     }
     if (baseDataStart) {
       testParams.dataStartDate = baseDataStart;
-    } else if (!testParams.dataStartDate && testParams.startDate) {
-      testParams.dataStartDate = testParams.startDate;
+    } else if (!testParams.dataStartDate) {
+      testParams.dataStartDate =
+        testParams.effectiveStartDate || testParams.startDate || null;
     }
     if (baseLookback !== null) {
       testParams.lookbackDays = baseLookback;


### PR DESCRIPTION
## Summary
- keep single-parameter optimization trials using the user-selected `startDate` while applying the cached warmup context to `effectiveStartDate`/`dataStartDate`
- avoid overriding optimization parameters so metrics remain aligned with standalone backtests

## Testing
- node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE

------
https://chatgpt.com/codex/tasks/task_e_68e5ae3ac4f08324820198298fbf5d17