### PR TITLE
fix: guard forecast volatility bounds

### DIFF
--- a/js/ai-prediction.js
+++ b/js/ai-prediction.js
@@ -2473,9 +2473,9 @@
         }, trainingOdds);
         const evaluationRule = normalizeTradeRule(evaluation.rule || selectedRule);
         const allRecords = Array.isArray(evaluation.allRecords) ? evaluation.allRecords : [];
-        const evaluationBounds = resolveVolatilityBounds(evaluation.volatilityThresholds || resolvedVolatility);
-        const volatilityUpper = evaluationBounds.upper;
-        const volatilityLower = evaluationBounds.lower;
+        const { upper: evaluationVolatilityUpper, lower: evaluationVolatilityLower } = resolveVolatilityBounds(
+            evaluation.volatilityThresholds || resolvedVolatility
+        );
         const classAverages = evaluation.classReturnAverages || normalizeClassReturnAverages(payload.classReturnAverages, classificationMode);
         const forecast = payload.forecast && Number.isFinite(payload.forecast?.probability)
             ? annotateForecast({ ...payload.forecast }, payload) || { ...payload.forecast }
@@ -2489,10 +2489,10 @@
             forecast.fraction = forecastFraction;
             forecast.tradeRule = evaluationRule;
             if (!Number.isFinite(forecast.volatilityUpper)) {
-                forecast.volatilityUpper = volatilityUpper;
+                forecast.volatilityUpper = evaluationVolatilityUpper;
             }
             if (!Number.isFinite(forecast.volatilityLower)) {
-                forecast.volatilityLower = volatilityLower;
+                forecast.volatilityLower = evaluationVolatilityLower;
             }
             if (evaluationRule === 'open-entry') {
                 forecast.buyPrice = Number.isFinite(forecast.buyPrice) ? NaN : forecast.buyPrice;


### PR DESCRIPTION
## Summary
- ensure `applyTradeEvaluation` derives volatility bounds from the resolved thresholds before backfilling forecast values

## Testing
- `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/ai-prediction.js','js/worker.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`

------
https://chatgpt.com/codex/tasks/task_e_68e5b2dc143083249dec898b5b8e5f31