### PR TITLE
Fix risk-only training optimization guard (follow-up)

### DIFF
--- a/js/rolling-test.js
+++ b/js/rolling-test.js
@@ -1271,14 +1271,6 @@
             return { params: outputParams, summary };
         }
 
-        const requiresStrategyOptimizer = plan.scopes.some((scope) => scope !== 'risk');
-
-        if (requiresStrategyOptimizer && typeof optimizeSingleStrategyParameter !== 'function') {
-            summary.error = '缺少批量優化模組';
-            summary.messages.push('優化模組未載入，已沿用原始參數。');
-            return { params: outputParams, summary };
-        }
-
         const missingStrategyOptimizer = typeof optimizeSingleStrategyParameter !== 'function';
 
         if (typeof strategyDescriptions !== 'object' || !strategyDescriptions) {


### PR DESCRIPTION
## Summary
- remove the premature return that aborted optimization whenever the strategy optimizer module was missing
- allow risk-only optimization to continue while emitting per-scope errors for unavailable strategy optimizers

## Testing
- `node - <<'NODE' const fs=require('fs');const vm=require('vm');['js/rolling-test.js'].forEach((file)=>{const code=fs.readFileSync(file,'utf8');new vm.Script(code,{filename:file});});console.log('scripts compile');NODE`


------
https://chatgpt.com/codex/tasks/task_e_68e5b32f5adc8324a7e625da7b5b475a